### PR TITLE
Add new browser interaction tools

### DIFF
--- a/src/accessibilityChecker.ts
+++ b/src/accessibilityChecker.ts
@@ -215,6 +215,42 @@ export class AccessibilityScanner {
         await this.page.waitForLoadState('load');
     }
 
+    async hoverElement(selector: string) {
+        if (!this.page) {
+            throw new Error("Page not created. Call createPage() first.");
+        }
+
+        await this.page.hover(selector);
+        await this.page.waitForLoadState('load');
+    }
+
+    async dragAndDrop(startSelector: string, endSelector: string) {
+        if (!this.page) {
+            throw new Error("Page not created. Call createPage() first.");
+        }
+
+        await this.page.dragAndDrop(startSelector, endSelector);
+        await this.page.waitForLoadState('load');
+    }
+
+    async pressKey(key: string) {
+        if (!this.page) {
+            throw new Error("Page not created. Call createPage() first.");
+        }
+
+        await this.page.keyboard.press(key);
+        await this.page.waitForLoadState('load');
+    }
+
+    async selectOption(selector: string, values: string[]) {
+        if (!this.page) {
+            throw new Error("Page not created. Call createPage() first.");
+        }
+
+        await this.page.selectOption(selector, values);
+        await this.page.waitForLoadState('load');
+    }
+
     private async addViolationStyles() {
         if (!this.page) {
             throw new Error("Page not created.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,350 @@ server.registerTool(
 );
 
 server.registerTool(
+    "hover-element",
+    {
+        title: "Hover Element",
+        description: "Hovers over an element specified by a CSS selector on the current page.",
+        inputSchema: z.object({
+            url: z.string().url().describe("The public URL to navigate to"),
+            selector: z.string().describe("CSS selector for the element to hover"),
+            viewport: z
+                .object({
+                    width: z.number().default(1920),
+                    height: z.number().default(1080),
+                })
+                .optional()
+                .describe("Optional viewport dimensions"),
+            shouldRunInHeadless: z.boolean().default(true).describe("Whether to run the browser in headless mode"),
+        }).shape,
+    },
+    async (args) => {
+        const { url, selector, viewport, shouldRunInHeadless } = args as {
+            url: string;
+            selector: string;
+            viewport?: { width: number; height: number };
+            shouldRunInHeadless: boolean;
+        };
+
+        const scanner = new AccessibilityScanner();
+
+        try {
+            await scanner.initialize(shouldRunInHeadless);
+            await scanner.createContext(viewport);
+            await scanner.createPage();
+            await scanner.navigateToUrl(url);
+            await scanner.hoverElement(selector);
+
+            const base64Screenshot = await scanner.takeScreenshot();
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Successfully hovered element: ${selector}`,
+                                url,
+                                selector,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                    {
+                        type: "image",
+                        data: base64Screenshot,
+                        mimeType: "image/png",
+                    },
+                ],
+                isError: false,
+            };
+        } catch (error) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Failed to hover element: ${selector}`,
+                                error: error instanceof Error ? error.message : "Unknown error",
+                                url,
+                                selector,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                ],
+                isError: true,
+            };
+        } finally {
+            await scanner.cleanup();
+        }
+    },
+);
+
+server.registerTool(
+    "drag-and-drop",
+    {
+        title: "Drag and Drop",
+        description: "Drags an element from one selector to another on the current page.",
+        inputSchema: z.object({
+            url: z.string().url().describe("The public URL to navigate to"),
+            startSelector: z.string().describe("CSS selector for the element to drag"),
+            endSelector: z.string().describe("CSS selector for the drop target"),
+            viewport: z
+                .object({
+                    width: z.number().default(1920),
+                    height: z.number().default(1080),
+                })
+                .optional()
+                .describe("Optional viewport dimensions"),
+            shouldRunInHeadless: z.boolean().default(true).describe("Whether to run the browser in headless mode"),
+        }).shape,
+    },
+    async (args) => {
+        const { url, startSelector, endSelector, viewport, shouldRunInHeadless } = args as {
+            url: string;
+            startSelector: string;
+            endSelector: string;
+            viewport?: { width: number; height: number };
+            shouldRunInHeadless: boolean;
+        };
+
+        const scanner = new AccessibilityScanner();
+
+        try {
+            await scanner.initialize(shouldRunInHeadless);
+            await scanner.createContext(viewport);
+            await scanner.createPage();
+            await scanner.navigateToUrl(url);
+            await scanner.dragAndDrop(startSelector, endSelector);
+
+            const base64Screenshot = await scanner.takeScreenshot();
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Successfully dragged ${startSelector} to ${endSelector}`,
+                                url,
+                                startSelector,
+                                endSelector,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                    {
+                        type: "image",
+                        data: base64Screenshot,
+                        mimeType: "image/png",
+                    },
+                ],
+                isError: false,
+            };
+        } catch (error) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Failed to drag ${startSelector} to ${endSelector}`,
+                                error: error instanceof Error ? error.message : "Unknown error",
+                                url,
+                                startSelector,
+                                endSelector,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                ],
+                isError: true,
+            };
+        } finally {
+            await scanner.cleanup();
+        }
+    },
+);
+
+server.registerTool(
+    "press-key",
+    {
+        title: "Press Key",
+        description: "Presses a key on the keyboard on the current page.",
+        inputSchema: z.object({
+            url: z.string().url().describe("The public URL to navigate to"),
+            key: z.string().describe("The key to press"),
+            viewport: z
+                .object({
+                    width: z.number().default(1920),
+                    height: z.number().default(1080),
+                })
+                .optional()
+                .describe("Optional viewport dimensions"),
+            shouldRunInHeadless: z.boolean().default(true).describe("Whether to run the browser in headless mode"),
+        }).shape,
+    },
+    async (args) => {
+        const { url, key, viewport, shouldRunInHeadless } = args as {
+            url: string;
+            key: string;
+            viewport?: { width: number; height: number };
+            shouldRunInHeadless: boolean;
+        };
+
+        const scanner = new AccessibilityScanner();
+
+        try {
+            await scanner.initialize(shouldRunInHeadless);
+            await scanner.createContext(viewport);
+            await scanner.createPage();
+            await scanner.navigateToUrl(url);
+            await scanner.pressKey(key);
+
+            const base64Screenshot = await scanner.takeScreenshot();
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Successfully pressed key: ${key}`,
+                                url,
+                                key,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                    {
+                        type: "image",
+                        data: base64Screenshot,
+                        mimeType: "image/png",
+                    },
+                ],
+                isError: false,
+            };
+        } catch (error) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Failed to press key: ${key}`,
+                                error: error instanceof Error ? error.message : "Unknown error",
+                                url,
+                                key,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                ],
+                isError: true,
+            };
+        } finally {
+            await scanner.cleanup();
+        }
+    },
+);
+
+server.registerTool(
+    "select-option",
+    {
+        title: "Select Option",
+        description: "Selects options in a dropdown element on the current page.",
+        inputSchema: z.object({
+            url: z.string().url().describe("The public URL to navigate to"),
+            selector: z.string().describe("CSS selector for the select element"),
+            values: z.array(z.string()).describe("Array of values to select"),
+            viewport: z
+                .object({
+                    width: z.number().default(1920),
+                    height: z.number().default(1080),
+                })
+                .optional()
+                .describe("Optional viewport dimensions"),
+            shouldRunInHeadless: z.boolean().default(true).describe("Whether to run the browser in headless mode"),
+        }).shape,
+    },
+    async (args) => {
+        const { url, selector, values, viewport, shouldRunInHeadless } = args as {
+            url: string;
+            selector: string;
+            values: string[];
+            viewport?: { width: number; height: number };
+            shouldRunInHeadless: boolean;
+        };
+
+        const scanner = new AccessibilityScanner();
+
+        try {
+            await scanner.initialize(shouldRunInHeadless);
+            await scanner.createContext(viewport);
+            await scanner.createPage();
+            await scanner.navigateToUrl(url);
+            await scanner.selectOption(selector, values);
+
+            const base64Screenshot = await scanner.takeScreenshot();
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Successfully selected options in ${selector}`,
+                                url,
+                                selector,
+                                values,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                    {
+                        type: "image",
+                        data: base64Screenshot,
+                        mimeType: "image/png",
+                    },
+                ],
+                isError: false,
+            };
+        } catch (error) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                message: `Failed to select options in ${selector}`,
+                                error: error instanceof Error ? error.message : "Unknown error",
+                                url,
+                                selector,
+                                values,
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                ],
+                isError: true,
+            };
+        } finally {
+            await scanner.cleanup();
+        }
+    },
+);
+
+server.registerTool(
     "create-session",
     {
         title: "Create Browser Session",


### PR DESCRIPTION
## Summary
- expose new methods in `AccessibilityScanner` for hover, drag-and-drop, pressing keys and selecting options
- register corresponding MCP tools for hovering, dragging, pressing keys and selecting options

## Testing
- `npm run build` *(fails: Cannot find module 'playwright' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d5cf2ed408333acc8b2ab7809daa5