### PR TITLE
Add tool for scanning provided HTML

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -28,6 +28,7 @@ import tabs from './tools/tabs.js';
 import screenshot from './tools/screenshot.js';
 import vision from './tools/vision.js';
 import wait from './tools/wait.js';
+import html from './tools/html.js';
 
 import type { Tool } from './tools/tool.js';
 
@@ -45,6 +46,7 @@ export const snapshotTools: Tool<any>[] = [
   ...snapshot,
   ...tabs(true),
   ...wait(true),
+  ...html,
 ];
 
 export const visionTools: Tool<any>[] = [
@@ -60,4 +62,5 @@ export const visionTools: Tool<any>[] = [
   ...tabs(false),
   ...vision,
   ...wait(false),
+  ...html,
 ];

--- a/src/tools/html.ts
+++ b/src/tools/html.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import AxeBuilder from '@axe-core/playwright';
+
+import { defineTool } from './tool.js';
+import { tagValues } from './snapshot.js';
+
+const scanHtmlSchema = z.object({
+  html: z.string().describe('HTML content to scan'),
+  elementSelector: z.string().optional().describe('CSS selector of the element to scan. Scans entire document if not provided.'),
+  violationsTag: z
+      .array(z.enum(tagValues))
+      .min(1)
+      .optional()
+      .describe('Array of tags to filter violations by. If not specified, all violations are returned.'),
+});
+
+const scanHtml = defineTool({
+  capability: 'core',
+  schema: {
+    name: 'scan_html',
+    title: 'Scan provided HTML for accessibility violations',
+    description: 'Scan provided HTML snippet for accessibility violations using Axe',
+    inputSchema: scanHtmlSchema,
+    type: 'readOnly',
+  },
+
+  handle: async (context, params) => {
+    const tab = await context.newTab();
+    await tab.page.setContent(params.html);
+
+    let builder = new AxeBuilder({ page: tab.page });
+    if (params.elementSelector)
+      builder = builder.include(params.elementSelector);
+    if (params.violationsTag)
+      builder = builder.withTags(params.violationsTag);
+
+    const results = await builder.analyze();
+    await tab.page.close();
+
+    return {
+      code: [`// Scan provided HTML${params.elementSelector ? ` for selector: ${params.elementSelector}` : ''}`],
+      captureSnapshot: false,
+      waitForNetwork: false,
+      resultOverride: {
+        content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+      },
+    };
+  },
+});
+
+export default [scanHtml];

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -47,7 +47,7 @@ const elementSchema = z.object({
   ref: z.string().describe('Exact target element reference from the page snapshot'),
 });
 
-const tagValues = [
+export const tagValues = [
   'wcag2a', 'wcag2aa', 'wcag2aaa', 'wcag21a', 'wcag21aa', 'wcag21aaa',
   'wcag22a', 'wcag22aa', 'wcag22aaa', 'section508', 'cat.aria', 'cat.color',
   'cat.forms', 'cat.keyboard', 'cat.language', 'cat.name-role-value',


### PR DESCRIPTION
## Summary
- export shared Axe tag list from snapshot tools and reuse it in the new HTML scan tool
- drop unused testing tools module
- add scan_html tool to analyze provided HTML snippets
- remove license notice from scan_html tool

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/tools/html.ts src/tools/snapshot.ts` *(fails: Missing notice header)*
- `npx tsc --noEmit` *(hangs; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6895aaa8fa288333b3cb33f1a6ff649a