### PR TITLE
Fix HTTP MCP default bind address and preserve wildcard address reporting

### DIFF
--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -30,7 +30,8 @@ const testDebug = debug('pw:mcp:test');
 const allowedLoopbackHostnamePattern = /^127(?:\.\d{1,3}){3}$/;
 
 export async function startHttpServer(config: { host?: string, port?: number }, abortSignal?: AbortSignal): Promise<http.Server> {
-  const { host, port } = config;
+  const host = config.host ?? 'localhost';
+  const { port } = config;
   const httpServer = http.createServer();
   decorateServer(httpServer);
   await new Promise<void>((resolve, reject) => {
@@ -52,9 +53,7 @@ export function httpAddressToString(address: string | net.AddressInfo | null): s
   if (typeof address === 'string')
     return address;
   const resolvedPort = address.port;
-  let resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
-  if (resolvedHost === '0.0.0.0' || resolvedHost === '[::]')
-    resolvedHost = 'localhost';
+  const resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
   return `http://${resolvedHost}:${resolvedPort}`;
 }
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -16,7 +16,7 @@
 
 import http from 'http';
 import { afterEach, describe, expect, it } from 'vitest';
-import { installHttpTransport, startHttpServer } from '../src/mcp/http.js';
+import { httpAddressToString, installHttpTransport, startHttpServer } from '../src/mcp/http.js';
 
 import type { ServerBackendFactory } from '../src/mcp/server.js';
 
@@ -40,6 +40,21 @@ describe('mcp http transport hardening', () => {
   afterEach(async () => {
     await Promise.all([...servers].map(server => new Promise<void>(resolve => server.close(() => resolve()))));
     servers.clear();
+  });
+
+  it('binds to localhost by default', async () => {
+    const server = await startHttpServer({ port: 0 });
+    servers.add(server);
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('Expected TCP server address');
+
+    expect(['127.0.0.1', '::1']).toContain(address.address);
+  });
+
+  it('reports wildcard bind addresses without rewriting them to localhost', () => {
+    expect(httpAddressToString({ address: '0.0.0.0', family: 'IPv4', port: 1234 })).toBe('http://0.0.0.0:1234');
+    expect(httpAddressToString({ address: '::', family: 'IPv6', port: 1234 })).toBe('http://[::]:1234');
   });
 
   async function startServer() {


### PR DESCRIPTION
### Motivation
- The HTTP MCP transport could bind to all interfaces when `--port` was used because the server host default was left undefined, exposing powerful tools to the network.
- The displayed server URL rewrote wildcard binds (`0.0.0.0` / `::`) to `localhost`, masking the real public bind and misleading operators.

### Description
- Default the HTTP server bind host to `localhost` when no host is provided by changing `startHttpServer` to use `config.host ?? 'localhost'` (src/mcp/http.ts). 
- Stop rewriting explicit wildcard addresses to `localhost` in `httpAddressToString` so reported URLs reflect the actual bound address (src/mcp/http.ts). 
- Add tests that assert the server binds to localhost by default and that wildcard addresses are reported verbatim (tests/mcp-http.test.ts).

### Testing
- Ran `npm test -- tests/mcp-http.test.ts`, which passed all tests in the file. 
- Ran `npm run lint` (ESLint + `tsc --noEmit`) with no failures. 
- Ran `npm run build` (`tsc`) with successful build results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a130982fc8333a559ce7eaf140a3e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP server now explicitly binds to localhost by default when no host configuration is provided.
  * Wildcard bind addresses are no longer rewritten in server address formatting, preserving the original binding configuration.

* **Tests**
  * Added test coverage for HTTP server binding behavior and address formatting with wildcard addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JustasMonkev/mcp-accessibility-scanner/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->