### PR TITLE
Update dependencies, fix Playwright 1.60 breakage, reduce dedup work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
 				"debug": "^4.4.3",
 				"dotenv": "^17.4.2",
 				"mime": "^4.1.0",
-				"playwright": "^1.60.0",
-				"playwright-core": "^1.60.0",
+				"playwright": "1.60.0",
+				"playwright-core": "1.60.0",
 				"re2": "^1.24.1",
 				"ws": "^8.21.0",
 				"zod": "^4.4.3"
@@ -28,7 +28,7 @@
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.5",
 				"@eslint/js": "^9.39.4",
-				"@playwright/test": "^1.60.0",
+				"@playwright/test": "1.60.0",
 				"@stylistic/eslint-plugin": "^5.10.0",
 				"@types/chrome": "^0.1.42",
 				"@types/debug": "^4.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
 			"version": "2.0.10",
 			"license": "MIT",
 			"dependencies": {
-				"@axe-core/playwright": "^4.11.2",
+				"@axe-core/playwright": "^4.11.3",
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"commander": "^14.0.3",
 				"debug": "^4.4.3",
 				"dotenv": "^17.4.2",
 				"mime": "^4.1.0",
-				"playwright": "^1.59.1",
-				"playwright-core": "^1.59.1",
-				"re2": "^1.24.0",
-				"ws": "^8.20.0",
-				"zod": "^4.3.6"
+				"playwright": "^1.60.0",
+				"playwright-core": "^1.60.0",
+				"re2": "^1.24.1",
+				"ws": "^8.21.0",
+				"zod": "^4.4.3"
 			},
 			"bin": {
 				"mcp-server-playwright": "cli.js"
@@ -28,37 +28,37 @@
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.5",
 				"@eslint/js": "^9.39.4",
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.60.0",
 				"@stylistic/eslint-plugin": "^5.10.0",
-				"@types/chrome": "^0.1.40",
+				"@types/chrome": "^0.1.42",
 				"@types/debug": "^4.1.13",
-				"@types/node": "^25.6.0",
+				"@types/node": "^25.9.1",
 				"@types/ws": "^8.18.1",
-				"@typescript-eslint/eslint-plugin": "^8.58.2",
-				"@typescript-eslint/parser": "^8.58.2",
-				"@typescript-eslint/utils": "^8.58.2",
-				"@typescript/native-preview": "7.0.0-dev.20260518.1",
-				"@vitest/coverage-v8": "^4.1.4",
-				"@vitest/ui": "^4.1.4",
+				"@typescript-eslint/eslint-plugin": "^8.60.0",
+				"@typescript-eslint/parser": "^8.60.0",
+				"@typescript-eslint/utils": "^8.60.0",
+				"@typescript/native-preview": "7.0.0-dev.20260527.2",
+				"@vitest/coverage-v8": "^4.1.7",
+				"@vitest/ui": "^4.1.7",
 				"eslint": "^9.39.4",
 				"eslint-plugin-import": "^2.32.0",
 				"eslint-plugin-notice": "^1.0.0",
 				"happy-dom": "^20.9.0",
 				"ts-node": "^10.9.2",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.4"
+				"vitest": "^4.1.7"
 			},
 			"engines": {
 				"node": ">=24.0.0"
 			}
 		},
 		"node_modules/@axe-core/playwright": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
-			"integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+			"integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"axe-core": "~4.11.3"
+				"axe-core": "~4.11.4"
 			},
 			"peerDependencies": {
 				"playwright-core": ">= 1.0.0"
@@ -144,9 +144,9 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -506,38 +506,10 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
-		"node_modules/@npmcli/agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-			"integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^11.2.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/fs": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.124.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-			"integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+			"version": "0.132.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+			"integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -545,13 +517,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -568,9 +540,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+			"integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -585,9 +557,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+			"integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -602,9 +574,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+			"integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
 			"cpu": [
 				"x64"
 			],
@@ -619,9 +591,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+			"integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
 			"cpu": [
 				"x64"
 			],
@@ -636,9 +608,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-			"integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+			"integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
 			"cpu": [
 				"arm"
 			],
@@ -653,9 +625,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+			"integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -670,9 +642,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-			"integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+			"integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
 			"cpu": [
 				"arm64"
 			],
@@ -687,9 +659,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+			"integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -704,9 +676,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+			"integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -721,9 +693,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+			"integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
 			"cpu": [
 				"x64"
 			],
@@ -738,9 +710,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-			"integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+			"integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
 			"cpu": [
 				"x64"
 			],
@@ -755,9 +727,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+			"integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
 			"cpu": [
 				"arm64"
 			],
@@ -772,9 +744,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-			"integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+			"integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -782,18 +754,18 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "1.9.2",
-				"@emnapi/runtime": "1.9.2",
-				"@napi-rs/wasm-runtime": "^1.1.3"
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-			"integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+			"integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -808,9 +780,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-			"integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+			"integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -825,9 +797,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-			"integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -895,9 +867,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -917,9 +889,9 @@
 			}
 		},
 		"node_modules/@types/chrome": {
-			"version": "0.1.40",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.40.tgz",
-			"integrity": "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==",
+			"version": "0.1.42",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.42.tgz",
+			"integrity": "sha512-tdT2roFqGecZZDjA9fUEAINb2STxSPifHMDvY6EfRjNRCjdrs/0FwKt5RCIA9MKMd1arAYZZL3nwEkp6ZLZu2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -997,13 +969,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/whatwg-mimetype": {
@@ -1024,17 +996,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-			"integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.2",
-				"@typescript-eslint/type-utils": "8.58.2",
-				"@typescript-eslint/utils": "8.58.2",
-				"@typescript-eslint/visitor-keys": "8.58.2",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/type-utils": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1047,7 +1019,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.2",
+				"@typescript-eslint/parser": "^8.60.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -1063,16 +1035,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-			"integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.2",
-				"@typescript-eslint/types": "8.58.2",
-				"@typescript-eslint/typescript-estree": "8.58.2",
-				"@typescript-eslint/visitor-keys": "8.58.2",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1088,14 +1060,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-			"integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.2",
-				"@typescript-eslint/types": "^8.58.2",
+				"@typescript-eslint/tsconfig-utils": "^8.60.0",
+				"@typescript-eslint/types": "^8.60.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1110,14 +1082,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-			"integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+			"integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.2",
-				"@typescript-eslint/visitor-keys": "8.58.2"
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1128,9 +1100,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-			"integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1145,15 +1117,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-			"integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.2",
-				"@typescript-eslint/typescript-estree": "8.58.2",
-				"@typescript-eslint/utils": "8.58.2",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1170,9 +1142,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-			"integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+			"integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1184,16 +1156,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-			"integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.2",
-				"@typescript-eslint/tsconfig-utils": "8.58.2",
-				"@typescript-eslint/types": "8.58.2",
-				"@typescript-eslint/visitor-keys": "8.58.2",
+				"@typescript-eslint/project-service": "8.60.0",
+				"@typescript-eslint/tsconfig-utils": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1212,16 +1184,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-			"integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.2",
-				"@typescript-eslint/types": "8.58.2",
-				"@typescript-eslint/typescript-estree": "8.58.2"
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1236,13 +1208,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-			"integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+			"integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/types": "8.60.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1267,9 +1239,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-aJq3XQBPkL91U0YWPQ4WUzFpfzLmfwWt5tmtzdXaIiPZisqFVeG/uw+2b4e/uL/YhPAQt9OHG0UEIGLNfoiFwA==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1279,19 +1251,19 @@
 				"node": ">=16.20.0"
 			},
 			"optionalDependencies": {
-				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260518.1",
-				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260518.1"
+				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260527.2"
 			}
 		},
 		"node_modules/@typescript/native-preview-darwin-arm64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-5n6xnR8jsDjrjHkf30hVVzby/cTusPrc0f6S3hQLrTdACC9JejsrHMHV1rRu55gSAIZhhBY0pqvG3/VKB9J0tA==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew==",
 			"cpu": [
 				"arm64"
 			],
@@ -1306,9 +1278,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-darwin-x64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-zO1lq7F6QskMZOfyQGpvnJF+DtbWtraMF/1srgtu86Yoc3MvRAnidX3R5S6l10d+r153WL0T4A8aMfZNhv2SAQ==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw==",
 			"cpu": [
 				"x64"
 			],
@@ -1323,9 +1295,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-u2XUYrpqqBoYa+sb80pNURIy7OqIj1sBNecJb3+cGVxKdeBOMT2p7yPlg6ozuZnurAeUSuGwMWt5eekG0QRYVQ==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg==",
 			"cpu": [
 				"arm"
 			],
@@ -1340,9 +1312,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-V/nLg3BtptWuRJnFUM2wACfZqtkqwC461eb07VabOWTkTEP+ouB7bUWapx6sbb023FiUIk3C3BPK5icjDM7GxA==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1357,9 +1329,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-x64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-NpG2X1kViy7YRpw54GTanHuoH/hwLywuVvFDnoAitR7zDCGJ7OP2YMyCLMrVJX+aCjz4NPrYqROf9OfdwRyNIw==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA==",
 			"cpu": [
 				"x64"
 			],
@@ -1374,9 +1346,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-win32-arm64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-Y7NTZd5yD/FxQLVxQdlK9MdXEsVQFgSOMu24p32kHthFJeVT81TYeMCr6qg0dKWCgOHGEcZtgN3jdmBz0OdaTg==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1391,9 +1363,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-win32-x64": {
-			"version": "7.0.0-dev.20260518.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260518.1.tgz",
-			"integrity": "sha512-bFtq+ynOjZ3zqJSSm0wMFxlstXHoxGhT+dXnj5HihmuGGjrRM5PoNbPZVnpJ4xqAwvx8KHWZchZnpAr+yPgekA==",
+			"version": "7.0.0-dev.20260527.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260527.2.tgz",
+			"integrity": "sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg==",
 			"cpu": [
 				"x64"
 			],
@@ -1408,14 +1380,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-			"integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+			"integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.4",
+				"@vitest/utils": "4.1.7",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -1429,8 +1401,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.4",
-				"vitest": "4.1.4"
+				"@vitest/browser": "4.1.7",
+				"vitest": "4.1.7"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -1439,16 +1411,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+			"integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.4",
-				"@vitest/utils": "4.1.4",
+				"@vitest/spy": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1457,13 +1429,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+			"integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.4",
+				"@vitest/spy": "4.1.7",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1484,9 +1456,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+			"integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1497,13 +1469,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+			"integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.4",
+				"@vitest/utils": "4.1.7",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1511,14 +1483,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+			"integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.4",
-				"@vitest/utils": "4.1.4",
+				"@vitest/pretty-format": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1527,9 +1499,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+			"integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1537,13 +1509,13 @@
 			}
 		},
 		"node_modules/@vitest/ui": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
-			"integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+			"integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.4",
+				"@vitest/utils": "4.1.7",
 				"fflate": "^0.8.2",
 				"flatted": "^3.4.2",
 				"pathe": "^2.0.3",
@@ -1555,17 +1527,17 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": "4.1.4"
+				"vitest": "4.1.7"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+			"integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.4",
+				"@vitest/pretty-format": "4.1.7",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1629,15 +1601,6 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/ajv": {
@@ -1908,9 +1871,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.3",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-			"integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+			"integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
 			"license": "MPL-2.0",
 			"engines": {
 				"node": ">=4"
@@ -1920,6 +1883,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -1953,6 +1917,7 @@
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
 			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -1968,28 +1933,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/cacache": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
-			"integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^5.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^13.0.0",
-				"lru-cache": "^11.1.0",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^13.0.0",
-				"unique-filename": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/call-bind": {
@@ -2393,29 +2336,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
-			}
-		},
-		"node_modules/encoding/node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/entities": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -2437,12 +2357,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"license": "MIT"
 		},
 		"node_modules/es-abstract": {
 			"version": "1.24.0",
@@ -2532,9 +2446,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3060,9 +2974,9 @@
 			}
 		},
 		"node_modules/fflate": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3179,18 +3093,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3298,23 +3200,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/glob": {
-			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minimatch": "^10.2.2",
-				"minipass": "^7.1.3",
-				"path-scurry": "^2.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -3504,12 +3389,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/http-cache-semantics": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3528,32 +3407,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -3603,6 +3456,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -3615,13 +3469,16 @@
 			"license": "ISC"
 		},
 		"node_modules/install-artifact-from-github": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.4.0.tgz",
-			"integrity": "sha512-+y6WywKZREw5rq7U2jvr2nmZpT7cbWbQQ0N/qfcseYnzHFz2cZz1Et52oY+XttYuYeTkI8Y+R2JNWj68MpQFSg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
+			"integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
 			"license": "BSD-3-Clause",
 			"bin": {
 				"install-from-cache": "bin/install-from-cache.js",
 				"save-to-github-cache": "bin/save-to-github-cache.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/internal-slot": {
@@ -4480,15 +4337,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lru-cache": {
-			"version": "11.2.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-			"integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4533,28 +4381,6 @@
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/make-fetch-happen": {
-			"version": "15.0.3",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
-			"integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^4.0.0",
-				"cacache": "^20.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^5.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^1.0.0",
-				"proc-log": "^6.0.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^13.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -4637,6 +4463,7 @@
 			"version": "10.2.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
 			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
@@ -4665,107 +4492,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/minipass-collect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-			"integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/minipass-fetch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.1.tgz",
-			"integrity": "sha512-yHK8pb0iCGat0lDrs/D6RZmCdaBT64tULXjdxjSMAqoDi18Q3qKEUTHypHQZQd9+FYpIS+lkvpq6C/R6SbUeRw==",
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^2.0.0",
-				"minizlib": "^3.0.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC"
-		},
-		"node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC"
-		},
-		"node_modules/minipass-sized": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
-			"integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/minizlib": {
@@ -4797,15 +4523,15 @@
 			"license": "MIT"
 		},
 		"node_modules/nan": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+			"integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4838,20 +4564,20 @@
 			}
 		},
 		"node_modules/node-gyp": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
-			"integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+			"integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^15.0.0",
 				"nopt": "^9.0.0",
 				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
 				"tar": "^7.5.4",
 				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
 				"which": "^6.0.0"
 			},
 			"bin": {
@@ -4862,21 +4588,21 @@
 			}
 		},
 		"node_modules/node-gyp/node_modules/isexe": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
-			"integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/node-gyp/node_modules/which": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-			"integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^4.0.0"
 			},
 			"bin": {
 				"node-which": "bin/which.js"
@@ -5105,18 +4831,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5165,22 +4879,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/path-scurry": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/path-to-regexp": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
@@ -5227,12 +4925,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5245,9 +4943,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
@@ -5267,9 +4965,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -5287,7 +4985,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5314,19 +5012,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/promise-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"license": "MIT",
-			"dependencies": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5351,9 +5036,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -5390,15 +5075,18 @@
 			}
 		},
 		"node_modules/re2": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/re2/-/re2-1.24.0.tgz",
-			"integrity": "sha512-pBm6cMaOb0Yb0kg0Sfw/k4LwDMkPScb/NVd7GrEllDwfsPZstsZIo93A6Nn0wZuWJw3h57GdzkrOk81EofKY/g==",
+			"version": "1.24.1",
+			"resolved": "https://registry.npmjs.org/re2/-/re2-1.24.1.tgz",
+			"integrity": "sha512-uRl9cLDKuobJQp+6lVz7E3AyVszubUJ0fqAMWout4ocUWTIFvdHgpqLwwMh/vuNGGGJGh2p2mJZJIQr9am9M/A==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"install-artifact-from-github": "^1.4.0",
-				"nan": "^2.26.2",
-				"node-gyp": "^12.2.0"
+				"install-artifact-from-github": "^1.6.0",
+				"nan": "^2.27.0",
+				"node-gyp": "^12.3.0"
+			},
+			"engines": {
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/uhop"
@@ -5488,24 +5176,15 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-			"integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+			"integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.124.0",
-				"@rolldown/pluginutils": "1.0.0-rc.15"
+				"@oxc-project/types": "=0.132.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -5514,21 +5193,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+				"@rolldown/binding-android-arm64": "1.0.2",
+				"@rolldown/binding-darwin-arm64": "1.0.2",
+				"@rolldown/binding-darwin-x64": "1.0.2",
+				"@rolldown/binding-freebsd-x64": "1.0.2",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.2",
+				"@rolldown/binding-linux-arm64-musl": "1.0.2",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.2",
+				"@rolldown/binding-linux-x64-gnu": "1.0.2",
+				"@rolldown/binding-linux-x64-musl": "1.0.2",
+				"@rolldown/binding-openharmony-arm64": "1.0.2",
+				"@rolldown/binding-wasm32-wasi": "1.0.2",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.2",
+				"@rolldown/binding-win32-x64-msvc": "1.0.2"
 			}
 		},
 		"node_modules/router": {
@@ -5835,44 +5514,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^10.0.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5881,18 +5522,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/ssri": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.0.tgz",
-			"integrity": "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/stackback": {
@@ -6041,9 +5670,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -6064,9 +5693,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+			"integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6074,13 +5703,13 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -6334,36 +5963,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+			"integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/unique-filename": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
-			"integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/unique-slug": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
-			"integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -6401,17 +6015,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.8",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-			"integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+			"version": "8.0.14",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+			"integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.8",
-				"rolldown": "1.0.0-rc.15",
-				"tinyglobby": "^0.2.15"
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.2",
+				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -6427,7 +6041,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -6494,19 +6108,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+			"integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.4",
-				"@vitest/mocker": "4.1.4",
-				"@vitest/pretty-format": "4.1.4",
-				"@vitest/runner": "4.1.4",
-				"@vitest/snapshot": "4.1.4",
-				"@vitest/spy": "4.1.4",
-				"@vitest/utils": "4.1.4",
+				"@vitest/expect": "4.1.7",
+				"@vitest/mocker": "4.1.7",
+				"@vitest/pretty-format": "4.1.7",
+				"@vitest/runner": "4.1.7",
+				"@vitest/snapshot": "4.1.7",
+				"@vitest/spy": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -6534,12 +6148,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.4",
-				"@vitest/browser-preview": "4.1.4",
-				"@vitest/browser-webdriverio": "4.1.4",
-				"@vitest/coverage-istanbul": "4.1.4",
-				"@vitest/coverage-v8": "4.1.4",
-				"@vitest/ui": "4.1.4",
+				"@vitest/browser-playwright": "4.1.7",
+				"@vitest/browser-preview": "4.1.7",
+				"@vitest/browser-webdriverio": "4.1.7",
+				"@vitest/coverage-istanbul": "4.1.7",
+				"@vitest/coverage-v8": "4.1.7",
+				"@vitest/ui": "4.1.7",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6731,9 +6345,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -6784,9 +6398,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 		"debug": "^4.4.3",
 		"dotenv": "^17.4.2",
 		"mime": "^4.1.0",
-		"playwright": "^1.60.0",
-		"playwright-core": "^1.60.0",
+		"playwright": "1.60.0",
+		"playwright-core": "1.60.0",
 		"re2": "^1.24.1",
 		"ws": "^8.21.0",
 		"zod": "^4.4.3"
@@ -52,7 +52,7 @@
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.5",
 		"@eslint/js": "^9.39.4",
-		"@playwright/test": "^1.60.0",
+		"@playwright/test": "1.60.0",
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/chrome": "^0.1.42",
 		"@types/debug": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -36,41 +36,41 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@axe-core/playwright": "^4.11.2",
+		"@axe-core/playwright": "^4.11.3",
 		"@cfworker/json-schema": "^4.1.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"commander": "^14.0.3",
 		"debug": "^4.4.3",
 		"dotenv": "^17.4.2",
 		"mime": "^4.1.0",
-		"playwright": "^1.59.1",
-		"playwright-core": "^1.59.1",
-		"re2": "^1.24.0",
-		"ws": "^8.20.0",
-		"zod": "^4.3.6"
+		"playwright": "^1.60.0",
+		"playwright-core": "^1.60.0",
+		"re2": "^1.24.1",
+		"ws": "^8.21.0",
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.5",
 		"@eslint/js": "^9.39.4",
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@stylistic/eslint-plugin": "^5.10.0",
-		"@types/chrome": "^0.1.40",
+		"@types/chrome": "^0.1.42",
 		"@types/debug": "^4.1.13",
-		"@types/node": "^25.6.0",
+		"@types/node": "^25.9.1",
 		"@types/ws": "^8.18.1",
-		"@typescript-eslint/eslint-plugin": "^8.58.2",
-		"@typescript-eslint/parser": "^8.58.2",
-		"@typescript-eslint/utils": "^8.58.2",
-		"@typescript/native-preview": "7.0.0-dev.20260518.1",
-		"@vitest/coverage-v8": "^4.1.4",
-		"@vitest/ui": "^4.1.4",
+		"@typescript-eslint/eslint-plugin": "^8.60.0",
+		"@typescript-eslint/parser": "^8.60.0",
+		"@typescript-eslint/utils": "^8.60.0",
+		"@typescript/native-preview": "7.0.0-dev.20260527.2",
+		"@vitest/coverage-v8": "^4.1.7",
+		"@vitest/ui": "^4.1.7",
 		"eslint": "^9.39.4",
 		"eslint-plugin-import": "^2.32.0",
 		"eslint-plugin-notice": "^1.0.0",
 		"happy-dom": "^20.9.0",
 		"ts-node": "^10.9.2",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.4"
+		"vitest": "^4.1.7"
 	},
 	"keywords": [
 		"mcp",
@@ -97,6 +97,7 @@
 	"overrides": {
 		"minimatch": ">=10.2.3",
 		"diff": "5.2.2",
-		"rollup": "^4.59.0"
+		"rollup": "^4.59.0",
+		"qs": ">=6.15.2"
 	}
 }

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -20,10 +20,11 @@ import net from 'net';
 import path from 'path';
 
 import * as playwright from 'playwright';
-// @ts-ignore
-import { registryDirectory } from 'playwright-core/lib/server/registry/index';
-// @ts-ignore
-import { startTraceViewerServer } from 'playwright-core/lib/server';
+// @ts-ignore -- internal bundle entry point exposed via package exports
+import { registry as registryBundle, server as serverBundle } from 'playwright-core/lib/coreBundle';
+
+const { registryDirectory } = registryBundle;
+const { startTraceViewerServer } = serverBundle;
 import { logUnhandledError, testDebug } from './utils/log.js';
 import { createHash } from './utils/guid.js';
 import { outputFile  } from './config.js';

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -21,10 +21,10 @@ import path from 'path';
 
 import * as playwright from 'playwright';
 // @ts-ignore -- internal bundle entry point exposed via package exports
-import { registry as registryBundle, server as serverBundle } from 'playwright-core/lib/coreBundle';
+import coreBundle from 'playwright-core/lib/coreBundle';
 
-const { registryDirectory } = registryBundle;
-const { startTraceViewerServer } = serverBundle;
+const { registryDirectory } = coreBundle.registry;
+const { startTraceViewerServer } = coreBundle.server;
 import { logUnhandledError, testDebug } from './utils/log.js';
 import { createHash } from './utils/guid.js';
 import { outputFile  } from './config.js';

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -35,8 +35,9 @@ import type websocket from 'ws';
 import type { ClientInfo } from '../browserContextFactory.js';
 import type { ExtensionCommand, ExtensionEvents } from './protocol.js';
 
-// @ts-ignore
-const { registry } = await import('playwright-core/lib/server/registry/index');
+// @ts-ignore -- internal bundle entry point exposed via package exports
+const { registry: registryBundle } = await import('playwright-core/lib/coreBundle');
+const { registry } = registryBundle;
 
 const debugLogger = debug('pw:mcp:relay');
 

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -36,8 +36,8 @@ import type { ClientInfo } from '../browserContextFactory.js';
 import type { ExtensionCommand, ExtensionEvents } from './protocol.js';
 
 // @ts-ignore -- internal bundle entry point exposed via package exports
-const { registry: registryBundle } = await import('playwright-core/lib/coreBundle');
-const { registry } = registryBundle;
+const coreBundle = (await import('playwright-core/lib/coreBundle')).default;
+const { registry } = coreBundle.registry;
 
 const debugLogger = debug('pw:mcp:relay');
 

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -384,7 +384,7 @@ const auditSite = defineTabTool({
             ...violation,
             nodes: dedupeAxeNodes(violation.nodes),
           }));
-          const trimmedViolations = trimAxeResults({ violations: dedupedViolations }, { maxNodesPerViolation: params.maxNodesPerViolation });
+          const trimmedViolations = trimAxeResults({ violations: dedupedViolations }, { maxNodesPerViolation: params.maxNodesPerViolation, dedupe: false });
 
           pageReport.status = 'scanned';
           pageReport.violations = trimmedViolations;

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -49,10 +49,14 @@ export function dedupeAxeNodes(nodes: AxeNode[]): AxeNode[] {
 
 export function trimAxeResults(
   results: Pick<AxeScanResult, 'violations'>,
-  options: { maxNodesPerViolation: number }
+  options: { maxNodesPerViolation: number; dedupe?: boolean }
 ): TrimmedAxeViolation[] {
+  // Callers that already deduped node lists can pass `dedupe: false` to skip a
+  // redundant second dedup pass over potentially large node sets.
+  const shouldDedupe = options.dedupe ?? true;
   return results.violations.map(violation => {
-    const nodes = dedupeAxeNodes(violation.nodes).slice(0, options.maxNodesPerViolation).map(node => ({
+    const sourceNodes = shouldDedupe ? dedupeAxeNodes(violation.nodes) : violation.nodes;
+    const nodes = sourceNodes.slice(0, options.maxNodesPerViolation).map(node => ({
       target: [...(node.target ?? [])],
       html: node.html ?? '',
       failureSummary: node.failureSummary ?? null,

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -183,7 +183,7 @@ const scanPageMatrix = defineTabTool({
           ...violation,
           nodes: dedupeAxeNodes(violation.nodes),
         }));
-        const trimmedViolations = trimAxeResults({ violations: dedupedViolations }, { maxNodesPerViolation: params.maxNodesPerViolation });
+        const trimmedViolations = trimAxeResults({ violations: dedupedViolations }, { maxNodesPerViolation: params.maxNodesPerViolation, dedupe: false });
         const nodeCountByRuleId = countNodesByRule(dedupedViolations);
 
         variantResults.push({

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-// @ts-ignore
-import { asLocator } from 'playwright-core/lib/utils';
+// @ts-ignore -- internal bundle entry point exposed via package exports
+import { iso as isoBundle } from 'playwright-core/lib/coreBundle';
+
+const { asLocator } = isoBundle;
 
 import type * as playwright from 'playwright';
 import type { Tab } from '../tab.js';

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -15,9 +15,9 @@
  */
 
 // @ts-ignore -- internal bundle entry point exposed via package exports
-import { iso as isoBundle } from 'playwright-core/lib/coreBundle';
+import coreBundle from 'playwright-core/lib/coreBundle';
 
-const { asLocator } = isoBundle;
+const { asLocator } = coreBundle.iso;
 
 import type * as playwright from 'playwright';
 import type { Tab } from '../tab.js';

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -113,8 +113,10 @@ describe('Tool Utils', () => {
 
       // Mock the asLocator function (exposed via the coreBundle `iso` namespace)
       vi.mock('playwright-core/lib/coreBundle', () => ({
-        iso: {
-          asLocator: (lang: string, selector: string) => `locator('${selector}')`,
+        default: {
+          iso: {
+            asLocator: (lang: string, selector: string) => `locator('${selector}')`,
+          },
         },
       }));
 

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -111,9 +111,11 @@ describe('Tool Utils', () => {
         }),
       } as any;
 
-      // Mock the asLocator function
-      vi.mock('playwright-core/lib/utils', () => ({
-        asLocator: (lang: string, selector: string) => `locator('${selector}')`,
+      // Mock the asLocator function (exposed via the coreBundle `iso` namespace)
+      vi.mock('playwright-core/lib/coreBundle', () => ({
+        iso: {
+          asLocator: (lang: string, selector: string) => `locator('${selector}')`,
+        },
       }));
 
       const result = await generateLocator(mockLocator);


### PR DESCRIPTION
Dependency updates (all at latest compatible versions):
- playwright / playwright-core / @playwright/test 1.59.1 -> 1.60.0
- vitest, @vitest/coverage-v8, @vitest/ui 4.1.4 -> 4.1.7
- zod 4.3.6 -> 4.4.3, ws 8.20.0 -> 8.21.0 (fixes advisory)
- @axe-core/playwright 4.11.3, re2 1.24.1
- @typescript-eslint/* 8.60.0, @types/node 25.9.1, @types/chrome 0.1.42
- @typescript/native-preview dev preview bump
- Add qs >=6.15.2 override to clear transitive DoS advisory (0 vulnerabilities)
- ESLint held at latest 9.x: eslint-plugin-import does not yet support ESLint 10

Playwright 1.60 restructured playwright-core internals and dropped the
lib/server, lib/server/registry/index, and lib/utils export paths the
project relied on. Re-point those imports at the publicly exported
lib/coreBundle entry point (registry/server/iso namespaces) and update
the matching test mock.

Performance: trimAxeResults re-deduped node lists that audit_site and
scan_page_matrix had already deduped. Add a dedupe option (default true)
so those callers skip the redundant second pass over large node sets.

https://claude.ai/code/session_01HvVFEM9r526U3MTbGo4Fem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Playwright, TypeScript, and testing framework dependencies; bumped several libraries and added an npm override for qs.

* **Bug Fixes**
  * Accessibility audit trimming now supports an option to disable deduplication, improving report accuracy.

* **Refactor**
  * Updated internal import usage for compatibility with the current Playwright bundle.

* **Tests**
  * Adjusted unit tests to align with updated import structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JustasMonkev/mcp-accessibility-scanner/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->