### PR TITLE
fix: include root export files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
 		"mcp-server-playwright": "cli.js"
 	},
 	"files": [
+		"index.js",
+		"index.d.ts",
+		"config.d.ts",
 		"lib/**/*",
 		"README.md",
 		"LICENSE",


### PR DESCRIPTION
## Summary

This includes the package root entrypoint files in the published npm tarball:

- `index.js`
- `index.d.ts`
- `config.d.ts`

## Why

`package.json` advertises the package root export as `./index.js` with types at `./index.d.ts`, but the `files` allowlist only published `lib/**/*` and metadata/docs files. As a result, `mcp-accessibility-scanner@2.0.11` installs without the files that Node and TypeScript resolve for the package root.

`config.d.ts` is included as well because `index.d.ts` imports `Config` from `./config.js`.

## Validation

- `npm install`
- `npm run build`
- `npm run typecheck`
- `npm pack --dry-run --json` confirms `index.js`, `index.d.ts`, `config.d.ts`, and `lib/index.js` are included
- Installed the packed tarball into a clean temp project and verified:
  - `import.meta.resolve('mcp-accessibility-scanner')` resolves to `node_modules/mcp-accessibility-scanner/index.js`
  - `await import('mcp-accessibility-scanner')` exports `createConnection`

Note: local validation used Node v22.18.0, so npm printed the existing `engines.node >=24.0.0` warning, but the build/typecheck and package import checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include TypeScript type definitions and main entry point file, ensuring complete library functionality is available upon installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->