### PR TITLE
Adopt latest MCP spec features and bump package to 2.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mcp-accessibility-scanner",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mcp-accessibility-scanner",
-			"version": "2.0.12",
+			"version": "2.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"@axe-core/playwright": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mcp-accessibility-scanner",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"mcpName": "io.github.JustasMonkev/mcp-accessibility-scanner",
 	"description": "A Model Context Protocol (MCP) server for performing automated accessibility scans of web pages using Playwright and Axe-core",
 	"type": "module",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/JustasMonkev/mcp-accessibility-scanner",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "2.0.13",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "mcp-accessibility-scanner",
-      "version": "1.1.1",
+      "version": "2.0.13",
       "transport": { "type": "stdio" },
       "environment_variables": []
     }

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -15,6 +15,8 @@
  */
 
 import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FullConfig } from './config.js';
 import { Context } from './context.js';
 import { logUnhandledError } from './utils/log.js';
@@ -63,10 +65,19 @@ export class BrowserServerBackend implements ServerBackend {
   }
 
   async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'], requestContext?: mcpServer.CallToolRequestContext) {
-    const tool = this._tools.find(tool => tool.schema.name === name)!;
+    const tool = this._tools.find(tool => tool.schema.name === name);
     if (!tool)
-      throw new Error(`Tool "${name}" not found`);
-    const parsedArguments = tool.schema.inputSchema.parse(rawArguments || {}) as Record<string, any>;
+      throw new McpError(ErrorCode.InvalidParams, `Tool "${name}" not found`);
+    let parsedArguments: Record<string, any>;
+    try {
+      parsedArguments = tool.schema.inputSchema.parse(rawArguments || {}) as Record<string, any>;
+    } catch (error) {
+      // Per the MCP spec, input validation failures are tool execution
+      // errors (isError results), not protocol errors.
+      if (error instanceof z.ZodError)
+        throw new Error(`Invalid input for tool "${name}":\n${z.prettifyError(error)}`);
+      throw error;
+    }
     const context = this._context!;
     const response = new Response(context, name, parsedArguments, requestContext);
     context.setRunningTool(name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { BrowserServerBackend } from './browserServerBackend.js';
 import { resolveConfig } from './config.js';
 import { contextFactory } from './browserContextFactory.js';
 import * as mcpServer from './mcp/server.js';
+import { serverInstructions } from './tools.js';
 import { packageJSON } from './utils/package.js';
 
 import type { Config } from '../config.js';
@@ -28,7 +29,7 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 export async function createConnection(userConfig: Config = {}, contextGetter?: () => Promise<BrowserContext>): Promise<Server> {
   const config = await resolveConfig(userConfig);
   const factory = contextGetter ? new SimpleBrowserContextFactory(contextGetter) : contextFactory(config);
-  return mcpServer.createServer('Playwright', packageJSON.version, new BrowserServerBackend(config, factory), false);
+  return mcpServer.createServer('Playwright', packageJSON.version, new BrowserServerBackend(config, factory), false, { title: 'Accessibility Scanner', instructions: serverInstructions });
 }
 
 class SimpleBrowserContextFactory implements BrowserContextFactory {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,7 +17,7 @@
 import debug from 'debug';
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { httpAddressToString, installHttpTransport, startHttpServer } from './http.js';
@@ -44,7 +44,12 @@ export interface ServerBackend {
   serverClosed?(): void;
 }
 
-export type ServerBackendFactory = {
+export type ServerMetadata = {
+  title?: string;
+  instructions?: string;
+};
+
+export type ServerBackendFactory = ServerMetadata & {
   name: string;
   nameInConfig: string;
   version: string;
@@ -52,7 +57,7 @@ export type ServerBackendFactory = {
 };
 
 export async function connect(factory: ServerBackendFactory, transport: Transport, runHeartbeat: boolean) {
-  const server = createServer(factory.name, factory.version, factory.create(), runHeartbeat);
+  const server = createServer(factory.name, factory.version, factory.create(), runHeartbeat, factory);
   await server.connect(transport);
 }
 
@@ -61,15 +66,16 @@ export async function wrapInProcess(backend: ServerBackend): Promise<Transport> 
   return new InProcessTransport(server);
 }
 
-export function createServer(name: string, version: string, backend: ServerBackend, runHeartbeat: boolean): Server {
+export function createServer(name: string, version: string, backend: ServerBackend, runHeartbeat: boolean, metadata?: ServerMetadata): Server {
   let initializedPromiseResolve = () => {};
   const initializedPromise = new Promise<void>(resolve => initializedPromiseResolve = resolve);
-  const server = new Server({ name, version }, {
+  const server = new Server({ name, version, title: metadata?.title }, {
     capabilities: {
       tools: {
         listChanged: true,
       },
-    }
+    },
+    instructions: metadata?.instructions,
   });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -92,6 +98,10 @@ export function createServer(name: string, version: string, backend: ServerBacke
     try {
       return await backend.callTool(request.params.name, request.params.arguments || {}, extra);
     } catch (error) {
+      // Protocol-level failures (e.g. unknown tool) surface as JSON-RPC
+      // errors; only tool execution failures become isError results.
+      if (error instanceof McpError)
+        throw error;
       return {
         content: [{ type: 'text', text: '### Result\n' + String(error) }],
         isError: true,

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -28,6 +28,9 @@ export type ToolSchema<Input extends z.Schema> = {
 export function toMcpTool(tool: ToolSchema<any>): mcpServer.Tool {
   return {
     name: tool.name,
+    // Top-level title takes precedence over annotations.title on spec
+    // 2025-06-18+ clients; annotations.title is kept for older clients.
+    title: tool.title,
     description: tool.description,
     inputSchema: z.toJSONSchema(tool.inputSchema) as mcpServer.Tool['inputSchema'],
     annotations: {

--- a/src/program.ts
+++ b/src/program.ts
@@ -25,7 +25,7 @@ import { contextFactory } from './browserContextFactory.js';
 import { ProxyBackend } from './mcp/proxyBackend.js';
 import { BrowserServerBackend } from './browserServerBackend.js';
 import { ExtensionContextFactory } from './extension/extensionContextFactory.js';
-import { filteredTools } from './tools.js';
+import { filteredTools, serverInstructions } from './tools.js';
 import { logUnhandledError } from './utils/log.js';
 
 import { runVSCodeTools } from './vscode/host.js';
@@ -49,8 +49,10 @@ async function resolveProgramContext(options: Record<string, unknown>): Promise<
 async function startMCPServer(config: FullConfig, browserContextFactory: BrowserContextFactory) {
   const factory: mcpServer.ServerBackendFactory = {
     name: 'Playwright',
+    title: 'Accessibility Scanner',
     nameInConfig: 'playwright',
     version: packageJSON.version,
+    instructions: serverInstructions,
     create: () => new BrowserServerBackend(config, browserContextFactory)
   };
   await mcpServer.start(factory, config.server);
@@ -108,8 +110,10 @@ configureBaseProgram()
       if (options.extension) {
         const serverBackendFactory: mcpServer.ServerBackendFactory = {
           name: 'Playwright w/ extension',
+          title: 'Accessibility Scanner (browser extension)',
           nameInConfig: 'playwright-extension',
           version: packageJSON.version,
+          instructions: serverInstructions,
           create: () => new BrowserServerBackend(config, extensionContextFactory)
         };
         await mcpServer.start(serverBackendFactory, config.server);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -64,3 +64,12 @@ export const allTools: Tool<any>[] = [
 export function filteredTools(config: FullConfig) {
   return allTools.filter(tool => tool.capability.startsWith('core') || config.capabilities?.includes(tool.capability));
 }
+
+export const serverInstructions = [
+  'This server runs automated web accessibility audits (axe-core / WCAG) and drives a real browser via Playwright.',
+  'Use `browser_navigate` to load a page first. Then use `audit_site` to crawl and scan multiple pages of a site,',
+  '`scan_page_matrix` to scan the current page across viewports and WCAG tag sets, and `audit_keyboard` to check',
+  'keyboard navigation, focus visibility and skip links. Results are returned as markdown with axe-core rule ids,',
+  'impact levels, failure summaries and remediation links. Regular browser interaction tools (click, type, snapshot,',
+  'screenshot, tabs) are also available for navigating to the state you want to audit.',
+].join(' ');

--- a/tests/browserServerBackend.test.ts
+++ b/tests/browserServerBackend.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { BrowserServerBackend } from '../src/browserServerBackend.js';
+import { resolveConfig } from '../src/config.js';
+
+const unusedFactory = {
+  createContext: async () => {
+    throw new Error('browser should not be launched in this test');
+  },
+} as any;
+
+describe('BrowserServerBackend.callTool', () => {
+  it('rejects unknown tools with an InvalidParams protocol error', async () => {
+    const config = await resolveConfig({});
+    const backend = new BrowserServerBackend(config, unusedFactory);
+    await expect(backend.callTool('does_not_exist', {}))
+        .rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+  });
+
+  it('reports invalid tool input as a readable execution error', async () => {
+    const config = await resolveConfig({});
+    const backend = new BrowserServerBackend(config, unusedFactory);
+    await expect(backend.callTool('browser_navigate', { url: 123 }))
+        .rejects.toThrow(/Invalid input for tool "browser_navigate"/);
+  });
+});

--- a/tests/mcp-server-errors.test.ts
+++ b/tests/mcp-server-errors.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ErrorCode, McpError, PingRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { wrapInProcess } from '../src/mcp/server.js';
+
+async function connectClient(backend: unknown) {
+  const transport = await wrapInProcess(backend as any);
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  client.setRequestHandler(PingRequestSchema, () => ({}));
+  await client.connect(transport);
+  return client;
+}
+
+describe('mcp server error mapping', () => {
+  it('surfaces McpError from the backend as a protocol error', async () => {
+    const backend = {
+      initialize: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => []),
+      callTool: vi.fn(async () => {
+        throw new McpError(ErrorCode.InvalidParams, 'Tool "missing_tool" not found');
+      }),
+    };
+
+    const client = await connectClient(backend);
+    try {
+      await expect(client.callTool({ name: 'missing_tool', arguments: {} }))
+          .rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('converts ordinary backend errors into isError tool results', async () => {
+    const backend = {
+      initialize: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => []),
+      callTool: vi.fn(async () => {
+        throw new Error('tool execution exploded');
+      }),
+    };
+
+    const client = await connectClient(backend);
+    try {
+      const result = await client.callTool({ name: 'some_tool', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect((result.content as Array<{ type: string, text: string }>)[0].text).toContain('tool execution exploded');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('exposes server title and instructions to the client', async () => {
+    const backend = {
+      initialize: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => []),
+      callTool: vi.fn(async () => ({ content: [] })),
+    };
+
+    const { createServer } = await import('../src/mcp/server.js');
+    const { InProcessTransport } = await import('../src/mcp/inProcessTransport.js');
+    const server = createServer('Test', '1.0.0', backend as any, false, {
+      title: 'Test Title',
+      instructions: 'Use the tools wisely.',
+    });
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    client.setRequestHandler(PingRequestSchema, () => ({}));
+    await client.connect(new InProcessTransport(server));
+    try {
+      expect(client.getInstructions()).toBe('Use the tools wisely.');
+      expect(client.getServerVersion()).toMatchObject({ name: 'Test', title: 'Test Title' });
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/tests/mcp-tool.test.ts
+++ b/tests/mcp-tool.test.ts
@@ -33,6 +33,7 @@ describe('mcp/tool', () => {
 
     const tool = toMcpTool(schema);
     expect(tool.name).toBe('test_read');
+    expect(tool.title).toBe('Test Read');
     expect(tool.description).toBe('Read-only tool');
     expect(tool.annotations?.title).toBe('Test Read');
     expect(tool.annotations?.readOnlyHint).toBe(true);


### PR DESCRIPTION
- Expose top-level tool title (spec 2025-06-18+ precedence) alongside
  annotations.title for older clients
- Advertise server title and instructions in the initialize handshake so
  clients get usage guidance for the accessibility tools
- Return unknown-tool calls as JSON-RPC InvalidParams protocol errors and
  input validation failures as readable tool execution errors, per the
  2025-11-25 spec guidance
- Sync stale server.json registry manifest (1.1.1) with the package version
- Add tests for error mapping, server metadata, and tool title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.0.13

* **Bug Fixes**
  * Improved error handling with clearer messages when tool parameters are invalid or missing

* **New Features**
  * Server now provides detailed instructions about available accessibility scanning tools and how to use them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->