### PR TITLE
chore: bump playwright/playwright-core to 1.61.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -633,6 +633,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -650,6 +653,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -667,6 +673,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -684,6 +693,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -701,6 +713,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -718,6 +733,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
 				"debug": "^4.4.3",
 				"dotenv": "^17.4.2",
 				"mime": "^4.1.0",
-				"playwright": "1.60.0",
-				"playwright-core": "1.60.0",
+				"playwright": "1.61.0",
+				"playwright-core": "1.61.0",
 				"re2": "^1.24.1",
 				"ws": "^8.21.0",
 				"zod": "^4.4.3"
@@ -29,7 +29,7 @@
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.5",
 				"@eslint/js": "^9.39.4",
-				"@playwright/test": "1.60.0",
+				"@playwright/test": "1.61.0",
 				"@stylistic/eslint-plugin": "^5.10.0",
 				"@types/chrome": "^0.1.42",
 				"@types/debug": "^4.1.13",
@@ -518,13 +518,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -633,9 +633,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -653,9 +650,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -673,9 +667,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -693,9 +684,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -713,9 +701,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -733,9 +718,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4954,12 +4936,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4972,9 +4954,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 		"debug": "^4.4.3",
 		"dotenv": "^17.4.2",
 		"mime": "^4.1.0",
-		"playwright": "1.60.0",
-		"playwright-core": "1.60.0",
+		"playwright": "1.61.0",
+		"playwright-core": "1.61.0",
 		"re2": "^1.24.1",
 		"ws": "^8.21.0",
 		"zod": "^4.4.3"
@@ -56,7 +56,7 @@
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.5",
 		"@eslint/js": "^9.39.4",
-		"@playwright/test": "1.60.0",
+		"@playwright/test": "1.61.0",
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/chrome": "^0.1.42",
 		"@types/debug": "^4.1.13",


### PR DESCRIPTION
## Upstream change

Playwright shipped **[v1.61.0](https://github.com/microsoft/playwright/releases/tag/v1.61.0)** (latest stable). This repo currently pins `playwright`/`playwright-core` to `1.60.0`.

## What changed upstream

1.61.0 adds WebAuthn passkeys (`browserContext.credentials`), the Web Storage API (`page.localStorage`/`page.sessionStorage`), and assorted network/test-runner features. **It contains no Playwright MCP API changes** — the recent upstream MCP commits (May–Jun 2026) are all test-runner MCP, not the browser MCP tools vendored here.

## Why it matters for this repo

This repo vendors Playwright's browser MCP tools and pins `playwright-core` exactly, bumping it manually because the vendored tools depend on `playwright-core` internals that shift between releases — most recently the 1.59 `_evaluateFunction` removal ([microsoft/playwright#39646](https://github.com/microsoft/playwright/pull/39646)) that broke `browser_evaluate` and was fixed in #84. Keeping the runtime current and confirming the MCP tools still work against it is exactly what this bump verifies.

## Action

Bump `playwright`, `playwright-core`, and `@playwright/test` to `1.61.0`.

Verified locally under 1.61.0:
- `npm run build` ✅
- `npm run lint` (eslint + typecheck) ✅
- `npm test` — **230 passed, 1 skipped** ✅

The `browser_evaluate` `toString` workaround is still required: `_evaluateFunction` remains absent from `playwright-core` on `main`, so no code change beyond the version bump is needed.

Minimal and focused: only `package.json` + `package-lock.json` (playwright-scoped) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnRcXQVZ9BNaX1osSuT5Z9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnRcXQVZ9BNaX1osSuT5Z9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing framework dependencies to the latest versions to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->