### PR TITLE
fix: restore resolved locator code snippets via public Locator.normalize() (playwright-core 1.61)

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -74,6 +74,20 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
 }
 
 export async function generateLocator(locator: playwright.Locator): Promise<string> {
+  // playwright-core 1.61 replaced the private `_resolveSelector` helper with the
+  // public `Locator.normalize()` method (microsoft/playwright). `normalize()`
+  // returns a locator whose `toString()` is the resolved JavaScript locator
+  // expression, which is exactly what the "Ran Playwright code" snippet needs.
+  if (typeof (locator as any).normalize === 'function') {
+    try {
+      const normalized = await locator.normalize();
+      return normalized.toString();
+    } catch {
+      // Fall through to the legacy/string strategies below.
+    }
+  }
+
+  // Older cores (< 1.61) still expose the private `_resolveSelector` helper.
   if (typeof (locator as any)._resolveSelector === 'function') {
     const { resolvedSelector } = await (locator as any)._resolveSelector();
     return asLocator('javascript', resolvedSelector);

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -104,6 +104,34 @@ describe('Tool Utils', () => {
   });
 
   describe('generateLocator', () => {
+    it('should resolve via the public normalize() API (playwright-core >= 1.61)', async () => {
+      const normalized = { toString: () => `getByRole('button', { name: 'Submit' })` };
+      const mockLocator = {
+        normalize: vi.fn().mockResolvedValue(normalized),
+        // Should be ignored when normalize() is available.
+        _resolveSelector: vi.fn().mockResolvedValue({ resolvedSelector: 'ignored' }),
+      } as any;
+
+      const result = await generateLocator(mockLocator);
+
+      expect(mockLocator.normalize).toHaveBeenCalled();
+      expect(mockLocator._resolveSelector).not.toHaveBeenCalled();
+      expect(result).toBe(`getByRole('button', { name: 'Submit' })`);
+    });
+
+    it('should fall back to _resolveSelector when normalize() throws', async () => {
+      const mockLocator = {
+        normalize: vi.fn().mockRejectedValue(new Error('ref not found')),
+        _resolveSelector: vi.fn().mockResolvedValue({ resolvedSelector: 'button[name="submit"]' }),
+      } as any;
+
+      const result = await generateLocator(mockLocator);
+
+      expect(mockLocator.normalize).toHaveBeenCalled();
+      expect(mockLocator._resolveSelector).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
     it('should generate locator string', async () => {
       const mockLocator = {
         _resolveSelector: vi.fn().mockResolvedValue({

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -14,10 +14,33 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { chromium, type Browser } from 'playwright';
 import { waitForCompletion, generateLocator, callOnPageNoTrace } from '../src/tools/utils.js';
 import type { Tab } from '../src/tab.js';
 import { EventEmitter } from 'events';
+
+const hasBundledChromium = fs.existsSync(chromium.executablePath());
+async function canLaunchBundledChromium(): Promise<boolean> {
+  if (!hasBundledChromium)
+    return false;
+
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      chromiumSandbox: false,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await browser?.close().catch(() => undefined);
+  }
+}
+
+const canRunLocatorIntegration = await canLaunchBundledChromium();
 
 describe('Tool Utils', () => {
   let mockTab: Tab;
@@ -170,6 +193,33 @@ describe('Tool Utils', () => {
       } as any;
 
       await expect(generateLocator(mockLocator)).resolves.toBe('locator(\'<unresolved>\')');
+    });
+
+    it.skipIf(!canRunLocatorIntegration)('should resolve aria-ref locators to runnable locator code', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        await page.setContent('<button type="button">Submit</button>');
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const ref = snapshot.match(/\[ref=([^\]]+)\]/)?.[1];
+        if (!ref)
+          throw new Error(`Could not find aria ref in snapshot:\n${snapshot}`);
+
+        const locator = page.locator(`aria-ref=${ref}`).describe('Submit button');
+        const locatorSource = await generateLocator(locator);
+
+        expect(locatorSource).not.toBe('Submit button');
+        expect(locatorSource).toContain('getByRole');
+        expect(locatorSource).toContain('button');
+        expect(locatorSource).toContain('Submit');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
     });
   });
 


### PR DESCRIPTION
## What changed upstream

Playwright removed the private `Locator._resolveSelector()` helper and replaced it with a **public `Locator.normalize(): Promise<Locator>`** method. The MCP server in `microsoft/playwright` now resolves locators for its "Ran Playwright code" output via this public API:

```ts
const resolved = await locator.normalize();
return { locator, resolved: resolved.toString() };
```
— [`packages/playwright-core/src/tools/backend/tab.ts` (`targetLocators`)](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/tools/backend/tab.ts)

At the pinned `playwright-core@1.61.0`, `Locator` exposes `normalize()` and no longer has `_resolveSelector` (verified in the installed `types/types.d.ts` and lib bundle). `Locator.toString()` returns `asLocatorDescription('javascript', selector)` — the resolved JavaScript locator expression — see [`client/locator.ts@v1.61.0`](https://github.com/microsoft/playwright/blob/v1.61.0/packages/playwright-core/src/client/locator.ts).

This is the same class of breakage previously handled in #84 (`_evaluateFunction` removed in 1.59) and reported in #13 (`_generateLocatorString`).

## Why it matters here

`generateLocator()` in `src/tools/utils.ts` guarded the now-missing `_resolveSelector` and fell through to its `String(locator)` fallback. For a real Playwright `Locator`, `String(locator)` is `"[object Object]"`, so the function returned the placeholder `locator('<unresolved>')`.

That string feeds the **"Ran Playwright code" snippets** for every element-targeted tool:
- `browser_evaluate` (`src/tools/evaluate.ts`)
- form fills (`src/tools/form.ts`)
- `browser_verify_*` (`src/tools/verify.ts`)
- element screenshots (`src/tools/screenshot.ts`)

So on 1.61.0 these all emitted `await page.locator('<unresolved>').…` instead of a real locator. The actual browser actions still worked (the guard intentionally never throws) — only the reproducible-code output was degraded.

## The fix (minimal, public API only)

`generateLocator()` now:
1. Prefers the public `Locator.normalize()` and returns `normalized.toString()` (the resolved JS locator), wrapped in try/catch so it can never block an action.
2. Keeps `_resolveSelector` as a fallback for older cores (< 1.61).
3. Keeps the existing `String(locator)`/`<unresolved>` last-resort fallback.

Added two regression tests in `tests/tools-utils.test.ts` covering the `normalize()` path and the `normalize()`-throws → `_resolveSelector` fallback.

## Verification

- `npm run build` ✅
- `npm run lint` (eslint + tsgo typecheck) ✅
- `tests/tools-utils.test.ts` 13/13 ✅ (incl. 2 new), plus `tools-evaluate`, `response`, `tool-definitions` 41/41 ✅

Browser e2e was not run here (browser binaries aren't installed in this environment); the change is confined to the code-snippet rendering path and is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGbdMzYcnomsngzmepQ9hw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGbdMzYcnomsngzmepQ9hw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locator resolution by using the public `normalize()` API when available, with a safe fallback to legacy selector resolution when normalization isn’t supported.  
* **Tests**
  * Expanded unit coverage for the new normalize/fallback behavior.
  * Added a conditional Playwright integration test for ARIA-based locators (skipped when runtime Chromium isn’t available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->