### PR TITLE
fix: wait for commit on navigate_back to avoid bfcache timeouts

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -50,7 +50,10 @@ const goBack = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    await tab.page.goBack();
+    // History traversal / bfcache restore can update the URL without Playwright
+    // observing the `load` lifecycle event, so wait only for the navigation to
+    // commit to avoid spurious timeouts. See microsoft/playwright#41153.
+    await tab.page.goBack({ waitUntil: 'commit' });
     response.setIncludeSnapshot();
     response.addCode(`await page.goBack();`);
   },

--- a/tests/tools-navigate.test.ts
+++ b/tests/tools-navigate.test.ts
@@ -102,6 +102,12 @@ describe('Navigate Tools', () => {
       expect(mockPage.goBack).toHaveBeenCalled();
     });
 
+    it('should wait for commit to avoid bfcache timeouts', async () => {
+      await backTool.handle(mockContext, {}, response);
+
+      expect(mockPage.goBack).toHaveBeenCalledWith({ waitUntil: 'commit' });
+    });
+
     it('should include snapshot after navigation', async () => {
       const setIncludeSnapshotSpy = vi.spyOn(response, 'setIncludeSnapshot');
 


### PR DESCRIPTION
## Upstream change

- **Upstream PR:** [microsoft/playwright#41153 — *fix(mcp): use waitUntil commit for navigate back/forward*](https://github.com/microsoft/playwright/pull/41153) (merged 2026-06-05, commit `e67af4f`)
- **Upstream issue:** [microsoft/playwright-mcp#1635 — *browser_navigate_back times out even though page.goBack succeeds*](https://github.com/microsoft/playwright-mcp/issues/1635)

## What changed upstream

Playwright MCP's `browser_navigate_back` (and `_forward`) was changed to call `page.goBack({ waitUntil: 'commit' })` instead of relying on the default `waitUntil: 'load'`. During history traversal or a bfcache restore, the URL can update without Playwright ever observing the `load` lifecycle event, so the navigation call would time out even though the page actually went back successfully.

## Why it matters here

This repository carries a near-verbatim fork of that tool. `src/tools/navigate.ts` called `tab.page.goBack()` with no options, so it defaults to `waitUntil: 'load'` and is vulnerable to the exact same spurious timeout against pages served from the bfcache.

(Note: this fork only ships `browser_navigate_back`; upstream removed `navigate_forward`, so no forward handler needs the same treatment.)

## Change

- Pass `waitUntil: 'commit'` to `page.goBack()` in `browser_navigate_back`, with a comment linking the upstream fix.
- Add a unit test asserting `goBack` is called with `{ waitUntil: 'commit' }`.

Minimal and focused; typecheck, lint, and the navigate test suite (13 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E31NFGdCjhbnwLRmkcmEmP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced back button navigation to handle browser history traversal more reliably, preventing spurious timeouts.

* **Tests**
  * Updated navigation tests to verify back button behavior with improved timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->