### PR TITLE
feat: make MCP heartbeat timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Create a `config.json` file with the following options:
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, and `--cdp-launch-startup-timeout`.
 
+#### HTTP Heartbeat
+
+When the server runs with `--port`, it sends MCP heartbeat pings for Streamable HTTP sessions. Set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to override the default `5000` ms timeout. Set it to `0` or any negative value to disable heartbeat pings for clients or proxies that do not answer server-initiated pings.
+
 ## Available Tools
 
 The MCP server provides comprehensive browser automation and accessibility scanning tools:

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -131,10 +131,14 @@ export function createServer(name: string, version: string, backend: ServerBacke
 }
 
 const startHeartbeat = (server: Server) => {
+  const timeout = pingTimeout();
+  if (timeout <= 0)
+    return;
+
   const beat = () => {
     Promise.race([
       server.ping(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('ping timeout')), 5000)),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('ping timeout')), timeout)),
     ]).then(() => {
       setTimeout(beat, 3000);
     }).catch(() => {
@@ -143,6 +147,18 @@ const startHeartbeat = (server: Server) => {
   };
 
   beat();
+};
+
+const defaultPingTimeout = 5000;
+
+const pingTimeout = (): number => {
+  const value = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+  if (value === undefined)
+    return defaultPingTimeout;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed))
+    return defaultPingTimeout;
+  return parsed;
 };
 
 function addServerListener(server: Server, event: 'close' | 'initialized', listener: () => void) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,7 +17,7 @@
 import debug from 'debug';
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, EmptyResultSchema, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { httpAddressToString, installHttpTransport, startHttpServer } from './http.js';
@@ -136,9 +136,16 @@ const startHeartbeat = (server: Server) => {
     return;
 
   const beat = () => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const ping = server.request({ method: 'ping' }, EmptyResultSchema, { timeout }).finally(() => {
+      if (timeoutId)
+        clearTimeout(timeoutId);
+    });
     Promise.race([
-      server.ping(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('ping timeout')), timeout)),
+      ping,
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('ping timeout')), timeout);
+      }),
     ]).then(() => {
       setTimeout(beat, 3000);
     }).catch(() => {
@@ -155,7 +162,10 @@ const pingTimeout = (): number => {
   const value = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
   if (value === undefined)
     return defaultPingTimeout;
-  const parsed = Number(value);
+  const trimmed = value.trim();
+  if (!trimmed)
+    return defaultPingTimeout;
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed))
     return defaultPingTimeout;
   return parsed;

--- a/tests/mcp-server-errors.test.ts
+++ b/tests/mcp-server-errors.test.ts
@@ -17,7 +17,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { ErrorCode, McpError, PingRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { wrapInProcess } from '../src/mcp/server.js';
+import { createServer, wrapInProcess } from '../src/mcp/server.js';
+import { InProcessTransport } from '../src/mcp/inProcessTransport.js';
 
 async function connectClient(backend: unknown) {
   const transport = await wrapInProcess(backend as any);
@@ -25,6 +26,42 @@ async function connectClient(backend: unknown) {
   client.setRequestHandler(PingRequestSchema, () => ({}));
   await client.connect(transport);
   return client;
+}
+
+async function connectHeartbeatClient(backend: unknown, pingHandler: () => object | Promise<object>) {
+  const server = createServer('Test', '1.0.0', backend as any, true);
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  client.setRequestHandler(PingRequestSchema, pingHandler);
+  await client.connect(new InProcessTransport(server));
+  return client;
+}
+
+async function waitForAssertion(assertion: () => void) {
+  const deadline = Date.now() + 1000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
+}
+
+async function withPingTimeout<T>(value: string, callback: () => Promise<T>) {
+  const previous = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+  process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = value;
+  try {
+    return await callback();
+  } finally {
+    if (previous === undefined)
+      delete process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+    else
+      process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = previous;
+  }
 }
 
 describe('mcp server error mapping', () => {
@@ -87,5 +124,47 @@ describe('mcp server error mapping', () => {
     } finally {
       await client.close();
     }
+  });
+
+  it('closes the server when heartbeat ping times out', async () => {
+    await withPingTimeout('20', async () => {
+      const backend = {
+        initialize: vi.fn(async () => undefined),
+        listTools: vi.fn(async () => []),
+        callTool: vi.fn(async () => ({ content: [] })),
+        serverClosed: vi.fn(),
+      };
+
+      const client = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
+      try {
+        await client.callTool({ name: 'some_tool', arguments: {} });
+        await waitForAssertion(() => expect(backend.serverClosed).toHaveBeenCalledTimes(1));
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  it('does not run heartbeat when ping timeout is non-positive', async () => {
+    await withPingTimeout('0', async () => {
+      const backend = {
+        initialize: vi.fn(async () => undefined),
+        listTools: vi.fn(async () => []),
+        callTool: vi.fn(async () => ({ content: [] })),
+        serverClosed: vi.fn(),
+      };
+
+      const client = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
+      try {
+        await client.callTool({ name: 'some_tool', arguments: {} });
+        await new Promise(resolve => setTimeout(resolve, 100));
+        await client.callTool({ name: 'some_tool', arguments: {} });
+
+        expect(backend.callTool).toHaveBeenCalledTimes(2);
+        expect(backend.serverClosed).not.toHaveBeenCalled();
+      } finally {
+        await client.close();
+      }
+    });
   });
 });

--- a/tests/mcp-server-errors.test.ts
+++ b/tests/mcp-server-errors.test.ts
@@ -33,7 +33,7 @@ async function connectHeartbeatClient(backend: unknown, pingHandler: () => objec
   const client = new Client({ name: 'test-client', version: '1.0.0' });
   client.setRequestHandler(PingRequestSchema, pingHandler);
   await client.connect(new InProcessTransport(server));
-  return client;
+  return { client, server };
 }
 
 async function waitForAssertion(assertion: () => void) {
@@ -135,7 +135,7 @@ describe('mcp server error mapping', () => {
         serverClosed: vi.fn(),
       };
 
-      const client = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
+      const { client } = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
       try {
         await client.callTool({ name: 'some_tool', arguments: {} });
         await waitForAssertion(() => expect(backend.serverClosed).toHaveBeenCalledTimes(1));
@@ -154,7 +154,7 @@ describe('mcp server error mapping', () => {
         serverClosed: vi.fn(),
       };
 
-      const client = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
+      const { client } = await connectHeartbeatClient(backend, () => new Promise<object>(() => {}));
       try {
         await client.callTool({ name: 'some_tool', arguments: {} });
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -162,6 +162,54 @@ describe('mcp server error mapping', () => {
 
         expect(backend.callTool).toHaveBeenCalledTimes(2);
         expect(backend.serverClosed).not.toHaveBeenCalled();
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  it('passes configured heartbeat timeout into the ping request', async () => {
+    await withPingTimeout('120000', async () => {
+      const backend = {
+        initialize: vi.fn(async () => undefined),
+        listTools: vi.fn(async () => []),
+        callTool: vi.fn(async () => ({ content: [] })),
+      };
+
+      const { client, server } = await connectHeartbeatClient(backend, () => ({}));
+      const requestSpy = vi.spyOn(server, 'request');
+      try {
+        await client.callTool({ name: 'some_tool', arguments: {} });
+
+        expect(requestSpy).toHaveBeenCalledWith(
+            { method: 'ping' },
+            expect.any(Object),
+            expect.objectContaining({ timeout: 120000 }),
+        );
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  it('uses the default heartbeat timeout when env value is blank', async () => {
+    await withPingTimeout('  ', async () => {
+      const backend = {
+        initialize: vi.fn(async () => undefined),
+        listTools: vi.fn(async () => []),
+        callTool: vi.fn(async () => ({ content: [] })),
+      };
+
+      const { client, server } = await connectHeartbeatClient(backend, () => ({}));
+      const requestSpy = vi.spyOn(server, 'request');
+      try {
+        await client.callTool({ name: 'some_tool', arguments: {} });
+
+        expect(requestSpy).toHaveBeenCalledWith(
+            { method: 'ping' },
+            expect.any(Object),
+            expect.objectContaining({ timeout: 5000 }),
+        );
       } finally {
         await client.close();
       }


### PR DESCRIPTION
## Upstream change

Playwright merged microsoft/playwright#41391: https://github.com/microsoft/playwright/pull/41391

That upstream MCP change adds PLAYWRIGHT_MCP_PING_TIMEOUT_MS for Streamable HTTP heartbeat pings. The default remains 5000 ms, and non-positive values disable heartbeat pings for clients or proxies that do not answer server-initiated pings. Playwright closed the alternative missed-ping behavior PR in microsoft/playwright#41373: https://github.com/microsoft/playwright/pull/41373

## Why it matters here

This repository has the same MCP HTTP heartbeat shape in src/mcp/server.ts: a server.ping() race against a hard-coded 5000 ms timeout, then server.close() on any missed ping. That can reap otherwise-live HTTP MCP sessions when an intermediary or client does not answer server-initiated pings quickly enough.

## Implemented fix

- Mirror upstream's PLAYWRIGHT_MCP_PING_TIMEOUT_MS parser and disabled-heartbeat behavior.
- Keep the existing 5000 ms default and close-on-timeout behavior.
- Document the environment variable for --port / Streamable HTTP users.
- Add focused MCP server tests for timeout reaping and disabled heartbeat behavior.

Closes #89.

## Validation

- npm test -- tests/mcp-server-errors.test.ts
- npm run lint
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP Heartbeat pings for Streamable HTTP sessions are now configurable via the `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` environment variable (default: 5000ms). Disable heartbeat by setting the timeout to 0 or below.

* **Documentation**
  * Added HTTP Heartbeat configuration documentation.

* **Tests**
  * Added heartbeat timeout test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->