### PR TITLE
fix: guard CDP page state capture timeouts

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -155,8 +155,11 @@ export class Response {
     const currentTab = this._context.currentTab();
     if (this._includeSnapshot && currentTab)
       this._tabSnapshot = await currentTab.captureSnapshot();
-    else if (currentTab)
-      await Promise.allSettled([currentTab.updateTitle()]);
+
+    const tabsToUpdate = this._includeTabs
+      ? this._context.tabs().filter(tab => !this._includeSnapshot || tab !== currentTab)
+      : currentTab && !this._includeSnapshot ? [currentTab] : [];
+    await Promise.allSettled(tabsToUpdate.map(tab => tab.updateTitle()));
   }
 
   tabSnapshot(): TabSnapshot | undefined {

--- a/src/response.ts
+++ b/src/response.ts
@@ -152,9 +152,11 @@ export class Response {
   async finish() {
     // All the async snapshotting post-action is happening here.
     // Everything below should race against modal states.
-    if (this._includeSnapshot && this._context.currentTab())
-      this._tabSnapshot = await this._context.currentTabOrDie().captureSnapshot();
-    await Promise.allSettled(this._context.tabs().map(tab => tab.updateTitle()));
+    const currentTab = this._context.currentTab();
+    if (this._includeSnapshot && currentTab)
+      this._tabSnapshot = await currentTab.captureSnapshot();
+    else if (currentTab)
+      await Promise.allSettled([currentTab.updateTitle()]);
   }
 
   tabSnapshot(): TabSnapshot | undefined {

--- a/src/response.ts
+++ b/src/response.ts
@@ -154,8 +154,7 @@ export class Response {
     // Everything below should race against modal states.
     if (this._includeSnapshot && this._context.currentTab())
       this._tabSnapshot = await this._context.currentTabOrDie().captureSnapshot();
-    for (const tab of this._context.tabs())
-      await tab.updateTitle();
+    await Promise.allSettled(this._context.tabs().map(tab => tab.updateTitle()));
   }
 
   tabSnapshot(): TabSnapshot | undefined {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -50,12 +50,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _onPageClose: (tab: Tab) => void;
   private _modalStates: ModalState[] = [];
   private _downloads: { download: playwright.Download, finished: boolean, outputFile: string }[] = [];
+  private _defaultTimeout: number;
 
   constructor(context: Context, page: playwright.Page, onPageClose: (tab: Tab) => void) {
     super();
     this.context = context;
     this.page = page;
     this._onPageClose = onPageClose;
+    this._defaultTimeout = context.config.timeouts.defaultTimeout ?? 6000;
     page.on('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     page.on('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
     page.on('request', request => this._requests.set(request, null));
@@ -73,7 +75,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       void this._downloadStarted(download);
     });
     page.setDefaultNavigationTimeout(context.config.timeouts.navigationTimeout ?? 30000);
-    page.setDefaultTimeout(context.config.timeouts.defaultTimeout ?? 6000);
+    page.setDefaultTimeout(this._defaultTimeout);
     _pageTabMap.set(page, this);
   }
 
@@ -148,6 +150,11 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   lastTitle(): string {
     return this._lastTitle;
+  }
+
+  setDefaultTimeout(timeout: number) {
+    this._defaultTimeout = timeout;
+    this.page.setDefaultTimeout(timeout);
   }
 
   isCurrentTab(): boolean {
@@ -244,8 +251,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _pageStateTimeoutMs(): number {
-    const timeout = this.context.config.timeouts.defaultTimeout;
-    return typeof timeout === 'number' && timeout > 0 ? timeout : 5000;
+    return this._defaultTimeout > 0 ? this._defaultTimeout : 5000;
   }
 
   private async _withPageStateTimeout<T>(promise: Promise<T>, description: string): Promise<T> {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -135,7 +135,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   async updateTitle() {
     await this._raceAgainstModalStates(async () => {
-      this._lastTitle = await callOnPageNoTrace(this.page, page => page.title());
+      try {
+        this._lastTitle = await this._withPageStateTimeout(
+            callOnPageNoTrace(this.page, page => page.title()),
+            'reading page title',
+        );
+      } catch (error) {
+        logUnhandledError(error);
+      }
     });
   }
 
@@ -191,10 +198,26 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async captureSnapshot(): Promise<TabSnapshot> {
     let tabSnapshot: TabSnapshot | undefined;
     const modalStates = await this._raceAgainstModalStates(async () => {
-      const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
+      const [snapshot, title] = await Promise.all([
+        this._withPageStateTimeout(
+            this.page.ariaSnapshot({ mode: 'ai' }),
+            'capturing page accessibility snapshot',
+        ).catch(error => {
+          logUnhandledError(error);
+          return `# Page snapshot unavailable: ${formatPageStateError(error)}`;
+        }),
+        this._withPageStateTimeout(
+            this.page.title(),
+            'reading page title',
+        ).catch(error => {
+          logUnhandledError(error);
+          return this._lastTitle;
+        }),
+      ]);
+      this._lastTitle = title;
       tabSnapshot = {
         url: this.page.url(),
-        title: await this.page.title(),
+        title,
         ariaSnapshot: snapshot,
         modalStates: [],
         consoleMessages: [],
@@ -218,6 +241,28 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   private _javaScriptBlocked(): boolean {
     return this._modalStates.some(state => state.type === 'dialog');
+  }
+
+  private _pageStateTimeoutMs(): number {
+    const timeout = this.context.config.timeouts.defaultTimeout;
+    return typeof timeout === 'number' && timeout > 0 ? timeout : 5000;
+  }
+
+  private async _withPageStateTimeout<T>(promise: Promise<T>, description: string): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error(`Timed out after ${this._pageStateTimeoutMs()}ms while ${description}.`));
+          }, this._pageStateTimeoutMs());
+        }),
+      ]);
+    } finally {
+      if (timeoutId)
+        clearTimeout(timeoutId);
+    }
   }
 
   private async _raceAgainstModalStates(action: () => Promise<void>): Promise<ModalState[]> {
@@ -291,6 +336,12 @@ function pageErrorToConsoleMessage(errorOrValue: Error | any): ConsoleMessage {
     text: String(errorOrValue),
     toString: () => String(errorOrValue),
   };
+}
+
+function formatPageStateError(error: unknown): string {
+  if (error instanceof Error)
+    return error.message;
+  return String(error);
 }
 
 export function renderModalStates(context: Context, modalStates: ModalState[]): string[] {

--- a/src/tools/tabs.ts
+++ b/src/tools/tabs.ts
@@ -95,8 +95,7 @@ const defaultTimeout = defineTool({
   handle: async (context, params, response) => {
     const tabs = context.tabs();
     for (const tab of tabs)
-      tab.page.setDefaultTimeout(params.timeout);
-
+      tab.setDefaultTimeout(params.timeout);
 
     response.addResult(`Default timeout set to ${params.timeout}ms for all tabs.`);
     response.setIncludeTabs();

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -168,10 +168,20 @@ describe('Response', () => {
       expect(mockTab.captureSnapshot).toHaveBeenCalled();
     });
 
-    it('should update all tab titles', async () => {
+    it('should update the current tab title when no snapshot is requested', async () => {
       const response = new Response(mockContext, 'test_tool', {});
       await response.finish();
       expect(mockTab.updateTitle).toHaveBeenCalled();
+    });
+
+    it('should not refresh the current tab title after capturing its snapshot', async () => {
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+
+      await response.finish();
+
+      expect(mockTab.captureSnapshot).toHaveBeenCalled();
+      expect(mockTab.updateTitle).not.toHaveBeenCalled();
     });
 
     it('does not fail the response when a tab title update fails', async () => {

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -173,6 +173,14 @@ describe('Response', () => {
       await response.finish();
       expect(mockTab.updateTitle).toHaveBeenCalled();
     });
+
+    it('does not fail the response when a tab title update fails', async () => {
+      mockTab.updateTitle = vi.fn().mockRejectedValue(new Error('title unavailable'));
+      const response = new Response(mockContext, 'test_tool', {});
+
+      await expect(response.finish()).resolves.toBeUndefined();
+      expect(mockTab.updateTitle).toHaveBeenCalled();
+    });
   });
 
   describe('reportProgress', () => {

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -174,6 +174,23 @@ describe('Response', () => {
       expect(mockTab.updateTitle).toHaveBeenCalled();
     });
 
+    it('should update all tab titles when rendering the tab list without a snapshot', async () => {
+      const otherTab = {
+        page: { url: () => 'https://other.example.com' },
+        lastTitle: () => 'Other Page',
+        isCurrentTab: () => false,
+        updateTitle: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      mockContext.tabs = () => [mockTab, otherTab];
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeTabs();
+
+      await response.finish();
+
+      expect(mockTab.updateTitle).toHaveBeenCalled();
+      expect(otherTab.updateTitle).toHaveBeenCalled();
+    });
+
     it('should not refresh the current tab title after capturing its snapshot', async () => {
       const response = new Response(mockContext, 'test_tool', {});
       response.setIncludeSnapshot();
@@ -182,6 +199,25 @@ describe('Response', () => {
 
       expect(mockTab.captureSnapshot).toHaveBeenCalled();
       expect(mockTab.updateTitle).not.toHaveBeenCalled();
+    });
+
+    it('should refresh non-current tab titles when rendering tabs after a snapshot', async () => {
+      const otherTab = {
+        page: { url: () => 'https://other.example.com' },
+        lastTitle: () => 'Other Page',
+        isCurrentTab: () => false,
+        updateTitle: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      mockContext.tabs = () => [mockTab, otherTab];
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+      response.setIncludeTabs();
+
+      await response.finish();
+
+      expect(mockTab.captureSnapshot).toHaveBeenCalled();
+      expect(mockTab.updateTitle).not.toHaveBeenCalled();
+      expect(otherTab.updateTitle).toHaveBeenCalled();
     });
 
     it('does not fail the response when a tab title update fails', async () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Tab, renderModalStates } from '../src/tab.js';
 import type { Context } from '../src/context.js';
 import { EventEmitter } from 'events';
@@ -49,6 +49,10 @@ describe('Tab', () => {
     } as any;
 
     onPageClose = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('constructor', () => {
@@ -140,6 +144,21 @@ describe('Tab', () => {
     });
   });
 
+  describe('updateTitle', () => {
+    it('stops waiting when the page title never resolves', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      mockPage.title = vi.fn().mockReturnValue(new Promise(() => {}));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const updatePromise = tab.updateTitle();
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(updatePromise).resolves.toBeUndefined();
+      expect(tab.lastTitle()).toBe('about:blank');
+    });
+  });
+
   describe('captureSnapshot', () => {
     it('should capture page snapshot', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
@@ -173,6 +192,37 @@ describe('Tab', () => {
       await tab.captureSnapshot();
       const snapshot2 = await tab.captureSnapshot();
       expect(snapshot2.consoleMessages).toHaveLength(0);
+    });
+
+    it('returns a best-effort snapshot when the page title never resolves', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      mockPage.title = vi.fn().mockReturnValue(new Promise(() => {}));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshotPromise = tab.captureSnapshot();
+      await vi.advanceTimersByTimeAsync(25);
+      const snapshot = await snapshotPromise;
+
+      expect(snapshot.url).toBe('https://example.com');
+      expect(snapshot.title).toBe('about:blank');
+      expect(snapshot.ariaSnapshot).toBe('button "Submit" [ref=1]');
+    });
+
+    it('returns a best-effort snapshot when the accessibility snapshot never resolves', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      mockPage.ariaSnapshot = vi.fn().mockReturnValue(new Promise(() => {}));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshotPromise = tab.captureSnapshot();
+      await vi.advanceTimersByTimeAsync(25);
+      const snapshot = await snapshotPromise;
+
+      expect(snapshot.url).toBe('https://example.com');
+      expect(snapshot.title).toBe('Example Page');
+      expect(snapshot.ariaSnapshot).toContain('Page snapshot unavailable');
+      expect(snapshot.ariaSnapshot).toContain('capturing page accessibility snapshot');
     });
   });
 

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -157,6 +157,28 @@ describe('Tab', () => {
       await expect(updatePromise).resolves.toBeUndefined();
       expect(tab.lastTitle()).toBe('about:blank');
     });
+
+    it('uses the runtime default timeout when it changes after tab creation', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      mockPage.title = vi.fn().mockReturnValue(new Promise(() => {}));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      let finished = false;
+
+      tab.setDefaultTimeout(75);
+      const updatePromise = tab.updateTitle().then(() => {
+        finished = true;
+      });
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(finished).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(50);
+      await updatePromise;
+
+      expect(finished).toBe(true);
+      expect(mockPage.setDefaultTimeout).toHaveBeenLastCalledWith(75);
+    });
   });
 
   describe('captureSnapshot', () => {

--- a/tests/tools-tabs.test.ts
+++ b/tests/tools-tabs.test.ts
@@ -33,6 +33,7 @@ describe('Tabs Tools', () => {
         setDefaultNavigationTimeout: vi.fn(),
         setDefaultTimeout: vi.fn(),
       },
+      setDefaultTimeout: vi.fn((timeout: number) => mockTab1.page.setDefaultTimeout(timeout)),
       lastTitle: () => 'Example Page',
       isCurrentTab: () => true,
     } as any;
@@ -43,6 +44,7 @@ describe('Tabs Tools', () => {
         setDefaultNavigationTimeout: vi.fn(),
         setDefaultTimeout: vi.fn(),
       },
+      setDefaultTimeout: vi.fn((timeout: number) => mockTab2.page.setDefaultTimeout(timeout)),
       lastTitle: () => 'Other Page',
       isCurrentTab: () => false,
     } as any;
@@ -146,6 +148,8 @@ describe('Tabs Tools', () => {
     it('should set default timeout for all tabs', async () => {
       await defaultTimeoutTool.handle(mockContext, { timeout: 30000 }, response);
 
+      expect(mockTab1.setDefaultTimeout).toHaveBeenCalledWith(30000);
+      expect(mockTab2.setDefaultTimeout).toHaveBeenCalledWith(30000);
       expect(mockTab1.page.setDefaultTimeout).toHaveBeenCalledWith(30000);
       expect(mockTab2.page.setDefaultTimeout).toHaveBeenCalledWith(30000);
       expect(response.result()).toContain('30000ms');


### PR DESCRIPTION
## Summary

- Guard tab title refreshes and snapshot metadata reads with the existing `defaultTimeout` so a wedged CDP-attached page cannot hang the MCP response indefinitely.
- Return a best-effort snapshot when page title or accessibility snapshot capture times out.
- Refresh tab titles with `Promise.allSettled()` so one bad tab does not fail the whole response.

## Upstream context

- Upstream Playwright issue: https://github.com/microsoft/playwright/issues/41397
- Playwright closed the CDP/prerender repro as outside upstream scope, but the MCP-facing symptom still matters here because this repo supports `--cdp-endpoint` and `--cdp-launch-command`.
- The local risk is in `src/response.ts` and `src/tab.ts`, where response finalization reads tab titles and snapshots after tool execution.

Closes #92.

## Validation

- `npm test -- tests/tab.test.ts tests/response.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made tab title and snapshot handling more resilient: timeouts now prevent hangs and fall back to prior/placeholder values when snapshot/title retrieval fails.
  * Optimized post-action updates so title updates target only the active tab (and can be skipped when a snapshot is included).
* **New Features**
  * Updated the default-timeout tool to apply timeouts at the tab level.
* **Tests**
  * Expanded coverage for best-effort behavior, timeout expiry, and finish flow; added timer cleanup to keep tests isolated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->