### PR TITLE
Truncate data URL payloads in MCP output

### DIFF
--- a/src/tab.ts
+++ b/src/tab.ts
@@ -20,6 +20,7 @@ import { callOnPageNoTrace, waitForCompletion } from './tools/utils.js';
 import { logUnhandledError } from './utils/log.js';
 import { ManualPromise } from './mcp/manualPromise.js';
 import type { ModalState } from './tools/tool.js';
+import { truncateDataUrlsInText } from './utils/url.js';
 
 import type { Context } from './context.js';
 
@@ -225,7 +226,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot = {
         url: this.page.url(),
         title,
-        ariaSnapshot: snapshot,
+        ariaSnapshot: truncateDataUrlsInText(snapshot),
         modalStates: [],
         consoleMessages: [],
         downloads: this._downloads,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
+import { truncateDataUrl } from '../utils/url.js';
 
 import type * as playwright from 'playwright';
 
@@ -38,7 +39,7 @@ const requests = defineTabTool({
 
 function renderRequest(request: playwright.Request, response: playwright.Response | null) {
   const result: string[] = [];
-  result.push(`[${request.method().toUpperCase()}] ${request.url()}`);
+  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrl(request.url())}`);
   if (response)
     result.push(`=> [${response.status()}] ${response.statusText()}`);
   return result.join(' ');

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const dataUrlOutputTerminator = /[\s\]"'<)]/;
+
+export function truncateDataUrl(url: string): string {
+  if (!url.startsWith('data:'))
+    return url;
+  const comma = url.indexOf(',');
+  if (comma === -1)
+    return url;
+  return url.slice(0, comma + 1) + '\u2026';
+}
+
+export function truncateDataUrlsInText(text: string): string {
+  let result = '';
+  let position = 0;
+
+  while (position < text.length) {
+    const start = text.indexOf('data:', position);
+    if (start === -1) {
+      result += text.slice(position);
+      break;
+    }
+
+    result += text.slice(position, start);
+    let end = start;
+    while (end < text.length && !dataUrlOutputTerminator.test(text[end]))
+      ++end;
+
+    result += truncateDataUrl(text.slice(start, end));
+    position = end;
+  }
+
+  return result;
+}

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -191,6 +191,17 @@ describe('Tab', () => {
       expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
     });
 
+    it('truncates data URL payloads in page snapshots', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "a link" [ref=e2]: /url: data:text/html;base64,${payload}`);
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshot = await tab.captureSnapshot();
+
+      expect(snapshot.ariaSnapshot).toContain('data:text/html;base64,\u2026');
+      expect(snapshot.ariaSnapshot).not.toContain(payload);
+    });
+
     it('should include console messages in snapshot', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       mockPage.emit('console', {

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -96,6 +96,17 @@ describe('Network Tools', () => {
       expect(result).toContain('https://api.example.com/missing');
     });
 
+    it('truncates data URL payloads', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const request = { url: () => `data:text/html;base64,${payload}`, method: () => 'GET' };
+      mockTab.requests = vi.fn().mockReturnValue(new Map([[request, null]]));
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('data:text/html;base64,\u2026');
+      expect(response.result()).not.toContain(payload);
+    });
+
     it('should handle empty requests', async () => {
       mockTab.requests = vi.fn().mockReturnValue(new Map());
 


### PR DESCRIPTION
Upstream: https://github.com/microsoft/playwright/pull/41450 (commit https://github.com/microsoft/playwright/commit/e964bceba84906d45c9947a5c5bcb0561b6a2500)

What changed upstream:
Playwright MCP is adding data URL truncation for page snapshot link hrefs and network request output. The upstream PR keeps the data URL media type prefix and removes the payload, because base64 data can consume large amounts of agent context without adding useful information.

Why it matters here:
This server exposes the same MCP-facing output paths: browser_snapshot returns Playwright ARIA snapshots, and browser_network_requests prints request URLs. Without truncation, data URL payloads can be returned directly to clients.

Implemented fix:
- Added a shared data URL truncation helper.
- Applied it to captured page snapshots and network request output.
- Added focused regressions for both paths.

Validation:
- npm test -- tests/tab.test.ts tests/tools-network.test.ts
- npm run lint
- npm run build
- npm test