### PR TITLE
fix: truncate data URL payloads in MCP output

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Close a tab.
 
 #### `browser_console_messages`
 Returns all console messages from the page.
+Large `data:` URL payloads in console messages are truncated to their media type prefix.
 
 #### `browser_network_requests`
 Returns all network requests since loading the page.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Go forward to the next page.
 
 #### `browser_snapshot`
 Capture accessibility snapshot of the current page (better than screenshot for analysis).
+Large `data:` URL payloads in snapshot output are truncated to their media type prefix.
 
 #### `browser_click`
 Perform click on a web page element.
@@ -356,6 +357,7 @@ Returns all console messages from the page.
 
 #### `browser_network_requests`
 Returns all network requests since loading the page.
+Large `data:` URL payloads in request URLs are truncated to their media type prefix.
 
 ### Utility Tools
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,7 @@ import { pathToFileURL } from 'node:url';
 import debug from 'debug';
 
 import { renderModalStates } from './tab.js';
-import { truncateDataUrl, truncateDataUrls } from './utils/dataUrl.js';
+import { truncateDataUrls } from './utils/dataUrl.js';
 
 import type { Tab, TabSnapshot } from './tab.js';
 import type { CallToolResult, ResourceLink } from '@modelcontextprotocol/sdk/types.js';
@@ -243,7 +243,7 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
   }
 
   lines.push(`### Page state`);
-  lines.push(`- Page URL: ${truncateDataUrl(tabSnapshot.url)}`);
+  lines.push(`- Page URL: ${truncateDataUrls(tabSnapshot.url)}`);
   lines.push(`- Page Title: ${tabSnapshot.title}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
@@ -269,7 +269,7 @@ function renderTabsMarkdown(tabs: Tab[], force: boolean = false): string[] {
   for (let i = 0; i < tabs.length; i++) {
     const tab = tabs[i];
     const current = tab.isCurrentTab() ? ' (current)' : '';
-    lines.push(`- ${i}:${current} [${tab.lastTitle()}] (${truncateDataUrl(tab.page.url())})`);
+    lines.push(`- ${i}:${current} [${tab.lastTitle()}] (${truncateDataUrls(tab.page.url())})`);
   }
   lines.push('');
   return lines;

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,6 +19,7 @@ import { pathToFileURL } from 'node:url';
 import debug from 'debug';
 
 import { renderModalStates } from './tab.js';
+import { truncateDataUrl, truncateDataUrls } from './utils/dataUrl.js';
 
 import type { Tab, TabSnapshot } from './tab.js';
 import type { CallToolResult, ResourceLink } from '@modelcontextprotocol/sdk/types.js';
@@ -226,7 +227,7 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
   if (tabSnapshot.consoleMessages.length) {
     lines.push(`### New console messages`);
     for (const message of tabSnapshot.consoleMessages)
-      lines.push(`- ${trim(message.toString(), 100)}`);
+      lines.push(`- ${trim(truncateDataUrls(message.toString()), 100)}`);
     lines.push('');
   }
 
@@ -242,11 +243,11 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
   }
 
   lines.push(`### Page state`);
-  lines.push(`- Page URL: ${tabSnapshot.url}`);
+  lines.push(`- Page URL: ${truncateDataUrl(tabSnapshot.url)}`);
   lines.push(`- Page Title: ${tabSnapshot.title}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
-  lines.push(tabSnapshot.ariaSnapshot);
+  lines.push(truncateDataUrls(tabSnapshot.ariaSnapshot));
   lines.push('```');
 
   return lines.join('\n');
@@ -268,7 +269,7 @@ function renderTabsMarkdown(tabs: Tab[], force: boolean = false): string[] {
   for (let i = 0; i < tabs.length; i++) {
     const tab = tabs[i];
     const current = tab.isCurrentTab() ? ' (current)' : '';
-    lines.push(`- ${i}:${current} [${tab.lastTitle()}] (${tab.page.url()})`);
+    lines.push(`- ${i}:${current} [${tab.lastTitle()}] (${truncateDataUrl(tab.page.url())})`);
   }
   lines.push('');
   return lines;

--- a/src/response.ts
+++ b/src/response.ts
@@ -244,7 +244,7 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
 
   lines.push(`### Page state`);
   lines.push(`- Page URL: ${truncateDataUrls(tabSnapshot.url)}`);
-  lines.push(`- Page Title: ${tabSnapshot.title}`);
+  lines.push(`- Page Title: ${truncateDataUrls(tabSnapshot.title)}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
   lines.push(truncateDataUrls(tabSnapshot.ariaSnapshot));
@@ -269,7 +269,7 @@ function renderTabsMarkdown(tabs: Tab[], force: boolean = false): string[] {
   for (let i = 0; i < tabs.length; i++) {
     const tab = tabs[i];
     const current = tab.isCurrentTab() ? ' (current)' : '';
-    lines.push(`- ${i}:${current} [${tab.lastTitle()}] (${truncateDataUrls(tab.page.url())})`);
+    lines.push(`- ${i}:${current} [${truncateDataUrls(tab.lastTitle())}] (${truncateDataUrls(tab.page.url())})`);
   }
   lines.push('');
   return lines;

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -226,7 +226,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot = {
         url: this.page.url(),
         title,
-        ariaSnapshot: truncateDataUrls(snapshot),
+        ariaSnapshot: snapshot,
         modalStates: [],
         consoleMessages: [],
         downloads: this._downloads,

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -357,7 +357,7 @@ export function renderModalStates(context: Context, modalStates: ModalState[]): 
     result.push('- There is no modal state present');
   for (const state of modalStates) {
     const tool = context.tools.filter(tool => 'clearsModalState' in tool).find(tool => tool.clearsModalState === state.type);
-    result.push(`- [${state.description}]: can be handled by the "${tool?.schema.name}" tool`);
+    result.push(`- [${truncateDataUrls(state.description)}]: can be handled by the "${tool?.schema.name}" tool`);
   }
   return result;
 }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -19,6 +19,7 @@ import type * as playwright from 'playwright';
 import { callOnPageNoTrace, waitForCompletion } from './tools/utils.js';
 import { logUnhandledError } from './utils/log.js';
 import { ManualPromise } from './mcp/manualPromise.js';
+import { truncateDataUrls } from './utils/dataUrl.js';
 import type { ModalState } from './tools/tool.js';
 
 import type { Context } from './context.js';
@@ -225,7 +226,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot = {
         url: this.page.url(),
         title,
-        ariaSnapshot: snapshot,
+        ariaSnapshot: truncateDataUrls(snapshot),
         modalStates: [],
         consoleMessages: [],
         downloads: this._downloads,

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
+import { truncateDataUrls } from '../utils/dataUrl.js';
 
 const console = defineTabTool({
   capability: 'core',
@@ -27,7 +28,8 @@ const console = defineTabTool({
     type: 'readOnly',
   },
   handle: async (tab, params, response) => {
-    tab.consoleMessages().map(message => response.addResult(message.toString()));
+    for (const message of tab.consoleMessages())
+      response.addResult(truncateDataUrls(message.toString()));
   },
 });
 

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -16,7 +16,7 @@
 
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
-import { truncateDataUrl } from '../utils/dataUrl.js';
+import { truncateDataUrls } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
 
@@ -39,7 +39,7 @@ const requests = defineTabTool({
 
 function renderRequest(request: playwright.Request, response: playwright.Response | null) {
   const result: string[] = [];
-  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrl(request.url())}`);
+  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
   if (response)
     result.push(`=> [${response.status()}] ${response.statusText()}`);
   return result.join(' ');

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
+import { truncateDataUrl } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
 
@@ -38,7 +39,7 @@ const requests = defineTabTool({
 
 function renderRequest(request: playwright.Request, response: playwright.Response | null) {
   const result: string[] = [];
-  result.push(`[${request.method().toUpperCase()}] ${request.url()}`);
+  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrl(request.url())}`);
   if (response)
     result.push(`=> [${response.status()}] ${response.statusText()}`);
   return result.join(' ');

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -57,6 +57,7 @@ type DataUrlMatch = {
   payloadStart: number;
   isBase64: boolean;
   isEmbeddedQueryValue: boolean;
+  quote: '"' | '\'' | undefined;
 };
 
 function findDataUrlStart(text: string, offset: number): number {
@@ -100,6 +101,7 @@ function parseDataUrl(text: string, start: number): DataUrlMatch | undefined {
     payloadStart: delimiter.end,
     isBase64: decodedMetadata.toLowerCase().split(';').includes('base64'),
     isEmbeddedQueryValue: start > 0 && text[start - 1] === '=',
+    quote: dataUrlQuoteAt(text, start),
   };
 }
 
@@ -147,15 +149,22 @@ function findDataUrlEnd(text: string, match: DataUrlMatch): number {
     const char = text[end];
     if (isLineBreak(char))
       break;
-    if (match.isEmbeddedQueryValue && char === '&' && looksLikeQueryParam(text, end + 1))
+    if (match.isEmbeddedQueryValue && char === '&' && isQueryParamBoundary(text, match, end))
       break;
     if (match.isBase64 && char === '&')
       break;
     if (match.isBase64 && isBase64PayloadTerminator(char))
       break;
+    if (!match.isBase64 && match.quote && char === match.quote && isQuotedDataUrlEnd(text, end))
+      break;
     end++;
   }
   return end;
+}
+
+function dataUrlQuoteAt(text: string, start: number): '"' | '\'' | undefined {
+  const char = start > 0 ? text[start - 1] : undefined;
+  return char === '"' || char === '\'' ? char : undefined;
 }
 
 function isLineBreak(char: string): boolean {
@@ -164,6 +173,26 @@ function isLineBreak(char: string): boolean {
 
 function isBase64PayloadTerminator(char: string): boolean {
   return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`', ':'].includes(char);
+}
+
+function isQueryParamBoundary(text: string, match: DataUrlMatch, ampersand: number): boolean {
+  if (!looksLikeQueryParam(text, ampersand + 1))
+    return false;
+  return match.isBase64 || isRawPayloadCompleteBefore(text, match.payloadStart, ampersand);
+}
+
+function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: number): boolean {
+  let position = end - 1;
+  while (position >= payloadStart && /\s/.test(text[position]))
+    position--;
+  return text[position] === '>' || (position >= 2 && startsWithIgnoreCase(text, position - 2, '%3e'));
+}
+
+function isQuotedDataUrlEnd(text: string, quote: number): boolean {
+  let position = quote + 1;
+  while (position < text.length && /[ \t]/.test(text[position]))
+    position++;
+  return position === text.length || isLineBreak(text[position]) || text[position] === '[';
 }
 
 function looksLikeQueryParam(text: string, offset: number): boolean {

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -15,14 +15,13 @@
  */
 
 const dataUrlPrefix = 'data:';
+const encodedDataUrlPrefix = 'data%3a';
 
 export function truncateDataUrl(url: string): string {
-  if (!url.startsWith(dataUrlPrefix))
+  const match = parseDataUrl(url, 0);
+  if (!match)
     return url;
-  const comma = url.indexOf(',');
-  if (comma === -1)
-    return url;
-  return `${url.slice(0, comma + 1)}...`;
+  return `${url.slice(0, match.payloadStart)}...`;
 }
 
 export function truncateDataUrls(text: string): string {
@@ -38,41 +37,121 @@ export function truncateDataUrls(text: string): string {
 
     result += text.slice(offset, start);
 
-    const comma = text.indexOf(',', start);
-    if (comma === -1) {
-      result += text.slice(start, start + dataUrlPrefix.length);
-      offset = start + dataUrlPrefix.length;
+    const match = parseDataUrl(text, start);
+    if (!match) {
+      const prefixLength = dataUrlPrefixLengthAt(text, start);
+      result += text.slice(start, start + prefixLength);
+      offset = start + prefixLength;
       continue;
     }
 
-    const isBase64 = text.slice(start, comma).toLowerCase().includes(';base64');
-    const end = findDataUrlEnd(text, comma + 1, isBase64);
-    result += `${text.slice(start, comma + 1)}...`;
+    const end = findDataUrlEnd(text, match);
+    result += `${text.slice(start, match.payloadStart)}...`;
     offset = end;
   }
 
   return result;
 }
 
+type DataUrlMatch = {
+  payloadStart: number;
+  isBase64: boolean;
+  isEmbeddedQueryValue: boolean;
+};
+
 function findDataUrlStart(text: string, offset: number): number {
-  let start = text.indexOf(dataUrlPrefix, offset);
+  const lowerText = text.toLowerCase();
+  let start = nextDataUrlPrefix(lowerText, offset);
   while (start !== -1) {
     if (start === 0 || !/[A-Za-z0-9_-]/.test(text[start - 1]))
       return start;
-    start = text.indexOf(dataUrlPrefix, start + dataUrlPrefix.length);
+    start = nextDataUrlPrefix(lowerText, start + dataUrlPrefixLengthAt(lowerText, start));
   }
   return -1;
 }
 
-function findDataUrlEnd(text: string, offset: number, isBase64: boolean): number {
-  let end = offset;
+function nextDataUrlPrefix(lowerText: string, offset: number): number {
+  const literalStart = lowerText.indexOf(dataUrlPrefix, offset);
+  const encodedStart = lowerText.indexOf(encodedDataUrlPrefix, offset);
+  if (literalStart === -1)
+    return encodedStart;
+  if (encodedStart === -1)
+    return literalStart;
+  return Math.min(literalStart, encodedStart);
+}
+
+function dataUrlPrefixLengthAt(text: string, start: number): number {
+  return startsWithIgnoreCase(text, start, encodedDataUrlPrefix) ? encodedDataUrlPrefix.length : dataUrlPrefix.length;
+}
+
+function parseDataUrl(text: string, start: number): DataUrlMatch | undefined {
+  const isEncoded = startsWithIgnoreCase(text, start, encodedDataUrlPrefix);
+  const metadataStart = start + (isEncoded ? encodedDataUrlPrefix.length : dataUrlPrefix.length);
+  const delimiter = findDataUrlDelimiter(text, metadataStart, isEncoded);
+  if (!delimiter)
+    return;
+
+  const metadata = text.slice(metadataStart, delimiter.start);
+  if (!isValidDataUrlMetadata(metadata, isEncoded))
+    return;
+
+  const decodedMetadata = decodeDataUrlMetadata(metadata, isEncoded);
+  return {
+    payloadStart: delimiter.end,
+    isBase64: decodedMetadata.toLowerCase().split(';').includes('base64'),
+    isEmbeddedQueryValue: start > 0 && text[start - 1] === '=',
+  };
+}
+
+function findDataUrlDelimiter(text: string, offset: number, isEncoded: boolean): { start: number; end: number } | undefined {
+  let position = offset;
+  while (position < text.length) {
+    const char = text[position];
+    if (isLineBreak(char))
+      return;
+    if (char === ',')
+      return { start: position, end: position + 1 };
+    if (isEncoded && startsWithEncodedComma(text, position))
+      return { start: position, end: position + 3 };
+    position++;
+  }
+}
+
+function isValidDataUrlMetadata(metadata: string, isEncoded: boolean): boolean {
+  if (!metadata)
+    return true;
+  const decodedMetadata = decodeDataUrlMetadata(metadata, isEncoded);
+  if (!decodedMetadata || /[\s"'<>()[\]{}]/.test(decodedMetadata))
+    return false;
+  if (decodedMetadata.startsWith(';'))
+    return true;
+
+  const mediaTypeEnd = decodedMetadata.indexOf(';');
+  const mediaType = mediaTypeEnd === -1 ? decodedMetadata : decodedMetadata.slice(0, mediaTypeEnd);
+  return /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+$/.test(mediaType);
+}
+
+function decodeDataUrlMetadata(metadata: string, isEncoded: boolean): string {
+  if (!isEncoded)
+    return metadata;
+  try {
+    return decodeURIComponent(metadata);
+  } catch {
+    return '';
+  }
+}
+
+function findDataUrlEnd(text: string, match: DataUrlMatch): number {
+  let end = match.payloadStart;
   while (end < text.length) {
     const char = text[end];
     if (isLineBreak(char))
       break;
-    if (isBase64 && char === '&')
+    if (match.isEmbeddedQueryValue && char === '&' && looksLikeQueryParam(text, end + 1))
       break;
-    if (isBase64 && isBase64PayloadTerminator(char))
+    if (match.isBase64 && char === '&')
+      break;
+    if (match.isBase64 && isBase64PayloadTerminator(char))
       break;
     end++;
   }
@@ -84,5 +163,26 @@ function isLineBreak(char: string): boolean {
 }
 
 function isBase64PayloadTerminator(char: string): boolean {
-  return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`'].includes(char);
+  return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`', ':'].includes(char);
+}
+
+function looksLikeQueryParam(text: string, offset: number): boolean {
+  if (offset >= text.length)
+    return false;
+  for (let position = offset; position < text.length; position++) {
+    const char = text[position];
+    if (char === '=')
+      return position > offset;
+    if (isLineBreak(char) || /\s/.test(char) || ['&', '#', '"', '\'', '<', '>', ')', '}', '`'].includes(char))
+      return false;
+  }
+  return false;
+}
+
+function startsWithEncodedComma(text: string, position: number): boolean {
+  return startsWithIgnoreCase(text, position, '%2c');
+}
+
+function startsWithIgnoreCase(text: string, position: number, value: string): boolean {
+  return text.slice(position, position + value.length).toLowerCase() === value;
 }

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -16,12 +16,13 @@
 
 const dataUrlPrefix = 'data:';
 const encodedDataUrlPrefix = 'data%3a';
+const maxDataUrlMetadataLength = 120;
 
 export function truncateDataUrl(url: string): string {
   const match = parseDataUrl(url, 0);
   if (!match)
     return url;
-  return `${url.slice(0, match.payloadStart)}...`;
+  return `${match.displayPrefix}...`;
 }
 
 export function truncateDataUrls(text: string): string {
@@ -46,7 +47,7 @@ export function truncateDataUrls(text: string): string {
     }
 
     const end = findDataUrlEnd(text, match);
-    result += `${text.slice(start, match.payloadStart)}...`;
+    result += `${match.displayPrefix}...`;
     offset = end;
   }
 
@@ -55,6 +56,7 @@ export function truncateDataUrls(text: string): string {
 
 type DataUrlMatch = {
   payloadStart: number;
+  displayPrefix: string;
   isBase64: boolean;
   isEmbeddedQueryValue: boolean;
   quote: '"' | '\'' | undefined;
@@ -88,7 +90,7 @@ function dataUrlPrefixLengthAt(text: string, start: number): number {
 function parseDataUrl(text: string, start: number): DataUrlMatch | undefined {
   const isEncoded = startsWithIgnoreCase(text, start, encodedDataUrlPrefix);
   const metadataStart = start + (isEncoded ? encodedDataUrlPrefix.length : dataUrlPrefix.length);
-  const delimiter = findDataUrlDelimiter(text, metadataStart, isEncoded);
+  const delimiter = findDataUrlDelimiter(text, metadataStart);
   if (!delimiter)
     return;
 
@@ -99,13 +101,14 @@ function parseDataUrl(text: string, start: number): DataUrlMatch | undefined {
   const decodedMetadata = decodeDataUrlMetadata(metadata, isEncoded);
   return {
     payloadStart: delimiter.end,
+    displayPrefix: dataUrlDisplayPrefix(text, start, metadata, decodedMetadata, delimiter, isEncoded),
     isBase64: decodedMetadata.toLowerCase().split(';').includes('base64'),
     isEmbeddedQueryValue: start > 0 && text[start - 1] === '=',
     quote: dataUrlQuoteAt(text, start),
   };
 }
 
-function findDataUrlDelimiter(text: string, offset: number, isEncoded: boolean): { start: number; end: number } | undefined {
+function findDataUrlDelimiter(text: string, offset: number): { start: number; end: number } | undefined {
   let position = offset;
   while (position < text.length) {
     const char = text[position];
@@ -113,10 +116,30 @@ function findDataUrlDelimiter(text: string, offset: number, isEncoded: boolean):
       return;
     if (char === ',')
       return { start: position, end: position + 1 };
-    if (isEncoded && startsWithEncodedComma(text, position))
+    if (startsWithEncodedComma(text, position))
       return { start: position, end: position + 3 };
     position++;
   }
+}
+
+function dataUrlDisplayPrefix(text: string, start: number, metadata: string, decodedMetadata: string, delimiter: { start: number; end: number }, isEncoded: boolean): string {
+  if (metadata.length <= maxDataUrlMetadataLength)
+    return text.slice(start, delimiter.end);
+
+  const compactMetadata = compactDataUrlMetadata(decodedMetadata);
+  const delimiterText = text.slice(delimiter.start, delimiter.end);
+  return `${text.slice(start, start + dataUrlPrefixLengthAt(text, start))}${encodeDataUrlMetadata(compactMetadata, isEncoded)}${delimiterText}`;
+}
+
+function compactDataUrlMetadata(decodedMetadata: string): string {
+  const parts = decodedMetadata.split(';');
+  const mediaType = parts[0]?.includes('/') ? parts[0] : '';
+  const base64 = parts.some(part => part.toLowerCase() === 'base64') ? ';base64' : '';
+  return `${mediaType}${base64}`;
+}
+
+function encodeDataUrlMetadata(metadata: string, isEncoded: boolean): string {
+  return isEncoded ? encodeURIComponent(metadata) : metadata;
 }
 
 function isValidDataUrlMetadata(metadata: string, isEncoded: boolean): boolean {
@@ -157,6 +180,8 @@ function findDataUrlEnd(text: string, match: DataUrlMatch): number {
       break;
     if (!match.isBase64 && match.quote && char === match.quote && isQuotedDataUrlEnd(text, end))
       break;
+    if (!match.isBase64 && !match.quote && isRawPayloadSuffixBoundary(text, match, end))
+      break;
     end++;
   }
   return end;
@@ -186,6 +211,11 @@ function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: num
   while (position >= payloadStart && /\s/.test(text[position]))
     position--;
   return text[position] === '>' || (position >= 2 && startsWithIgnoreCase(text, position - 2, '%3e'));
+}
+
+function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position: number): boolean {
+  const char = text[position];
+  return (/\s/.test(char) || char === ':') && isRawPayloadCompleteBefore(text, match.payloadStart, position);
 }
 
 function isQuotedDataUrlEnd(text: string, quote: number): boolean {

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -69,7 +69,7 @@ type DataUrlMatch = {
 function findDataUrlStart(text: string, lowerText: string, offset: number): number {
   let start = nextDataUrlPrefix(lowerText, offset);
   while (start !== -1) {
-    if (start === 0 || !/[A-Za-z0-9_-]/.test(text[start - 1]))
+    if (isDataUrlStartBoundary(text, start))
       return start;
     start = nextDataUrlPrefix(lowerText, start + dataUrlPrefixLengthAt(lowerText, start));
   }
@@ -150,7 +150,7 @@ function isValidDataUrlMetadata(metadata: string, isEncoded: boolean): boolean {
   if (!metadata)
     return true;
   const decodedMetadata = decodeDataUrlMetadata(metadata, isEncoded);
-  if (!decodedMetadata || /[\s"'<>()[\]{}]/.test(decodedMetadata))
+  if (!decodedMetadata || /[\r\n]/.test(decodedMetadata) || /[\s"'<>()[\]{}]/.test(metadata))
     return false;
   if (decodedMetadata.startsWith(';'))
     return true;
@@ -179,6 +179,8 @@ function findDataUrlEnd(text: string, match: DataUrlMatch): number {
     if (match.isEmbeddedQueryValue && char === '&' && isQueryParamBoundary(text, match, end))
       break;
     if (match.isBase64 && char === '&')
+      break;
+    if (match.isBase64 && isEncodedPayloadTerminator(text, end))
       break;
     if (match.isBase64 && isBase64PayloadTerminator(char))
       break;
@@ -214,13 +216,17 @@ function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: num
   let position = end - 1;
   while (position >= payloadStart && /\s/.test(text[position]))
     position--;
-  return text[position] === '>' || (position >= 2 && startsWithIgnoreCase(text, position - 2, '%3e'));
+  return text[position] === '>' || (position >= 3 && startsWithIgnoreCase(text, position - 3, '%3e'));
 }
 
 function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position: number): boolean {
   const char = text[position];
   if (/\s/.test(char))
     return !isRawMarkupPayload(text, match.payloadStart) || isRawPayloadCompleteBefore(text, match.payloadStart, position);
+  if (isRawPayloadWrapperBoundary(text, match, position))
+    return true;
+  if (isEncodedPayloadTerminator(text, position))
+    return isRawPayloadCompleteBefore(text, match.payloadStart, position);
   if (char !== ':')
     return false;
   if (isRawMarkupPayload(text, match.payloadStart) && !isRawPayloadCompleteBefore(text, match.payloadStart, position))
@@ -237,7 +243,12 @@ function isRawMarkupPayload(text: string, payloadStart: number): boolean {
 }
 
 function looksLikeSourceLocationSuffix(text: string, colon: number): boolean {
-  return /\d/.test(text[colon + 1] || '');
+  let position = colon + 1;
+  if (!/\d/.test(text[position] || ''))
+    return false;
+  while (position < text.length && /\d/.test(text[position]))
+    position++;
+  return position === text.length || isLineBreak(text[position]) || /\s/.test(text[position]);
 }
 
 function looksLikeQueryParam(text: string, offset: number): boolean {
@@ -259,6 +270,35 @@ function startsWithEncodedComma(text: string, position: number): boolean {
 
 function containsPercentEncoding(text: string): boolean {
   return /%[0-9a-f]{2}/i.test(text);
+}
+
+function isDataUrlStartBoundary(text: string, start: number): boolean {
+  if (start === 0)
+    return true;
+  if (!/[A-Za-z0-9_-]/.test(text[start - 1]))
+    return true;
+
+  const encodedChar = percentEncodedCharBefore(text, start);
+  return !!encodedChar && !/[A-Za-z0-9_-]/.test(encodedChar);
+}
+
+function isRawPayloadWrapperBoundary(text: string, match: DataUrlMatch, position: number): boolean {
+  return [')', ']', '}'].includes(text[position]) && isRawPayloadCompleteBefore(text, match.payloadStart, position);
+}
+
+function isEncodedPayloadTerminator(text: string, position: number): boolean {
+  const encodedChar = percentEncodedCharAt(text, position);
+  return !!encodedChar && ['"', '\'', ')', ']', '}', '`'].includes(encodedChar);
+}
+
+function percentEncodedCharBefore(text: string, position: number): string | undefined {
+  return position >= 3 ? percentEncodedCharAt(text, position - 3) : undefined;
+}
+
+function percentEncodedCharAt(text: string, position: number): string | undefined {
+  if (position < 0 || text[position] !== '%' || !/^[0-9a-f]{2}$/i.test(text.slice(position + 1, position + 3)))
+    return;
+  return String.fromCharCode(Number.parseInt(text.slice(position + 1, position + 3), 16));
 }
 
 function startsWithIgnoreCase(text: string, position: number, value: string): boolean {

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const dataUrlPrefix = 'data:';
+
+export function truncateDataUrl(url: string): string {
+  if (!url.startsWith(dataUrlPrefix))
+    return url;
+  const comma = url.indexOf(',');
+  if (comma === -1)
+    return url;
+  return `${url.slice(0, comma + 1)}...`;
+}
+
+export function truncateDataUrls(text: string): string {
+  let result = '';
+  let offset = 0;
+
+  while (offset < text.length) {
+    const start = findDataUrlStart(text, offset);
+    if (start === -1) {
+      result += text.slice(offset);
+      break;
+    }
+
+    result += text.slice(offset, start);
+
+    let end = start;
+    while (end < text.length && !isDataUrlTerminator(text[end]))
+      end++;
+
+    result += truncateDataUrl(text.slice(start, end));
+    offset = end;
+  }
+
+  return result;
+}
+
+function findDataUrlStart(text: string, offset: number): number {
+  let start = text.indexOf(dataUrlPrefix, offset);
+  while (start !== -1) {
+    if (start === 0 || !/[A-Za-z0-9_-]/.test(text[start - 1]))
+      return start;
+    start = text.indexOf(dataUrlPrefix, start + dataUrlPrefix.length);
+  }
+  return -1;
+}
+
+function isDataUrlTerminator(char: string): boolean {
+  return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`'].includes(char);
+}

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -38,11 +38,16 @@ export function truncateDataUrls(text: string): string {
 
     result += text.slice(offset, start);
 
-    let end = start;
-    while (end < text.length && !isDataUrlTerminator(text[end]))
-      end++;
+    const comma = text.indexOf(',', start);
+    if (comma === -1) {
+      result += text.slice(start, start + dataUrlPrefix.length);
+      offset = start + dataUrlPrefix.length;
+      continue;
+    }
 
-    result += truncateDataUrl(text.slice(start, end));
+    const isBase64 = text.slice(start, comma).toLowerCase().includes(';base64');
+    const end = findDataUrlEnd(text, comma + 1, isBase64);
+    result += `${text.slice(start, comma + 1)}...`;
     offset = end;
   }
 
@@ -59,6 +64,25 @@ function findDataUrlStart(text: string, offset: number): number {
   return -1;
 }
 
-function isDataUrlTerminator(char: string): boolean {
+function findDataUrlEnd(text: string, offset: number, isBase64: boolean): number {
+  let end = offset;
+  while (end < text.length) {
+    const char = text[end];
+    if (isLineBreak(char))
+      break;
+    if (isBase64 && char === '&')
+      break;
+    if (isBase64 && isBase64PayloadTerminator(char))
+      break;
+    end++;
+  }
+  return end;
+}
+
+function isLineBreak(char: string): boolean {
+  return char === '\n' || char === '\r';
+}
+
+function isBase64PayloadTerminator(char: string): boolean {
   return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`'].includes(char);
 }

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -118,6 +118,8 @@ function findDataUrlDelimiter(text: string, offset: number): { start: number; en
     const char = text[position];
     if (isLineBreak(char))
       return;
+    if (char === '&' && looksLikeQueryParam(text, position + 1))
+      return;
     if (char === ',')
       return { start: position, end: position + 1 };
     if (startsWithEncodedComma(text, position))
@@ -216,7 +218,7 @@ function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: num
   let position = end - 1;
   while (position >= payloadStart && /\s/.test(text[position]))
     position--;
-  return text[position] === '>' || (position >= 3 && startsWithIgnoreCase(text, position - 3, '%3e'));
+  return text[position] === '>' || (position >= payloadStart + 2 && startsWithIgnoreCase(text, position - 2, '%3e'));
 }
 
 function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position: number): boolean {
@@ -226,7 +228,7 @@ function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position:
   if (isRawPayloadWrapperBoundary(text, match, position))
     return true;
   if (isEncodedPayloadTerminator(text, position))
-    return isRawPayloadCompleteBefore(text, match.payloadStart, position);
+    return isRawPayloadCompleteBefore(text, match.payloadStart, position) || isRawPayloadBoundarySuffix(text, position + 3);
   if (char !== ':')
     return false;
   if (isRawMarkupPayload(text, match.payloadStart) && !isRawPayloadCompleteBefore(text, match.payloadStart, position))
@@ -283,7 +285,14 @@ function isDataUrlStartBoundary(text: string, start: number): boolean {
 }
 
 function isRawPayloadWrapperBoundary(text: string, match: DataUrlMatch, position: number): boolean {
-  return [')', ']', '}'].includes(text[position]) && isRawPayloadCompleteBefore(text, match.payloadStart, position);
+  return [')', ']', '}'].includes(text[position]) && (isRawPayloadCompleteBefore(text, match.payloadStart, position) || isRawPayloadBoundarySuffix(text, position + 1));
+}
+
+function isRawPayloadBoundarySuffix(text: string, offset: number): boolean {
+  if (offset >= text.length)
+    return true;
+  const char = text[offset];
+  return isLineBreak(char) || /\s/.test(char) || ['"', '\'', ')', ']', '}', '`'].includes(char) || (char === '&' && looksLikeQueryParam(text, offset + 1));
 }
 
 function isEncodedPayloadTerminator(text: string, position: number): boolean {

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -19,6 +19,9 @@ const encodedDataUrlPrefix = 'data%3a';
 const maxDataUrlMetadataLength = 120;
 
 export function truncateDataUrl(url: string): string {
+  if (!startsWithIgnoreCase(url, 0, dataUrlPrefix) && !startsWithIgnoreCase(url, 0, encodedDataUrlPrefix))
+    return url;
+
   const match = parseDataUrl(url, 0);
   if (!match)
     return url;
@@ -28,9 +31,10 @@ export function truncateDataUrl(url: string): string {
 export function truncateDataUrls(text: string): string {
   let result = '';
   let offset = 0;
+  const lowerText = text.toLowerCase();
 
   while (offset < text.length) {
-    const start = findDataUrlStart(text, offset);
+    const start = findDataUrlStart(text, lowerText, offset);
     if (start === -1) {
       result += text.slice(offset);
       break;
@@ -62,8 +66,7 @@ type DataUrlMatch = {
   quote: '"' | '\'' | undefined;
 };
 
-function findDataUrlStart(text: string, offset: number): number {
-  const lowerText = text.toLowerCase();
+function findDataUrlStart(text: string, lowerText: string, offset: number): number {
   let start = nextDataUrlPrefix(lowerText, offset);
   while (start !== -1) {
     if (start === 0 || !/[A-Za-z0-9_-]/.test(text[start - 1]))
@@ -88,20 +91,21 @@ function dataUrlPrefixLengthAt(text: string, start: number): number {
 }
 
 function parseDataUrl(text: string, start: number): DataUrlMatch | undefined {
-  const isEncoded = startsWithIgnoreCase(text, start, encodedDataUrlPrefix);
-  const metadataStart = start + (isEncoded ? encodedDataUrlPrefix.length : dataUrlPrefix.length);
+  const isEncodedPrefix = startsWithIgnoreCase(text, start, encodedDataUrlPrefix);
+  const metadataStart = start + (isEncodedPrefix ? encodedDataUrlPrefix.length : dataUrlPrefix.length);
   const delimiter = findDataUrlDelimiter(text, metadataStart);
   if (!delimiter)
     return;
 
   const metadata = text.slice(metadataStart, delimiter.start);
-  if (!isValidDataUrlMetadata(metadata, isEncoded))
+  const isEncodedMetadata = isEncodedPrefix || containsPercentEncoding(metadata);
+  if (!isValidDataUrlMetadata(metadata, isEncodedMetadata))
     return;
 
-  const decodedMetadata = decodeDataUrlMetadata(metadata, isEncoded);
+  const decodedMetadata = decodeDataUrlMetadata(metadata, isEncodedMetadata);
   return {
     payloadStart: delimiter.end,
-    displayPrefix: dataUrlDisplayPrefix(text, start, metadata, decodedMetadata, delimiter, isEncoded),
+    displayPrefix: dataUrlDisplayPrefix(text, start, metadata, decodedMetadata, delimiter, isEncodedMetadata),
     isBase64: decodedMetadata.toLowerCase().split(';').includes('base64'),
     isEmbeddedQueryValue: start > 0 && text[start - 1] === '=',
     quote: dataUrlQuoteAt(text, start),
@@ -178,7 +182,7 @@ function findDataUrlEnd(text: string, match: DataUrlMatch): number {
       break;
     if (match.isBase64 && isBase64PayloadTerminator(char))
       break;
-    if (!match.isBase64 && match.quote && char === match.quote && isQuotedDataUrlEnd(text, end))
+    if (!match.isBase64 && match.quote && char === match.quote && isQuotedDataUrlEnd(text, match, end))
       break;
     if (!match.isBase64 && !match.quote && isRawPayloadSuffixBoundary(text, match, end))
       break;
@@ -215,14 +219,25 @@ function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: num
 
 function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position: number): boolean {
   const char = text[position];
-  return (/\s/.test(char) || char === ':') && isRawPayloadCompleteBefore(text, match.payloadStart, position);
+  if (/\s/.test(char))
+    return !isRawMarkupPayload(text, match.payloadStart) || isRawPayloadCompleteBefore(text, match.payloadStart, position);
+  if (char !== ':')
+    return false;
+  if (isRawMarkupPayload(text, match.payloadStart) && !isRawPayloadCompleteBefore(text, match.payloadStart, position))
+    return false;
+  return looksLikeSourceLocationSuffix(text, position);
 }
 
-function isQuotedDataUrlEnd(text: string, quote: number): boolean {
-  let position = quote + 1;
-  while (position < text.length && /[ \t]/.test(text[position]))
-    position++;
-  return position === text.length || isLineBreak(text[position]) || text[position] === '[';
+function isQuotedDataUrlEnd(text: string, match: DataUrlMatch, quote: number): boolean {
+  return !isRawMarkupPayload(text, match.payloadStart) || isRawPayloadCompleteBefore(text, match.payloadStart, quote);
+}
+
+function isRawMarkupPayload(text: string, payloadStart: number): boolean {
+  return text[payloadStart] === '<' || startsWithIgnoreCase(text, payloadStart, '%3c');
+}
+
+function looksLikeSourceLocationSuffix(text: string, colon: number): boolean {
+  return /\d/.test(text[colon + 1] || '');
 }
 
 function looksLikeQueryParam(text: string, offset: number): boolean {
@@ -240,6 +255,10 @@ function looksLikeQueryParam(text: string, offset: number): boolean {
 
 function startsWithEncodedComma(text: string, position: number): boolean {
   return startsWithIgnoreCase(text, position, '%2c');
+}
+
+function containsPercentEncoding(text: string): boolean {
+  return /%[0-9a-f]{2}/i.test(text);
 }
 
 function startsWithIgnoreCase(text: string, position: number, value: string): boolean {

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -158,6 +158,19 @@ describe('Response', () => {
       const serialized = response.serialize();
       expect(expectTextContent(serialized.content[0]).text).toContain('Open tabs');
     });
+
+    it('should truncate data URL payloads in tab titles', () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      mockTab.lastTitle = () => `data:text/html;base64,${payload}`;
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeTabs();
+
+      const serialized = response.serialize();
+      const text = expectTextContent(serialized.content[0]).text;
+
+      expect(text).toContain('[data:text/html;base64,...]');
+      expect(text).not.toContain(payload);
+    });
   });
 
   describe('finish', () => {
@@ -396,7 +409,7 @@ describe('Response', () => {
       mockTab.page = { url: () => embeddedUrl } as any;
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
         url: embeddedUrl,
-        title: 'Data URL Page',
+        title: dataUrl,
         ariaSnapshot: `- link "Example" [ref=e1]:\n  - /url: ${dataUrl}`,
         modalStates: [],
         consoleMessages: [
@@ -412,6 +425,7 @@ describe('Response', () => {
       const textContent = expectTextContent(serialized.content[0]);
 
       expect(textContent.text).toContain('data:text/html;base64,...');
+      expect(textContent.text).toContain('- Page Title: data:text/html;base64,...');
       expect(textContent.text).toContain('https://example.com/upload?src=data:text/html;base64,...&id=123');
       expect(textContent.text).not.toContain(payload);
     });

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -430,6 +430,36 @@ describe('Response', () => {
       expect(textContent.text).not.toContain(payload);
     });
 
+    it('should truncate data URL payloads in modal snapshot output', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const dataUrl = `data:text/html;base64,${payload}`;
+      mockContext.tools = [{
+        schema: { name: 'browser_handle_dialog' },
+        clearsModalState: 'dialog',
+      }] as any;
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com',
+        title: 'Example Page',
+        ariaSnapshot: '',
+        modalStates: [{
+          type: 'dialog',
+          description: `Alert ${dataUrl}`,
+          dialog: {} as any,
+        }],
+        consoleMessages: [],
+        downloads: [],
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+      await response.finish();
+      const serialized = response.serialize();
+      const textContent = expectTextContent(serialized.content[0]);
+
+      expect(textContent.text).toContain('Alert data:text/html;base64,...');
+      expect(textContent.text).not.toContain(payload);
+    });
+
     it('should include console messages in snapshot', async () => {
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
         url: 'https://example.com',

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -392,9 +392,10 @@ describe('Response', () => {
     it('should truncate data URL payloads in rendered snapshot output', async () => {
       const payload = Buffer.from('<p>hello</p>').toString('base64');
       const dataUrl = `data:text/html;base64,${payload}`;
-      mockTab.page = { url: () => dataUrl } as any;
+      const embeddedUrl = `https://example.com/upload?src=${dataUrl}&id=123`;
+      mockTab.page = { url: () => embeddedUrl } as any;
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
-        url: dataUrl,
+        url: embeddedUrl,
         title: 'Data URL Page',
         ariaSnapshot: `- link "Example" [ref=e1]:\n  - /url: ${dataUrl}`,
         modalStates: [],
@@ -411,6 +412,7 @@ describe('Response', () => {
       const textContent = expectTextContent(serialized.content[0]);
 
       expect(textContent.text).toContain('data:text/html;base64,...');
+      expect(textContent.text).toContain('https://example.com/upload?src=data:text/html;base64,...&id=123');
       expect(textContent.text).not.toContain(payload);
     });
 

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -389,6 +389,31 @@ describe('Response', () => {
       expect(textContent.text).toContain('Example Page');
     });
 
+    it('should truncate data URL payloads in rendered snapshot output', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const dataUrl = `data:text/html;base64,${payload}`;
+      mockTab.page = { url: () => dataUrl } as any;
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: dataUrl,
+        title: 'Data URL Page',
+        ariaSnapshot: `- link "Example" [ref=e1]:\n  - /url: ${dataUrl}`,
+        modalStates: [],
+        consoleMessages: [
+          { type: 'log', text: 'Test message', toString: () => `[LOG] Test @ ${dataUrl}:1` }
+        ],
+        downloads: [],
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+      await response.finish();
+      const serialized = response.serialize();
+      const textContent = expectTextContent(serialized.content[0]);
+
+      expect(textContent.text).toContain('data:text/html;base64,...');
+      expect(textContent.text).not.toContain(payload);
+    });
+
     it('should include console messages in snapshot', async () => {
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
         url: 'https://example.com',

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -246,6 +246,17 @@ describe('Tab', () => {
       expect(snapshot.ariaSnapshot).toContain('Page snapshot unavailable');
       expect(snapshot.ariaSnapshot).toContain('capturing page accessibility snapshot');
     });
+
+    it('truncates data URL payloads in captured accessibility snapshots', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "Example" [ref=e1]:\n  - /url: data:text/html;base64,${payload}`);
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshot = await tab.captureSnapshot();
+
+      expect(snapshot.ariaSnapshot).toContain('data:text/html;base64,...');
+      expect(snapshot.ariaSnapshot).not.toContain(payload);
+    });
   });
 
   describe('refLocator', () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -247,16 +247,14 @@ describe('Tab', () => {
       expect(snapshot.ariaSnapshot).toContain('capturing page accessibility snapshot');
     });
 
-    it('truncates data URL payloads in captured accessibility snapshots', async () => {
+    it('keeps data URL payloads in captured accessibility snapshots for session logs', async () => {
       const payload = '<svg viewBox="0 0 10 10"><text>Hello</text></svg>';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "Example" [ref=e1]:\n  - /url: data:image/svg+xml,${payload}`);
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
       const snapshot = await tab.captureSnapshot();
 
-      expect(snapshot.ariaSnapshot).toContain('data:image/svg+xml,...');
-      expect(snapshot.ariaSnapshot).not.toContain(payload);
-      expect(snapshot.ariaSnapshot).not.toContain('<svg');
+      expect(snapshot.ariaSnapshot).toContain(`data:image/svg+xml,${payload}`);
     });
   });
 

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -248,14 +248,15 @@ describe('Tab', () => {
     });
 
     it('truncates data URL payloads in captured accessibility snapshots', async () => {
-      const payload = Buffer.from('<p>hello</p>').toString('base64');
-      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "Example" [ref=e1]:\n  - /url: data:text/html;base64,${payload}`);
+      const payload = '<svg viewBox="0 0 10 10"><text>Hello</text></svg>';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "Example" [ref=e1]:\n  - /url: data:image/svg+xml,${payload}`);
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
       const snapshot = await tab.captureSnapshot();
 
-      expect(snapshot.ariaSnapshot).toContain('data:text/html;base64,...');
+      expect(snapshot.ariaSnapshot).toContain('data:image/svg+xml,...');
       expect(snapshot.ariaSnapshot).not.toContain(payload);
+      expect(snapshot.ariaSnapshot).not.toContain('<svg');
     });
   });
 

--- a/tests/tools-console.test.ts
+++ b/tests/tools-console.test.ts
@@ -93,6 +93,20 @@ describe('Console Tools', () => {
 
       expect(response.result()).toBe('');
     });
+
+    it('should truncate data URL payloads in console messages', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      mockTab.consoleMessages = vi.fn().mockReturnValue([{
+        type: 'log',
+        text: 'Data URL',
+        toString: () => `[LOG] data:text/html;base64,${payload}`,
+      }]);
+
+      await consoleTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('data:text/html;base64,...');
+      expect(response.result()).not.toContain(payload);
+    });
   });
 
   describe('Tool capabilities', () => {

--- a/tests/tools-console.test.ts
+++ b/tests/tools-console.test.ts
@@ -107,6 +107,20 @@ describe('Console Tools', () => {
       expect(response.result()).toContain('data:text/html;base64,...');
       expect(response.result()).not.toContain(payload);
     });
+
+    it('should preserve console suffix text after raw data URL payloads', async () => {
+      const payload = '<svg></svg>';
+      mockTab.consoleMessages = vi.fn().mockReturnValue([{
+        type: 'log',
+        text: 'Data URL',
+        toString: () => `[LOG] data:image/svg+xml,${payload} done @ app.js:7`,
+      }]);
+
+      await consoleTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('data:image/svg+xml,... done @ app.js:7');
+      expect(response.result()).not.toContain(payload);
+    });
   });
 
   describe('Tool capabilities', () => {

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -115,6 +115,18 @@ describe('Network Tools', () => {
       expect(response.result()).toContain('data:text/html;base64,...');
       expect(response.result()).not.toContain(payload);
     });
+
+    it('should truncate embedded data URL payloads in request URLs', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const mockRequests = new Map();
+      mockRequests.set({ url: () => `https://api.example/upload?src=data:text/html;base64,${payload}&id=123`, method: () => 'POST' }, null);
+      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('https://api.example/upload?src=data:text/html;base64,...&id=123');
+      expect(response.result()).not.toContain(payload);
+    });
   });
 
   describe('Tool capabilities', () => {

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -128,6 +128,18 @@ describe('Network Tools', () => {
       expect(response.result()).not.toContain(payload);
     });
 
+    it('should truncate data URLs with literal prefixes and encoded commas in request URLs', async () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const mockRequests = new Map();
+      mockRequests.set({ url: () => `https://api.example/upload?src=data:text/html;base64%2C${payload}&id=123`, method: () => 'POST' }, null);
+      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('https://api.example/upload?src=data:text/html;base64%2C...&id=123');
+      expect(response.result()).not.toContain(payload);
+    });
+
     it('should preserve query params after raw embedded data URL payloads', async () => {
       const payload = '<svg><text>Hello</text></svg>';
       const mockRequests = new Map();

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -127,6 +127,30 @@ describe('Network Tools', () => {
       expect(response.result()).toContain('https://api.example/upload?src=data:text/html;base64,...&id=123');
       expect(response.result()).not.toContain(payload);
     });
+
+    it('should preserve query params after raw embedded data URL payloads', async () => {
+      const payload = '<svg><text>Hello</text></svg>';
+      const mockRequests = new Map();
+      mockRequests.set({ url: () => `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`, method: () => 'POST' }, null);
+      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('https://api.example/upload?src=data:image/svg+xml,...&id=123');
+      expect(response.result()).not.toContain(payload);
+    });
+
+    it('should truncate percent-encoded data URL payloads in request URLs', async () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const mockRequests = new Map();
+      mockRequests.set({ url: () => `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`, method: () => 'POST' }, null);
+      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
+      expect(response.result()).not.toContain(payload);
+    });
   });
 
   describe('Tool capabilities', () => {

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -103,6 +103,18 @@ describe('Network Tools', () => {
 
       expect(response.result()).toBe('');
     });
+
+    it('should truncate data URL payloads', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const mockRequests = new Map();
+      mockRequests.set({ url: () => `data:text/html;base64,${payload}`, method: () => 'GET' }, null);
+      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toContain('data:text/html;base64,...');
+      expect(response.result()).not.toContain(payload);
+    });
   });
 
   describe('Tool capabilities', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -146,6 +146,16 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
     });
 
+    it('should truncate data URLs inside encoded wrappers', () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const text = `https://api.example/upload?src=%22data%3Atext%2Fhtml%3Bbase64%2C${payload}%22&id=123`;
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toBe('https://api.example/upload?src=%22data%3Atext%2Fhtml%3Bbase64%2C...%22&id=123');
+      expect(result).not.toContain(payload);
+    });
+
     it('should preserve suffix text after unquoted raw data URLs', () => {
       const text = '[LOG] data:image/svg+xml,<svg></svg> done @ app.js:7';
 
@@ -180,6 +190,23 @@ describe('Utils', () => {
       expect(result).not.toContain('</text>');
     });
 
+    it('should keep source-like colons inside raw text payloads redacted', () => {
+      const text = '[LOG] data:text/plain,secret:1<large-tail> done @ app.js:7';
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toBe('[LOG] data:text/plain,... done @ app.js:7');
+      expect(result).not.toContain('secret');
+      expect(result).not.toContain('large-tail');
+    });
+
+    it('should truncate data URLs with escaped spaces in metadata', () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const text = `data:text/plain;name=hello%20world;base64,${payload}`;
+
+      expect(truncateDataUrl(text)).toBe('data:text/plain;name=hello%20world;base64,...');
+    });
+
     it('should cap oversized data URL metadata before the ellipsis', () => {
       const largeParameter = 'a'.repeat(1024);
 
@@ -201,6 +228,12 @@ describe('Utils', () => {
       expect(result).toBe('- link "data:text/html,..." [ref=e1]');
       expect(result).not.toContain('&b=2');
       expect(result).not.toContain('link</a>');
+    });
+
+    it('should preserve wrappers around raw data URLs', () => {
+      const text = '- img "url(data:image/svg+xml,<svg></svg>)" [ref=e1]';
+
+      expect(truncateDataUrls(text)).toBe('- img "url(data:image/svg+xml,...)" [ref=e1]');
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -80,6 +80,11 @@ describe('Utils', () => {
       expect(truncateDataUrl('data:text/html;base64,PHAgLz4=')).toBe('data:text/html;base64,...');
     });
 
+    it('should not truncate ordinary prose that starts with data:', () => {
+      expect(truncateDataUrls('data: total, average')).toBe('data: total, average');
+      expect(truncateDataUrl('data: total, average')).toBe('data: total, average');
+    });
+
     it('should truncate raw SVG data URL payloads without leaking markup', () => {
       const payload = '<svg viewBox="0 0 10 10"><text>&Hello</text></svg>';
       const text = `- /url: data:image/svg+xml,${payload}\n- button "Next"`;
@@ -97,6 +102,20 @@ describe('Utils', () => {
       const text = `https://api.example/upload?src=data:text/html;base64,${payload}&id=123`;
 
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text/html;base64,...&id=123');
+    });
+
+    it('should preserve query params after raw data URLs embedded in query strings', () => {
+      const payload = '<svg><text>Hello</text></svg>';
+      const text = `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`;
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:image/svg+xml,...&id=123');
+    });
+
+    it('should truncate percent-encoded data URLs embedded in query strings', () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const text = `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`;
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -85,6 +85,10 @@ describe('Utils', () => {
       expect(truncateDataUrl('data: total, average')).toBe('data: total, average');
     });
 
+    it('should not truncate direct strings without a data URL prefix', () => {
+      expect(truncateDataUrl('12345image/png,payload')).toBe('12345image/png,payload');
+    });
+
     it('should truncate raw SVG data URL payloads without leaking markup', () => {
       const payload = '<svg viewBox="0 0 10 10"><text>&Hello</text></svg>';
       const text = `- /url: data:image/svg+xml,${payload}\n- button "Next"`;
@@ -109,6 +113,13 @@ describe('Utils', () => {
       const text = `https://api.example/upload?src=data:text/html;base64%2C${payload}&id=123`;
 
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text/html;base64%2C...&id=123');
+    });
+
+    it('should truncate data URLs with literal prefixes and encoded metadata', () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const text = `https://api.example/upload?src=data:text%2Fhtml%3Bbase64%2C${payload}&id=123`;
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text%2Fhtml%3Bbase64%2C...&id=123');
     });
 
     it('should preserve query params after raw data URLs embedded in query strings', () => {
@@ -141,10 +152,32 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('[LOG] data:image/svg+xml,... done @ app.js:7');
     });
 
+    it('should preserve suffix text after unquoted raw text data URLs', () => {
+      const text = '[LOG] data:text/plain,hello done @ app.js:7';
+
+      expect(truncateDataUrls(text)).toBe('[LOG] data:text/plain,... done @ app.js:7');
+    });
+
+    it('should preserve suffix text after quoted raw data URLs', () => {
+      const text = '[LOG] "data:image/svg+xml,<svg></svg>" done @ app.js:7';
+
+      expect(truncateDataUrls(text)).toBe('[LOG] "data:image/svg+xml,..." done @ app.js:7');
+    });
+
     it('should preserve source locations after unquoted raw data URLs', () => {
       const text = '[LOG] Test @ data:image/svg+xml,<svg></svg>:1';
 
       expect(truncateDataUrls(text)).toBe('[LOG] Test @ data:image/svg+xml,...:1');
+    });
+
+    it('should keep source-like colons inside raw markup payloads redacted', () => {
+      const text = '[LOG] Test @ data:image/svg+xml,<svg><text>1:2</text></svg>:1';
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toBe('[LOG] Test @ data:image/svg+xml,...:1');
+      expect(result).not.toContain('1:2');
+      expect(result).not.toContain('</text>');
     });
 
     it('should cap oversized data URL metadata before the ellipsis', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -111,11 +111,37 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:image/svg+xml,...&id=123');
     });
 
+    it('should keep raw data URL payload query-like ampersands redacted', () => {
+      const text = 'https://api.example/upload?src=data:text/html,<a href="/?a=1&b=2">link</a>&id=123';
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toBe('https://api.example/upload?src=data:text/html,...&id=123');
+      expect(result).not.toContain('&b=2');
+      expect(result).not.toContain('link</a>');
+    });
+
     it('should truncate percent-encoded data URLs embedded in query strings', () => {
       const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
       const text = `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`;
 
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
+    });
+
+    it('should preserve snapshot refs after raw data URLs in accessible names', () => {
+      const text = '- button "data:image/svg+xml,<svg></svg>" [ref=e1]';
+
+      expect(truncateDataUrls(text)).toBe('- button "data:image/svg+xml,..." [ref=e1]');
+    });
+
+    it('should redact query-like ampersands in quoted raw data URL payloads', () => {
+      const text = '- link "data:text/html,<a href="/?a=1&b=2">link</a>" [ref=e1]';
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toBe('- link "data:text/html,..." [ref=e1]');
+      expect(result).not.toContain('&b=2');
+      expect(result).not.toContain('link</a>');
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { createGuid, createHash } from '../src/utils/guid.js';
+import { truncateDataUrl, truncateDataUrls } from '../src/utils/dataUrl.js';
 
 describe('Utils', () => {
   describe('createGuid', () => {
@@ -71,6 +72,31 @@ describe('Utils', () => {
     it('should generate 7 character hashes', () => {
       const hash = createHash('test data');
       expect(hash.length).toBe(7);
+    });
+  });
+
+  describe('data URL truncation', () => {
+    it('should truncate direct data URL payloads', () => {
+      expect(truncateDataUrl('data:text/html;base64,PHAgLz4=')).toBe('data:text/html;base64,...');
+    });
+
+    it('should truncate raw SVG data URL payloads without leaking markup', () => {
+      const payload = '<svg viewBox="0 0 10 10"><text>&Hello</text></svg>';
+      const text = `- /url: data:image/svg+xml,${payload}\n- button "Next"`;
+
+      const result = truncateDataUrls(text);
+
+      expect(result).toContain('data:image/svg+xml,...\n- button "Next"');
+      expect(result).not.toContain(payload);
+      expect(result).not.toContain('<svg');
+      expect(result).not.toContain('<text>');
+    });
+
+    it('should truncate data URLs embedded in query strings', () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const text = `https://api.example/upload?src=data:text/html;base64,${payload}&id=123`;
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text/html;base64,...&id=123');
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -122,6 +122,12 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text%2Fhtml%3Bbase64%2C...&id=123');
     });
 
+    it('should not parse data URL metadata across query boundaries', () => {
+      const text = 'https://api.example/search?type=data:text/html;base64&tags=a,b';
+
+      expect(truncateDataUrls(text)).toBe(text);
+    });
+
     it('should preserve query params after raw data URLs embedded in query strings', () => {
       const payload = '<svg><text>Hello</text></svg>';
       const text = `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`;
@@ -154,6 +160,12 @@ describe('Utils', () => {
 
       expect(result).toBe('https://api.example/upload?src=%22data%3Atext%2Fhtml%3Bbase64%2C...%22&id=123');
       expect(result).not.toContain(payload);
+    });
+
+    it('should preserve encoded wrappers around non-markup raw data URLs', () => {
+      const text = 'https://api.example/upload?src=%22data%3Atext%2Fplain%2Chello%22&id=123';
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=%22data%3Atext%2Fplain%2C...%22&id=123');
     });
 
     it('should preserve suffix text after unquoted raw data URLs', () => {
@@ -234,6 +246,18 @@ describe('Utils', () => {
       const text = '- img "url(data:image/svg+xml,<svg></svg>)" [ref=e1]';
 
       expect(truncateDataUrls(text)).toBe('- img "url(data:image/svg+xml,...)" [ref=e1]');
+    });
+
+    it('should preserve refs after encoded raw markup data URLs', () => {
+      const text = '- button "data:image/svg+xml,%3Csvg%3E%3C%2Fsvg%3E" [ref=e1]';
+
+      expect(truncateDataUrls(text)).toBe('- button "data:image/svg+xml,..." [ref=e1]');
+    });
+
+    it('should preserve wrappers around non-markup raw data URLs', () => {
+      const text = '[LOG] url(data:text/plain,hello) done';
+
+      expect(truncateDataUrls(text)).toBe('[LOG] url(data:text/plain,...) done');
     });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -104,6 +104,13 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text/html;base64,...&id=123');
     });
 
+    it('should truncate data URLs with literal prefixes and encoded commas', () => {
+      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
+      const text = `https://api.example/upload?src=data:text/html;base64%2C${payload}&id=123`;
+
+      expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data:text/html;base64%2C...&id=123');
+    });
+
     it('should preserve query params after raw data URLs embedded in query strings', () => {
       const payload = '<svg><text>Hello</text></svg>';
       const text = `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`;
@@ -126,6 +133,25 @@ describe('Utils', () => {
       const text = `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`;
 
       expect(truncateDataUrls(text)).toBe('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
+    });
+
+    it('should preserve suffix text after unquoted raw data URLs', () => {
+      const text = '[LOG] data:image/svg+xml,<svg></svg> done @ app.js:7';
+
+      expect(truncateDataUrls(text)).toBe('[LOG] data:image/svg+xml,... done @ app.js:7');
+    });
+
+    it('should preserve source locations after unquoted raw data URLs', () => {
+      const text = '[LOG] Test @ data:image/svg+xml,<svg></svg>:1';
+
+      expect(truncateDataUrls(text)).toBe('[LOG] Test @ data:image/svg+xml,...:1');
+    });
+
+    it('should cap oversized data URL metadata before the ellipsis', () => {
+      const largeParameter = 'a'.repeat(1024);
+
+      expect(truncateDataUrl(`data:text/html;name=${largeParameter},x`)).toBe('data:text/html,...');
+      expect(truncateDataUrl(`data:text/html;name=${largeParameter};base64,eA==`)).toBe('data:text/html;base64,...');
     });
 
     it('should preserve snapshot refs after raw data URLs in accessible names', () => {


### PR DESCRIPTION
## Summary
- Mirrors the upstream Playwright MCP direction in https://github.com/microsoft/playwright/pull/41450 (commit https://github.com/microsoft/playwright/commit/e964bceba849) to avoid returning full data: URL payloads in MCP output.
- Truncates data: URL request URLs in browser_network_requests and data: URLs rendered in browser_snapshot output, page URLs, tab URLs, and console-location text.
- Documents the truncated data: URL behavior for browser_snapshot and browser_network_requests.

## Why
The upstream PR notes that data: URLs can contain megabytes of base64 payload. This server exposes similar output surfaces and currently pins Playwright 1.61.0, so the local network renderer and snapshot response boundary need the same protection.

## Testing
- npm test -- tests/tools-network.test.ts tests/tab.test.ts tests/response.test.ts
- npm run lint
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic truncation for large `data:` URL payloads across snapshots, open-tab views, browser console messages, network request displays, and modal state output.
  * Ensures accessibility snapshot and captured aria snapshot text are shortened consistently.
* **Bug Fixes**
  * Prevents oversized embedded `data:` content from cluttering rendered output and improves readability.
* **Documentation**
  * README now documents the truncation behavior for large `data:` payloads.
* **Tests**
  * Extended coverage for `data:` truncation across response rendering, tab snapshots, console/network outputs, and utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->