### PR TITLE
test: convert output max size coverage to unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Create a `config.json` file with the following options:
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 - `outputDir`: Directory used for generated reports, screenshots, downloads, traces, and session logs
-- `outputMaxSize`: Maximum bytes of old evictable output artifacts to keep; oldest files are removed before each tool run, while current tool outputs, the active session log folder, and the active trace folder are preserved
+- `outputMaxSize`: Maximum bytes of old evictable output artifacts to keep; oldest files are removed before each tool run, while current tool outputs and every live session's log and trace folders are preserved
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), `--cdp-timeout`, `--output-dir`, and `--output-max-size`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Create a `config.json` file with the following options:
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 - `outputDir`: Directory used for generated reports, screenshots, downloads, traces, and session logs
-- `outputMaxSize`: Maximum bytes of evictable output artifacts to keep; oldest files are removed first and session logs are preserved
+- `outputMaxSize`: Maximum bytes of old evictable output artifacts to keep; oldest files are removed before each tool run, while current tool outputs and session log folders are preserved
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--output-dir`, and `--output-max-size`.
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,10 @@ Create a `config.json` file with the following options:
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
+- `outputDir`: Directory used for generated reports, screenshots, downloads, traces, and session logs
+- `outputMaxSize`: Maximum bytes of evictable output artifacts to keep; oldest files are removed first and session logs are preserved
 
-CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, and `--cdp-launch-startup-timeout`.
+CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--output-dir`, and `--output-max-size`.
 
 #### HTTP Heartbeat
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Create a `config.json` file with the following options:
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 - `outputDir`: Directory used for generated reports, screenshots, downloads, traces, and session logs
-- `outputMaxSize`: Maximum bytes of old evictable output artifacts to keep; oldest files are removed before each tool run, while current tool outputs and session log folders are preserved
+- `outputMaxSize`: Maximum bytes of old evictable output artifacts to keep; oldest files are removed before each tool run, while current tool outputs, the active session log folder, and the active trace folder are preserved
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), `--cdp-timeout`, `--output-dir`, and `--output-max-size`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -138,6 +138,11 @@ export type Config = {
    */
   outputDir?: string;
 
+  /**
+   * Threshold for evicting old output files, in bytes.
+   */
+  outputMaxSize?: number;
+
   network?: {
     /**
      * List of origins to allow the browser to request. Default is to allow all. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"@typescript-eslint/eslint-plugin": "^8.60.0",
 				"@typescript-eslint/parser": "^8.60.0",
 				"@typescript-eslint/utils": "^8.60.0",
-				"@typescript/native-preview": "7.0.0-dev.20260527.2",
+				"@typescript/native-preview": "7.0.0-dev.20260624.1",
 				"@vitest/coverage-v8": "^4.1.7",
 				"@vitest/ui": "^4.1.7",
 				"eslint": "^9.39.4",
@@ -1258,9 +1258,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-ogwfNo1xuAutOF8RbTCo3Ut0q/65u2ucOeHizi6O14q+3vnelNS+u8qVC2QWXubMcwtuN5E9cbfPslvGC4kdwA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1270,19 +1270,19 @@
 				"node": ">=16.20.0"
 			},
 			"optionalDependencies": {
-				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260527.2",
-				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260527.2"
+				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260624.1",
+				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260624.1"
 			}
 		},
 		"node_modules/@typescript/native-preview-darwin-arm64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-g8CqDkYCHTCYdhBHXs5cMraBurOS+KrcMFxE0SsaKZoI6Tnp+le1aWvxUBbzNKJYyThHJqb/1mLopzEJxJCuKA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1297,9 +1297,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-darwin-x64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-P00JVvSV90eioYDuINAKmOSA8yhFTWLq6RvS5lrCfUuDlcgr2kSOgZAfFHIksHBVz6ZXpAXpa0dHPmc5SJ3Ymw==",
 			"cpu": [
 				"x64"
 			],
@@ -1314,9 +1314,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-eWHELvfQMkVRjafMd+3ATgM9p9yAergJaM4AOY8AekCNWnHFwUrp/ohh+ryyMUIqque5jjb/kuTiOiGj728I2Q==",
 			"cpu": [
 				"arm"
 			],
@@ -1331,9 +1331,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-cppM2yTZ/Gd1hOXy8NEJcUBxJ0O0zl9CU3OU1ZWZ/OHWWX/ukEzCCr94SUwJhjIWOylBCpIYkrvYoTwxNa94XQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1348,9 +1348,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-linux-x64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-FaB8rS+rKYz4nDrEsHsF3b4cn7eCKCYroMJReA375OuQ6PHcmCNQ6QlVetA0dfFBxTTgejmoKyfw9xgAA5P4Yw==",
 			"cpu": [
 				"x64"
 			],
@@ -1365,9 +1365,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-win32-arm64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-BgkqbCmSHDb5UxqWaFlFFJ/DHNT3lEUO4W8627ap6+QthJZuXk2imiHAX3PgYXC6en9fLLyR6jjcseAa4CCshg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1382,9 +1382,9 @@
 			}
 		},
 		"node_modules/@typescript/native-preview-win32-x64": {
-			"version": "7.0.0-dev.20260527.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260527.2.tgz",
-			"integrity": "sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg==",
+			"version": "7.0.0-dev.20260624.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260624.1.tgz",
+			"integrity": "sha512-WaZ+ue63NgB2j/lqjirfevh/TqcsCxSqnKhGGiRnlxHyYIBcoq+x7KngyEnyGIaywJE1PcFeXA+2EMSIPlSEiQ==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@typescript-eslint/eslint-plugin": "^8.60.0",
 		"@typescript-eslint/parser": "^8.60.0",
 		"@typescript-eslint/utils": "^8.60.0",
-		"@typescript/native-preview": "7.0.0-dev.20260527.2",
+		"@typescript/native-preview": "7.0.0-dev.20260624.1",
 		"@vitest/coverage-v8": "^4.1.7",
 		"@vitest/ui": "^4.1.7",
 		"eslint": "^9.39.4",

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -27,7 +27,7 @@ const { registryDirectory } = coreBundle.registry;
 const { startTraceViewerServer } = coreBundle.server;
 import { logUnhandledError, testDebug } from './utils/log.js';
 import { createHash } from './utils/guid.js';
-import { outputFile  } from './config.js';
+import { OUTPUT_TRACE_FOLDER_PREFIX, outputFile  } from './config.js';
 
 import type { FullConfig } from './config.js';
 
@@ -326,7 +326,7 @@ async function startTraceServer(config: FullConfig, rootPath: string | undefined
   if (!config.saveTrace)
     return undefined;
 
-  const tracesDir = await outputFile(config, rootPath, `traces-${Date.now()}`);
+  const tracesDir = await outputFile(config, rootPath, `${OUTPUT_TRACE_FOLDER_PREFIX}${Date.now()}`);
   const server = await startTraceViewerServer();
   const urlPrefix = server.urlPrefix('human-readable');
   const url = urlPrefix + '/trace/index.html?trace=' + tracesDir + '/trace.json';

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -45,14 +45,23 @@ export function contextFactory(config: FullConfig): BrowserContextFactory {
 
 export type ClientInfo = { name?: string, version?: string, rootPath?: string };
 
+export type BrowserContextResult = {
+  browserContext: playwright.BrowserContext;
+  close: () => Promise<void>;
+  // Output folder of the trace recorded for this context, when `--save-trace`
+  // is enabled. Eviction preserves it while the context (and its trace) is live.
+  tracesDir?: string;
+};
+
 export interface BrowserContextFactory {
-  createContext(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }>;
+  createContext(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<BrowserContextResult>;
 }
 
 abstract class BaseContextFactory implements BrowserContextFactory {
   readonly config: FullConfig;
   private _logName: string;
   protected _browserPromise: Promise<playwright.Browser> | undefined;
+  protected _tracesDir: string | undefined;
 
   constructor(name: string, config: FullConfig) {
     this._logName = name;
@@ -76,11 +85,11 @@ abstract class BaseContextFactory implements BrowserContextFactory {
 
   protected abstract _doObtainBrowser(clientInfo: ClientInfo): Promise<playwright.Browser>;
 
-  async createContext(clientInfo: ClientInfo): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  async createContext(clientInfo: ClientInfo): Promise<BrowserContextResult> {
     testDebug(`create browser context (${this._logName})`);
     const browser = await this._obtainBrowser(clientInfo);
     const browserContext = await this._doCreateContext(browser);
-    return { browserContext, close: () => this._closeBrowserContext(browserContext, browser) };
+    return { browserContext, close: () => this._closeBrowserContext(browserContext, browser), tracesDir: this._tracesDir };
   }
 
   protected abstract _doCreateContext(browser: playwright.Browser): Promise<playwright.BrowserContext>;
@@ -105,8 +114,9 @@ class IsolatedContextFactory extends BaseContextFactory {
   protected override async _doObtainBrowser(clientInfo: ClientInfo): Promise<playwright.Browser> {
     await injectCdpPort(this.config.browser);
     const browserType = playwright[this.config.browser.browserName];
+    this._tracesDir = await startTraceServer(this.config, clientInfo.rootPath);
     return browserType.launch({
-      tracesDir: await startTraceServer(this.config, clientInfo.rootPath),
+      tracesDir: this._tracesDir,
       ...this.config.browser.launchOptions,
       handleSIGINT: false,
       handleSIGTERM: false,
@@ -127,7 +137,7 @@ class CdpContextFactory extends BaseContextFactory {
     super('cdp', config);
   }
 
-  override async createContext(clientInfo: ClientInfo): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  override async createContext(clientInfo: ClientInfo): Promise<BrowserContextResult> {
     testDebug('create browser context (cdp)');
     const browser = await this._obtainBrowser(clientInfo);
     const browserContext = await this._doCreateContext(browser);
@@ -177,7 +187,7 @@ class CdpLaunchContextFactory implements BrowserContextFactory {
     this.config = config;
   }
 
-  async createContext(clientInfo: ClientInfo): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  async createContext(clientInfo: ClientInfo): Promise<BrowserContextResult> {
     const cdpLaunch = this.config.browser.cdpLaunch!;
     const port = cdpLaunch.port ?? await findFreePort();
     const endpoint = `http://127.0.0.1:${port}`;
@@ -238,7 +248,7 @@ class PersistentContextFactory implements BrowserContextFactory {
     this.config = config;
   }
 
-  async createContext(clientInfo: ClientInfo): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  async createContext(clientInfo: ClientInfo): Promise<BrowserContextResult> {
     await injectCdpPort(this.config.browser);
     testDebug('create browser context (persistent)');
     const userDataDir = this.config.browser.userDataDir ?? await this._createUserDataDir(clientInfo.rootPath);
@@ -258,7 +268,7 @@ class PersistentContextFactory implements BrowserContextFactory {
           handleSIGTERM: false,
         });
         const close = () => this._closeBrowserContext(browserContext, userDataDir);
-        return { browserContext, close };
+        return { browserContext, close, tracesDir };
       } catch (error: any) {
         if (error.message.includes('Executable doesn\'t exist'))
           throw new Error(`Browser specified in your config is not installed. Either install it (likely) or change the config.`);

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FullConfig } from './config.js';
-import { Context } from './context.js';
+import { Context, outputEvictionGate } from './context.js';
 import { logUnhandledError } from './utils/log.js';
 import { Response } from './response.js';
 import { SessionLog } from './sessionLog.js';
@@ -80,14 +80,19 @@ export class BrowserServerBackend implements ServerBackend {
     }
     const context = this._context!;
     const response = new Response(context, name, parsedArguments, requestContext);
-    const shouldEvictOutputFiles = !context.isRunningTool();
     const runningToolToken = context.setRunningTool(name);
     try {
-      if (shouldEvictOutputFiles)
-        await context.evictOutputFiles();
-      await tool.handle(context, parsedArguments, response);
-      await response.finish();
-      this._sessionLog?.logResponse(response);
+      // The gate evicts old output only while the whole server is idle and
+      // blocks this tool from writing until any in-flight eviction completes, so
+      // eviction (even from another HTTP session) never deletes live artifacts.
+      await outputEvictionGate.run(
+          () => context.evictOutputFiles(),
+          async () => {
+            await tool.handle(context, parsedArguments, response);
+            await response.finish();
+            this._sessionLog?.logResponse(response);
+          },
+      );
     } catch (error: any) {
       response.addError(String(error));
     } finally {

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FullConfig } from './config.js';
-import { Context, outputEvictionGate } from './context.js';
+import { Context, currentToolNameStorage, outputEvictionGate } from './context.js';
 import { logUnhandledError } from './utils/log.js';
 import { Response } from './response.js';
 import { SessionLog } from './sessionLog.js';
@@ -87,11 +87,13 @@ export class BrowserServerBackend implements ServerBackend {
       // eviction (even from another HTTP session) never deletes live artifacts.
       await outputEvictionGate.run(
           () => context.evictOutputFiles(),
-          async () => {
+          // Tag the body's async stack with this call's tool name so a lazily
+          // created browser context attributes it to the right call.
+          () => currentToolNameStorage.run(name, async () => {
             await tool.handle(context, parsedArguments, response);
             await response.finish();
             this._sessionLog?.logResponse(response);
-          },
+          }),
       );
     } catch (error: any) {
       response.addError(String(error));

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -80,8 +80,11 @@ export class BrowserServerBackend implements ServerBackend {
     }
     const context = this._context!;
     const response = new Response(context, name, parsedArguments, requestContext);
+    const shouldEvictOutputFiles = !context.isRunningTool();
     context.setRunningTool(name);
     try {
+      if (shouldEvictOutputFiles)
+        await context.evictOutputFiles();
       await tool.handle(context, parsedArguments, response);
       await response.finish();
       this._sessionLog?.logResponse(response);

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -81,7 +81,7 @@ export class BrowserServerBackend implements ServerBackend {
     const context = this._context!;
     const response = new Response(context, name, parsedArguments, requestContext);
     const shouldEvictOutputFiles = !context.isRunningTool();
-    context.setRunningTool(name);
+    const runningToolToken = context.setRunningTool(name);
     try {
       if (shouldEvictOutputFiles)
         await context.evictOutputFiles();
@@ -91,7 +91,7 @@ export class BrowserServerBackend implements ServerBackend {
     } catch (error: any) {
       response.addError(String(error));
     } finally {
-      context.setRunningTool(undefined);
+      context.clearRunningTool(runningToolToken);
     }
     return response.serialize();
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import type { BrowserContextOptions, LaunchOptions } from 'playwright';
 import { devices } from 'playwright';
 import { sanitizeForFilePath } from './utils/fileUtils.js';
+import { SESSION_LOG_FILE_NAME } from './sessionLogConstants.js';
 
 import type { Config, ToolCapability } from '../config.js';
 
@@ -274,38 +275,126 @@ async function loadConfig(configFile: string | undefined): Promise<Config> {
   }
 }
 
-export async function outputFile(config: FullConfig, rootPath: string | undefined, name: string): Promise<string> {
-  const outputDir = config.outputDir
-        ?? (rootPath ? path.join(rootPath, '.playwright-mcp') : undefined)
-        ?? path.join(os.tmpdir(), 'playwright-mcp-output', sanitizeForFilePath(new Date().toISOString()));
+type OutputFileOptions = {
+  evict?: boolean;
+};
+
+export async function outputFile(config: FullConfig, rootPath: string | undefined, name: string, options: OutputFileOptions = {}): Promise<string> {
+  const outputDir = outputDirectory(config, rootPath);
+  const evictionDir = outputEvictionDirectory(config, rootPath);
 
   await fs.promises.mkdir(outputDir, { recursive: true });
-  await evictOldOutputFiles(outputDir, config.outputMaxSize);
+  if (options.evict !== false)
+    await evictOldOutputFiles(evictionDir, config.outputMaxSize);
   const fileName = sanitizeForFilePath(name);
   return path.join(outputDir, fileName);
 }
 
+export async function evictOutputFiles(config: FullConfig, rootPath: string | undefined): Promise<void> {
+  const outputDir = outputEvictionDirectory(config, rootPath);
+  await fs.promises.mkdir(outputDir, { recursive: true });
+  await evictOldOutputFiles(outputDir, config.outputMaxSize);
+}
+
+function outputDirectory(config: FullConfig, rootPath: string | undefined): string {
+  return config.outputDir
+    ?? (rootPath ? path.join(rootPath, '.playwright-mcp') : undefined)
+    ?? path.join(defaultTempOutputDirectory(), sanitizeForFilePath(new Date().toISOString()));
+}
+
+function outputEvictionDirectory(config: FullConfig, rootPath: string | undefined): string {
+  return config.outputDir
+    ?? (rootPath ? path.join(rootPath, '.playwright-mcp') : undefined)
+    ?? defaultTempOutputDirectory();
+}
+
+function defaultTempOutputDirectory(): string {
+  return path.join(os.tmpdir(), 'playwright-mcp-output');
+}
+
 async function evictOldOutputFiles(outputDir: string, maxSize: number | undefined) {
-  if (maxSize === undefined || maxSize < 0 || Number.isNaN(maxSize))
+  const limit = validateOutputMaxSize(maxSize);
+  if (limit === undefined)
     return;
 
-  const dirents = await fs.promises.readdir(outputDir, { recursive: true, withFileTypes: true });
-  const files = await Promise.all(dirents
-      .filter(dirent => dirent.isFile() && dirent.name !== 'session.md')
-      .map(async dirent => {
-        const filePath = path.join(dirent.parentPath, dirent.name);
-        const { size, mtimeMs } = await fs.promises.stat(filePath);
-        return { filePath, size, mtimeMs };
-      }));
+  const protectedDirs = new Set<string>();
+  const files = await collectOutputFiles(outputDir, protectedDirs);
+  const evictableFiles = files.filter(file => !hasProtectedAncestor(file.filePath, protectedDirs));
 
-  let totalSize = files.reduce((total, file) => total + file.size, 0);
-  files.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
-  for (const file of files) {
-    if (totalSize <= maxSize)
+  let totalSize = evictableFiles.reduce((total, file) => total + file.size, 0);
+  evictableFiles.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
+  for (const file of evictableFiles) {
+    if (totalSize <= limit)
       return;
     await fs.promises.rm(file.filePath, { force: true });
     totalSize -= file.size;
   }
+}
+
+type OutputFileEntry = {
+  filePath: string;
+  size: number;
+  mtimeMs: number;
+};
+
+async function collectOutputFiles(outputDir: string, protectedDirs: Set<string>): Promise<OutputFileEntry[]> {
+  const entries: OutputFileEntry[] = [];
+  let dirents: fs.Dirent[];
+  try {
+    dirents = await fs.promises.readdir(outputDir, { withFileTypes: true });
+  } catch (error) {
+    if (isFileNotFoundError(error))
+      return entries;
+    throw error;
+  }
+
+  await Promise.all(dirents.map(async dirent => {
+    const filePath = path.join(outputDir, dirent.name);
+    if (dirent.isDirectory()) {
+      entries.push(...await collectOutputFiles(filePath, protectedDirs));
+      return;
+    }
+    if (!dirent.isFile())
+      return;
+    if (dirent.name === SESSION_LOG_FILE_NAME)
+      protectedDirs.add(outputDir);
+    let size: number;
+    let mtimeMs: number;
+    try {
+      ({ size, mtimeMs } = await fs.promises.stat(filePath));
+    } catch (error) {
+      if (isFileNotFoundError(error))
+        return;
+      throw error;
+    }
+    entries.push({ filePath, size, mtimeMs });
+  }));
+
+  return entries;
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function hasProtectedAncestor(filePath: string, protectedDirs: Set<string>): boolean {
+  let directory = path.dirname(filePath);
+  while (true) {
+    if (protectedDirs.has(directory))
+      return true;
+    const parent = path.dirname(directory);
+    if (parent === directory)
+      return false;
+    directory = parent;
+  }
+}
+
+function validateOutputMaxSize(outputMaxSize: number | undefined): number | undefined {
+  if (outputMaxSize === undefined)
+    return undefined;
+  if (!Number.isFinite(outputMaxSize) || outputMaxSize < 0)
+    throw new Error('outputMaxSize must be a non-negative number');
+  return outputMaxSize;
 }
 
 function pickDefined<T extends object>(obj: T | undefined): Partial<T> {
@@ -334,9 +423,12 @@ function mergeConfig(base: FullConfig, overrides: Config): FullConfig {
   if (browser.browserName !== 'chromium' && browser.launchOptions)
     delete browser.launchOptions.channel;
 
+  const outputMaxSize = validateOutputMaxSize(overrides.outputMaxSize ?? base.outputMaxSize);
+
   return {
     ...pickDefined(base),
     ...pickDefined(overrides),
+    outputMaxSize,
     browser,
     network: {
       ...pickDefined(base.network),

--- a/src/config.ts
+++ b/src/config.ts
@@ -301,17 +301,11 @@ async function loadConfig(configFile: string | undefined): Promise<Config> {
   }
 }
 
-type OutputFileOptions = {
-  evict?: boolean;
-};
-
-export async function outputFile(config: FullConfig, rootPath: string | undefined, name: string, options: OutputFileOptions = {}): Promise<string> {
+export async function outputFile(config: FullConfig, rootPath: string | undefined, name: string): Promise<string> {
+  // Pure path allocation: eviction is driven centrally by `evictOutputFiles`
+  // (see `OutputEvictionGate`) so it never races with a tool that is writing.
   const outputDir = outputDirectory(config, rootPath);
-  const evictionDir = outputEvictionDirectory(config, rootPath);
-
   await fs.promises.mkdir(outputDir, { recursive: true });
-  if (options.evict !== false)
-    await evictOldOutputFiles(evictionDir, config.outputMaxSize);
   const fileName = sanitizeForFilePath(name);
   return path.join(outputDir, fileName);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,22 +20,29 @@ import path from 'node:path';
 import type { BrowserContextOptions, LaunchOptions } from 'playwright';
 import { devices } from 'playwright';
 import { sanitizeForFilePath } from './utils/fileUtils.js';
-import { SESSION_LOG_FOLDER_PREFIX } from './sessionLogConstants.js';
 
 import type { Config, ToolCapability } from '../config.js';
 
 /**
  * Prefix of the per-context trace folder created by `startTraceServer`.
- * Output eviction uses this to recognise and preserve live trace folders.
  */
 export const OUTPUT_TRACE_FOLDER_PREFIX = 'traces-';
 
 /**
- * Output subfolders that hold live session artifacts (session logs and traces).
- * These are preserved during `outputMaxSize` eviction so that the active
- * session's logs and in-progress traces are never deleted out from under it.
+ * Supplies the set of output directories that belong to live sessions (session
+ * logs and in-progress traces) and must be preserved during `outputMaxSize`
+ * eviction. The provider is registered by the context layer so that eviction —
+ * which can be triggered from any tool, in any of several concurrent HTTP
+ * sessions sharing one output directory — protects every active session's
+ * folders, not just a single inferred one. Defaults to protecting nothing.
  */
-const PROTECTED_OUTPUT_FOLDER_PREFIXES = [SESSION_LOG_FOLDER_PREFIX, OUTPUT_TRACE_FOLDER_PREFIX];
+type ProtectedOutputDirsProvider = () => string[];
+
+let protectedOutputDirsProvider: ProtectedOutputDirsProvider = () => [];
+
+export function setProtectedOutputDirsProvider(provider: ProtectedOutputDirsProvider): void {
+  protectedOutputDirsProvider = provider;
+}
 
 export type CLIOptions = {
     allowedOrigins?: string[];
@@ -340,9 +347,11 @@ async function evictOldOutputFiles(outputDir: string, maxSize: number | undefine
   if (limit === undefined)
     return;
 
-  const { files, liveFolders } = await collectOutputTree(outputDir);
-  const protectedDirs = selectLiveFolders(liveFolders);
-  const evictableFiles = files.filter(file => !isWithinAnyDir(file.filePath, protectedDirs));
+  // Folders for every live session (session logs and in-progress traces across
+  // all concurrent contexts) are skipped wholesale so a tool in one session can
+  // never evict another session's active artifacts.
+  const protectedDirs = protectedOutputDirsProvider().map(dir => path.resolve(dir));
+  const evictableFiles = await collectEvictableFiles(outputDir, protectedDirs);
 
   let totalSize = evictableFiles.reduce((total, file) => total + file.size, 0);
   evictableFiles.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
@@ -360,17 +369,13 @@ type OutputFileEntry = {
   mtimeMs: number;
 };
 
-type LiveFolderCandidate = {
-  prefix: string;
-  dirPath: string;
-  order: number;
-};
-
-async function collectOutputTree(outputDir: string): Promise<{ files: OutputFileEntry[]; liveFolders: LiveFolderCandidate[] }> {
+async function collectEvictableFiles(outputDir: string, protectedDirs: string[]): Promise<OutputFileEntry[]> {
   const files: OutputFileEntry[] = [];
-  const liveFolders: LiveFolderCandidate[] = [];
 
   const walk = async (dir: string): Promise<void> => {
+    if (isWithinAnyDir(dir, protectedDirs))
+      return;
+
     let dirents: fs.Dirent[];
     try {
       dirents = await fs.promises.readdir(dir, { withFileTypes: true });
@@ -383,9 +388,6 @@ async function collectOutputTree(outputDir: string): Promise<{ files: OutputFile
     await Promise.all(dirents.map(async dirent => {
       const filePath = path.join(dir, dirent.name);
       if (dirent.isDirectory()) {
-        const prefix = liveFolderPrefix(dirent.name);
-        if (prefix !== undefined)
-          liveFolders.push({ prefix, dirPath: filePath, order: liveFolderOrder(dirent.name, prefix) });
         await walk(filePath);
         return;
       }
@@ -404,40 +406,8 @@ async function collectOutputTree(outputDir: string): Promise<{ files: OutputFile
     }));
   };
 
-  await walk(outputDir);
-  return { files, liveFolders };
-}
-
-/**
- * Returns the live-artifact folder prefix that `name` matches (e.g. a session
- * log or trace folder), or undefined when the directory is an ordinary one.
- */
-function liveFolderPrefix(name: string): string | undefined {
-  return PROTECTED_OUTPUT_FOLDER_PREFIXES.find(prefix => name.startsWith(prefix));
-}
-
-/**
- * Orders folders that share a prefix; the folder name embeds `Date.now()`, so a
- * larger value means a more recently created (i.e. still-active) folder.
- */
-function liveFolderOrder(name: string, prefix: string): number {
-  const suffix = Number(name.slice(prefix.length));
-  return Number.isFinite(suffix) ? suffix : -1;
-}
-
-/**
- * Of all the session-log/trace folders found, keep only the most recent one per
- * prefix. That is the folder the current session is still writing to, so it is
- * preserved while older, closed folders stay eligible for eviction.
- */
-function selectLiveFolders(candidates: LiveFolderCandidate[]): string[] {
-  const newestByPrefix = new Map<string, LiveFolderCandidate>();
-  for (const candidate of candidates) {
-    const current = newestByPrefix.get(candidate.prefix);
-    if (!current || candidate.order > current.order || (candidate.order === current.order && candidate.dirPath > current.dirPath))
-      newestByPrefix.set(candidate.prefix, candidate);
-  }
-  return [...newestByPrefix.values()].map(candidate => candidate.dirPath);
+  await walk(path.resolve(outputDir));
+  return files;
 }
 
 function isWithinAnyDir(filePath: string, dirs: string[]): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,7 @@ export type CLIOptions = {
     proxyServer?: string;
     saveSession?: boolean;
     saveTrace?: boolean;
+    outputMaxSize?: number;
     storageState?: string;
     userAgent?: string;
     userDataDir?: string;
@@ -215,6 +216,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
     saveSession: cliOptions.saveSession,
     saveTrace: cliOptions.saveTrace,
     outputDir: cliOptions.outputDir,
+    outputMaxSize: cliOptions.outputMaxSize,
     imageResponses: cliOptions.imageResponses,
     timeouts: {
       navigationTimeout: cliOptions.navigationTimeout,
@@ -247,6 +249,7 @@ function configFromEnv(): Config {
     options.imageResponses = 'omit';
   options.sandbox = envToBoolean(process.env.PLAYWRIGHT_MCP_SANDBOX);
   options.outputDir = envToString(process.env.PLAYWRIGHT_MCP_OUTPUT_DIR);
+  options.outputMaxSize = envToNumber(process.env.PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE);
   options.port = envToNumber(process.env.PLAYWRIGHT_MCP_PORT);
   options.proxyBypass = envToString(process.env.PLAYWRIGHT_MCP_PROXY_BYPASS);
   options.proxyServer = envToString(process.env.PLAYWRIGHT_MCP_PROXY_SERVER);
@@ -277,8 +280,32 @@ export async function outputFile(config: FullConfig, rootPath: string | undefine
         ?? path.join(os.tmpdir(), 'playwright-mcp-output', sanitizeForFilePath(new Date().toISOString()));
 
   await fs.promises.mkdir(outputDir, { recursive: true });
+  await evictOldOutputFiles(outputDir, config.outputMaxSize);
   const fileName = sanitizeForFilePath(name);
   return path.join(outputDir, fileName);
+}
+
+async function evictOldOutputFiles(outputDir: string, maxSize: number | undefined) {
+  if (maxSize === undefined || maxSize < 0 || Number.isNaN(maxSize))
+    return;
+
+  const dirents = await fs.promises.readdir(outputDir, { recursive: true, withFileTypes: true });
+  const files = await Promise.all(dirents
+      .filter(dirent => dirent.isFile() && dirent.name !== 'session.md')
+      .map(async dirent => {
+        const filePath = path.join(dirent.parentPath, dirent.name);
+        const { size, mtimeMs } = await fs.promises.stat(filePath);
+        return { filePath, size, mtimeMs };
+      }));
+
+  let totalSize = files.reduce((total, file) => total + file.size, 0);
+  files.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
+  for (const file of files) {
+    if (totalSize <= maxSize)
+      return;
+    await fs.promises.rm(file.filePath, { force: true });
+    totalSize -= file.size;
+  }
 }
 
 function pickDefined<T extends object>(obj: T | undefined): Partial<T> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -342,12 +342,13 @@ async function evictOldOutputFiles(outputDir: string, maxSize: number | undefine
     return;
 
   // Folders for every live session (session logs and in-progress traces across
-  // all concurrent contexts) are skipped wholesale so a tool in one session can
-  // never evict another session's active artifacts.
+  // all concurrent contexts) must never be deleted, but their bytes still count
+  // toward the budget so the cap reflects the real directory size.
   const protectedDirs = protectedOutputDirsProvider().map(dir => path.resolve(dir));
-  const evictableFiles = await collectEvictableFiles(outputDir, protectedDirs);
+  const files = await collectOutputFiles(outputDir);
+  const evictableFiles = files.filter(file => !isWithinAnyDir(file.filePath, protectedDirs));
 
-  let totalSize = evictableFiles.reduce((total, file) => total + file.size, 0);
+  let totalSize = files.reduce((total, file) => total + file.size, 0);
   evictableFiles.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
   for (const file of evictableFiles) {
     if (totalSize <= limit)
@@ -363,13 +364,10 @@ type OutputFileEntry = {
   mtimeMs: number;
 };
 
-async function collectEvictableFiles(outputDir: string, protectedDirs: string[]): Promise<OutputFileEntry[]> {
+async function collectOutputFiles(outputDir: string): Promise<OutputFileEntry[]> {
   const files: OutputFileEntry[] = [];
 
   const walk = async (dir: string): Promise<void> => {
-    if (isWithinAnyDir(dir, protectedDirs))
-      return;
-
     let dirents: fs.Dirent[];
     try {
       dirents = await fs.promises.readdir(dir, { withFileTypes: true });

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,9 +20,22 @@ import path from 'node:path';
 import type { BrowserContextOptions, LaunchOptions } from 'playwright';
 import { devices } from 'playwright';
 import { sanitizeForFilePath } from './utils/fileUtils.js';
-import { SESSION_LOG_FILE_NAME } from './sessionLogConstants.js';
+import { SESSION_LOG_FOLDER_PREFIX } from './sessionLogConstants.js';
 
 import type { Config, ToolCapability } from '../config.js';
+
+/**
+ * Prefix of the per-context trace folder created by `startTraceServer`.
+ * Output eviction uses this to recognise and preserve live trace folders.
+ */
+export const OUTPUT_TRACE_FOLDER_PREFIX = 'traces-';
+
+/**
+ * Output subfolders that hold live session artifacts (session logs and traces).
+ * These are preserved during `outputMaxSize` eviction so that the active
+ * session's logs and in-progress traces are never deleted out from under it.
+ */
+const PROTECTED_OUTPUT_FOLDER_PREFIXES = [SESSION_LOG_FOLDER_PREFIX, OUTPUT_TRACE_FOLDER_PREFIX];
 
 export type CLIOptions = {
     allowedOrigins?: string[];
@@ -323,9 +336,7 @@ async function evictOldOutputFiles(outputDir: string, maxSize: number | undefine
   if (limit === undefined)
     return;
 
-  const protectedDirs = new Set<string>();
-  const files = await collectOutputFiles(outputDir, protectedDirs);
-  const evictableFiles = files.filter(file => !hasProtectedAncestor(file.filePath, protectedDirs));
+  const evictableFiles = await collectEvictableFiles(outputDir, true);
 
   let totalSize = evictableFiles.reduce((total, file) => total + file.size, 0);
   evictableFiles.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
@@ -343,7 +354,7 @@ type OutputFileEntry = {
   mtimeMs: number;
 };
 
-async function collectOutputFiles(outputDir: string, protectedDirs: Set<string>): Promise<OutputFileEntry[]> {
+async function collectEvictableFiles(outputDir: string, isRoot: boolean): Promise<OutputFileEntry[]> {
   const entries: OutputFileEntry[] = [];
   let dirents: fs.Dirent[];
   try {
@@ -357,13 +368,16 @@ async function collectOutputFiles(outputDir: string, protectedDirs: Set<string>)
   await Promise.all(dirents.map(async dirent => {
     const filePath = path.join(outputDir, dirent.name);
     if (dirent.isDirectory()) {
-      entries.push(...await collectOutputFiles(filePath, protectedDirs));
+      // Preserve live session-log and trace folders for the active session.
+      // These only ever live directly under the output root, so the prefix
+      // check is scoped there to avoid protecting look-alike report subfolders.
+      if (isRoot && isProtectedOutputFolder(dirent.name))
+        return;
+      entries.push(...await collectEvictableFiles(filePath, false));
       return;
     }
     if (!dirent.isFile())
       return;
-    if (dirent.name === SESSION_LOG_FILE_NAME)
-      protectedDirs.add(outputDir);
     let size: number;
     let mtimeMs: number;
     try {
@@ -379,20 +393,12 @@ async function collectOutputFiles(outputDir: string, protectedDirs: Set<string>)
   return entries;
 }
 
-function isFileNotFoundError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+function isProtectedOutputFolder(name: string): boolean {
+  return PROTECTED_OUTPUT_FOLDER_PREFIXES.some(prefix => name.startsWith(prefix));
 }
 
-function hasProtectedAncestor(filePath: string, protectedDirs: Set<string>): boolean {
-  let directory = path.dirname(filePath);
-  while (true) {
-    if (protectedDirs.has(directory))
-      return true;
-    const parent = path.dirname(directory);
-    if (parent === directory)
-      return false;
-    directory = parent;
-  }
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
 function validateOutputMaxSize(outputMaxSize: number | undefined): number | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -333,7 +333,10 @@ function outputEvictionDirectory(config: FullConfig, rootPath: string | undefine
 }
 
 function defaultTempOutputDirectory(): string {
-  return path.join(os.tmpdir(), 'playwright-mcp-output');
+  // Scope the shared-temp fallback to this process so that two server instances
+  // running without an explicit `outputDir` don't evict each other's live files
+  // (the eviction gate and protected-dir registry are process-local).
+  return path.join(os.tmpdir(), 'playwright-mcp-output', String(process.pid));
 }
 
 async function evictOldOutputFiles(outputDir: string, maxSize: number | undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -310,8 +310,12 @@ export async function outputFile(config: FullConfig, rootPath: string | undefine
 }
 
 export async function evictOutputFiles(config: FullConfig, rootPath: string | undefined): Promise<void> {
+  // Skip all filesystem work (including creating the output directory) when no
+  // size cap is configured, so plain tool calls never materialize an output dir
+  // for users who never opted into eviction.
+  if (config.outputMaxSize === undefined)
+    return;
   const outputDir = outputEvictionDirectory(config, rootPath);
-  await fs.promises.mkdir(outputDir, { recursive: true });
   await evictOldOutputFiles(outputDir, config.outputMaxSize);
 }
 
@@ -336,7 +340,9 @@ async function evictOldOutputFiles(outputDir: string, maxSize: number | undefine
   if (limit === undefined)
     return;
 
-  const evictableFiles = await collectEvictableFiles(outputDir, true);
+  const { files, liveFolders } = await collectOutputTree(outputDir);
+  const protectedDirs = selectLiveFolders(liveFolders);
+  const evictableFiles = files.filter(file => !isWithinAnyDir(file.filePath, protectedDirs));
 
   let totalSize = evictableFiles.reduce((total, file) => total + file.size, 0);
   evictableFiles.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
@@ -354,47 +360,88 @@ type OutputFileEntry = {
   mtimeMs: number;
 };
 
-async function collectEvictableFiles(outputDir: string, isRoot: boolean): Promise<OutputFileEntry[]> {
-  const entries: OutputFileEntry[] = [];
-  let dirents: fs.Dirent[];
-  try {
-    dirents = await fs.promises.readdir(outputDir, { withFileTypes: true });
-  } catch (error) {
-    if (isFileNotFoundError(error))
-      return entries;
-    throw error;
-  }
+type LiveFolderCandidate = {
+  prefix: string;
+  dirPath: string;
+  order: number;
+};
 
-  await Promise.all(dirents.map(async dirent => {
-    const filePath = path.join(outputDir, dirent.name);
-    if (dirent.isDirectory()) {
-      // Preserve live session-log and trace folders for the active session.
-      // These only ever live directly under the output root, so the prefix
-      // check is scoped there to avoid protecting look-alike report subfolders.
-      if (isRoot && isProtectedOutputFolder(dirent.name))
-        return;
-      entries.push(...await collectEvictableFiles(filePath, false));
-      return;
-    }
-    if (!dirent.isFile())
-      return;
-    let size: number;
-    let mtimeMs: number;
+async function collectOutputTree(outputDir: string): Promise<{ files: OutputFileEntry[]; liveFolders: LiveFolderCandidate[] }> {
+  const files: OutputFileEntry[] = [];
+  const liveFolders: LiveFolderCandidate[] = [];
+
+  const walk = async (dir: string): Promise<void> => {
+    let dirents: fs.Dirent[];
     try {
-      ({ size, mtimeMs } = await fs.promises.stat(filePath));
+      dirents = await fs.promises.readdir(dir, { withFileTypes: true });
     } catch (error) {
       if (isFileNotFoundError(error))
         return;
       throw error;
     }
-    entries.push({ filePath, size, mtimeMs });
-  }));
 
-  return entries;
+    await Promise.all(dirents.map(async dirent => {
+      const filePath = path.join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        const prefix = liveFolderPrefix(dirent.name);
+        if (prefix !== undefined)
+          liveFolders.push({ prefix, dirPath: filePath, order: liveFolderOrder(dirent.name, prefix) });
+        await walk(filePath);
+        return;
+      }
+      if (!dirent.isFile())
+        return;
+      let size: number;
+      let mtimeMs: number;
+      try {
+        ({ size, mtimeMs } = await fs.promises.stat(filePath));
+      } catch (error) {
+        if (isFileNotFoundError(error))
+          return;
+        throw error;
+      }
+      files.push({ filePath, size, mtimeMs });
+    }));
+  };
+
+  await walk(outputDir);
+  return { files, liveFolders };
 }
 
-function isProtectedOutputFolder(name: string): boolean {
-  return PROTECTED_OUTPUT_FOLDER_PREFIXES.some(prefix => name.startsWith(prefix));
+/**
+ * Returns the live-artifact folder prefix that `name` matches (e.g. a session
+ * log or trace folder), or undefined when the directory is an ordinary one.
+ */
+function liveFolderPrefix(name: string): string | undefined {
+  return PROTECTED_OUTPUT_FOLDER_PREFIXES.find(prefix => name.startsWith(prefix));
+}
+
+/**
+ * Orders folders that share a prefix; the folder name embeds `Date.now()`, so a
+ * larger value means a more recently created (i.e. still-active) folder.
+ */
+function liveFolderOrder(name: string, prefix: string): number {
+  const suffix = Number(name.slice(prefix.length));
+  return Number.isFinite(suffix) ? suffix : -1;
+}
+
+/**
+ * Of all the session-log/trace folders found, keep only the most recent one per
+ * prefix. That is the folder the current session is still writing to, so it is
+ * preserved while older, closed folders stay eligible for eviction.
+ */
+function selectLiveFolders(candidates: LiveFolderCandidate[]): string[] {
+  const newestByPrefix = new Map<string, LiveFolderCandidate>();
+  for (const candidate of candidates) {
+    const current = newestByPrefix.get(candidate.prefix);
+    if (!current || candidate.order > current.order || (candidate.order === current.order && candidate.dirPath > current.dirPath))
+      newestByPrefix.set(candidate.prefix, candidate);
+  }
+  return [...newestByPrefix.values()].map(candidate => candidate.dirPath);
+}
+
+function isWithinAnyDir(filePath: string, dirs: string[]): boolean {
+  return dirs.some(dir => filePath === dir || filePath.startsWith(dir + path.sep));
 }
 
 function isFileNotFoundError(error: unknown): boolean {

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ import type * as playwright from 'playwright';
 
 import { logUnhandledError } from './utils/log.js';
 import { Tab } from './tab.js';
-import { outputFile } from './config.js';
+import { evictOutputFiles, outputFile } from './config.js';
 
 import type { FullConfig } from './config.js';
 import type { Tool } from './tools/tool.js';
@@ -67,7 +67,7 @@ export class Context {
   private _clientInfo: ClientInfo;
 
   private _closeBrowserContextPromise: Promise<void> | undefined;
-  private _runningToolName: string | undefined;
+  private _runningToolNames: string[] = [];
   private _abortController = new AbortController();
 
   constructor(options: ContextOptions) {
@@ -132,7 +132,11 @@ export class Context {
   }
 
   async outputFile(name: string): Promise<string> {
-    return outputFile(this.config, this._clientInfo.rootPath, name);
+    return outputFile(this.config, this._clientInfo.rootPath, name, { evict: !this.isRunningTool() });
+  }
+
+  async evictOutputFiles(): Promise<void> {
+    await evictOutputFiles(this.config, this._clientInfo.rootPath);
   }
 
   private _onPageCreated(page: playwright.Page) {
@@ -162,11 +166,14 @@ export class Context {
   }
 
   isRunningTool() {
-    return this._runningToolName !== undefined;
+    return this._runningToolNames.length > 0;
   }
 
   setRunningTool(name: string | undefined) {
-    this._runningToolName = name;
+    if (name !== undefined)
+      this._runningToolNames.push(name);
+    else
+      this._runningToolNames.pop();
   }
 
   private async _closeBrowserContextImpl() {
@@ -219,7 +226,7 @@ export class Context {
     if (this._closeBrowserContextPromise)
       throw new Error('Another browser context is being closed.');
     // TODO: move to the browser context factory to make it based on isolation mode.
-    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._runningToolName);
+    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._runningToolNames.at(-1));
     const { browserContext } = result;
     await this._setupRequestInterception(browserContext);
     if (this.sessionLog)

--- a/src/context.ts
+++ b/src/context.ts
@@ -67,7 +67,7 @@ export class Context {
   private _clientInfo: ClientInfo;
 
   private _closeBrowserContextPromise: Promise<void> | undefined;
-  private _runningToolNames: string[] = [];
+  private _runningTools = new Map<symbol, string>();
   private _abortController = new AbortController();
 
   constructor(options: ContextOptions) {
@@ -166,14 +166,27 @@ export class Context {
   }
 
   isRunningTool() {
-    return this._runningToolNames.length > 0;
+    return this._runningTools.size > 0;
   }
 
-  setRunningTool(name: string | undefined) {
-    if (name !== undefined)
-      this._runningToolNames.push(name);
-    else
-      this._runningToolNames.pop();
+  // Each in-flight tool call gets its own token so that overlapping calls which
+  // finish out of order remove their own entry rather than popping whichever
+  // tool happened to start last.
+  setRunningTool(name: string): symbol {
+    const token = Symbol(name);
+    this._runningTools.set(token, name);
+    return token;
+  }
+
+  clearRunningTool(token: symbol) {
+    this._runningTools.delete(token);
+  }
+
+  private _currentRunningToolName(): string | undefined {
+    let name: string | undefined;
+    for (const value of this._runningTools.values())
+      name = value;
+    return name;
   }
 
   private async _closeBrowserContextImpl() {
@@ -226,7 +239,7 @@ export class Context {
     if (this._closeBrowserContextPromise)
       throw new Error('Another browser context is being closed.');
     // TODO: move to the browser context factory to make it based on isolation mode.
-    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._runningToolNames.at(-1));
+    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._currentRunningToolName());
     const { browserContext } = result;
     await this._setupRequestInterception(browserContext);
     if (this.sessionLog)

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,11 +19,11 @@ import type * as playwright from 'playwright';
 
 import { logUnhandledError } from './utils/log.js';
 import { Tab } from './tab.js';
-import { evictOutputFiles, outputFile } from './config.js';
+import { evictOutputFiles, outputFile, setProtectedOutputDirsProvider } from './config.js';
 
 import type { FullConfig } from './config.js';
 import type { Tool } from './tools/tool.js';
-import type { BrowserContextFactory, ClientInfo } from './browserContextFactory.js';
+import type { BrowserContextFactory, BrowserContextResult, ClientInfo } from './browserContextFactory.js';
 import type * as actions from './actions.js';
 import type { SessionLog } from './sessionLog.js';
 
@@ -43,9 +43,18 @@ class ContextRegistry {
   async disposeAll(): Promise<void> {
     await Promise.all([...this._contexts].map(ctx => ctx.dispose()));
   }
+
+  protectedOutputDirs(): string[] {
+    return [...this._contexts].flatMap(ctx => ctx.protectedOutputDirs());
+  }
 }
 
 const contextRegistry = new ContextRegistry();
+
+// Output eviction must preserve the live session-log and trace folders of every
+// active context (concurrent HTTP sessions share one output directory), so it
+// consults the registry rather than guessing which folders are still in use.
+setProtectedOutputDirsProvider(() => contextRegistry.protectedOutputDirs());
 
 type ContextOptions = {
   tools: Tool[];
@@ -60,11 +69,12 @@ export class Context {
   readonly config: FullConfig;
   readonly sessionLog: SessionLog | undefined;
   readonly options: ContextOptions;
-  private _browserContextPromise: Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> | undefined;
+  private _browserContextPromise: Promise<BrowserContextResult> | undefined;
   private _browserContextFactory: BrowserContextFactory;
   private _tabs: Tab[] = [];
   private _currentTab: Tab | undefined;
   private _clientInfo: ClientInfo;
+  private _tracesDir: string | undefined;
 
   private _closeBrowserContextPromise: Promise<void> | undefined;
   private _runningTools = new Map<symbol, string>();
@@ -139,6 +149,17 @@ export class Context {
     await evictOutputFiles(this.config, this._clientInfo.rootPath);
   }
 
+  // Output folders this context is actively writing to, which must survive
+  // `outputMaxSize` eviction (its own session log and in-progress trace).
+  protectedOutputDirs(): string[] {
+    const dirs: string[] = [];
+    if (this.sessionLog)
+      dirs.push(this.sessionLog.folder);
+    if (this._tracesDir)
+      dirs.push(this._tracesDir);
+    return dirs;
+  }
+
   private _onPageCreated(page: playwright.Page) {
     const tab = new Tab(this, page, tab => this._onPageClosed(tab));
     this._tabs.push(tab);
@@ -197,6 +218,7 @@ export class Context {
 
     const promise = this._browserContextPromise;
     this._browserContextPromise = undefined;
+    this._tracesDir = undefined;
 
     await promise.then(async ({ browserContext, close }) => {
       if (this.config.saveTrace)
@@ -235,12 +257,13 @@ export class Context {
     return this._browserContextPromise;
   }
 
-  private async _setupBrowserContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  private async _setupBrowserContext(): Promise<BrowserContextResult> {
     if (this._closeBrowserContextPromise)
       throw new Error('Another browser context is being closed.');
     // TODO: move to the browser context factory to make it based on isolation mode.
     const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._currentRunningToolName());
     const { browserContext } = result;
+    this._tracesDir = result.tracesDir;
     await this._setupRequestInterception(browserContext);
     if (this.sessionLog)
       await InputRecorder.create(this, browserContext);

--- a/src/context.ts
+++ b/src/context.ts
@@ -56,6 +56,35 @@ const contextRegistry = new ContextRegistry();
 // consults the registry rather than guessing which folders are still in use.
 setProtectedOutputDirsProvider(() => contextRegistry.protectedOutputDirs());
 
+/**
+ * Coordinates output eviction across every concurrent tool call (including those
+ * from different HTTP sessions, which share one output directory):
+ *
+ * - eviction only runs when no tool is currently executing anywhere, so it never
+ *   deletes in-progress artifacts that a running tool has not returned yet;
+ * - tool execution waits for any in-flight eviction to finish before it starts
+ *   writing, so an eviction walk can never race with a later tool's writes.
+ */
+class OutputEvictionGate {
+  private _runningTools = 0;
+  private _evictionPromise: Promise<void> = Promise.resolve();
+
+  async run<T>(evict: () => Promise<void>, body: () => Promise<T>): Promise<T> {
+    const shouldEvict = this._runningTools === 0;
+    this._runningTools++;
+    try {
+      if (shouldEvict)
+        this._evictionPromise = evict().catch(logUnhandledError);
+      await this._evictionPromise;
+      return await body();
+    } finally {
+      this._runningTools--;
+    }
+  }
+}
+
+export const outputEvictionGate = new OutputEvictionGate();
+
 type ContextOptions = {
   tools: Tool[];
   config: FullConfig;
@@ -142,7 +171,7 @@ export class Context {
   }
 
   async outputFile(name: string): Promise<string> {
-    return outputFile(this.config, this._clientInfo.rootPath, name, { evict: !this.isRunningTool() });
+    return outputFile(this.config, this._clientInfo.rootPath, name);
   }
 
   async evictOutputFiles(): Promise<void> {
@@ -218,13 +247,15 @@ export class Context {
 
     const promise = this._browserContextPromise;
     this._browserContextPromise = undefined;
-    this._tracesDir = undefined;
 
     await promise.then(async ({ browserContext, close }) => {
       if (this.config.saveTrace)
         await browserContext.tracing.stop();
       await close();
     });
+    // Keep the trace folder protected until tracing has fully stopped and the
+    // files are finalized; only then is it safe to let eviction reclaim it.
+    this._tracesDir = undefined;
   }
 
   async dispose() {

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import debug from 'debug';
 import type * as playwright from 'playwright';
 
@@ -84,6 +86,12 @@ class OutputEvictionGate {
 }
 
 export const outputEvictionGate = new OutputEvictionGate();
+
+// Name of the tool whose execution is on the current async call stack. Used when
+// a tool lazily creates the browser context so the right tool name reaches the
+// context factory (e.g. the extension relay's `newTab` flag), even when several
+// first-time tool calls overlap.
+export const currentToolNameStorage = new AsyncLocalStorage<string>();
 
 type ContextOptions = {
   tools: Tool[];
@@ -178,14 +186,17 @@ export class Context {
     await evictOutputFiles(this.config, this._clientInfo.rootPath);
   }
 
-  // Output folders this context is actively writing to, which must survive
-  // `outputMaxSize` eviction (its own session log and in-progress trace).
+  // Output paths this context is actively writing to, which must survive
+  // `outputMaxSize` eviction: its session log, in-progress trace, and any
+  // downloads still being saved.
   protectedOutputDirs(): string[] {
     const dirs: string[] = [];
     if (this.sessionLog)
       dirs.push(this.sessionLog.folder);
     if (this._tracesDir)
       dirs.push(this._tracesDir);
+    for (const tab of this._tabs)
+      dirs.push(...tab.pendingDownloadOutputFiles());
     return dirs;
   }
 
@@ -230,13 +241,6 @@ export class Context {
 
   clearRunningTool(token: symbol) {
     this._runningTools.delete(token);
-  }
-
-  private _currentRunningToolName(): string | undefined {
-    let name: string | undefined;
-    for (const value of this._runningTools.values())
-      name = value;
-    return name;
   }
 
   private async _closeBrowserContextImpl() {
@@ -292,7 +296,7 @@ export class Context {
     if (this._closeBrowserContextPromise)
       throw new Error('Another browser context is being closed.');
     // TODO: move to the browser context factory to make it based on isolation mode.
-    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, this._currentRunningToolName());
+    const result = await this._browserContextFactory.createContext(this._clientInfo, this._abortController.signal, currentToolNameStorage.getStore());
     const { browserContext } = result;
     this._tracesDir = result.tracesDir;
     await this._setupRequestInterception(browserContext);

--- a/src/program.ts
+++ b/src/program.ts
@@ -84,6 +84,7 @@ function configureBaseProgram() {
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".')
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
+      .option('--output-max-size <bytes>', 'Threshold for evicting old output files, in bytes.', parseInt)
       .option('--port <port>', 'port to listen on for MCP Streamable HTTP transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')

--- a/src/sessionLog.ts
+++ b/src/sessionLog.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { Response } from './response.js';
 import { logUnhandledError } from './utils/log.js';
 import { outputFile } from './config.js';
+import { SESSION_LOG_FILE_NAME } from './sessionLogConstants.js';
 
 import type { FullConfig } from './config.js';
 import type * as actions from './actions.js';
@@ -64,7 +65,7 @@ export class SessionLog {
 
   constructor(sessionFolder: string, storage: IFileStorage = new NodeFileStorage()) {
     this._folder = sessionFolder;
-    this._file = path.join(this._folder, 'session.md');
+    this._file = path.join(this._folder, SESSION_LOG_FILE_NAME);
     this._storage = storage;
   }
 

--- a/src/sessionLog.ts
+++ b/src/sessionLog.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { Response } from './response.js';
 import { logUnhandledError } from './utils/log.js';
 import { outputFile } from './config.js';
-import { SESSION_LOG_FILE_NAME } from './sessionLogConstants.js';
+import { SESSION_LOG_FILE_NAME, SESSION_LOG_FOLDER_PREFIX } from './sessionLogConstants.js';
 
 import type { FullConfig } from './config.js';
 import type * as actions from './actions.js';
@@ -70,7 +70,7 @@ export class SessionLog {
   }
 
   static async create(config: FullConfig, rootPath: string | undefined): Promise<SessionLog> {
-    const sessionFolder = await outputFile(config, rootPath, `session-${Date.now()}`);
+    const sessionFolder = await outputFile(config, rootPath, `${SESSION_LOG_FOLDER_PREFIX}${Date.now()}`);
     await fs.promises.mkdir(sessionFolder, { recursive: true });
     // eslint-disable-next-line no-console
     console.error(`Session: ${sessionFolder}`);

--- a/src/sessionLog.ts
+++ b/src/sessionLog.ts
@@ -69,6 +69,10 @@ export class SessionLog {
     this._storage = storage;
   }
 
+  get folder(): string {
+    return this._folder;
+  }
+
   static async create(config: FullConfig, rootPath: string | undefined): Promise<SessionLog> {
     const sessionFolder = await outputFile(config, rootPath, `${SESSION_LOG_FOLDER_PREFIX}${Date.now()}`);
     await fs.promises.mkdir(sessionFolder, { recursive: true });

--- a/src/sessionLogConstants.ts
+++ b/src/sessionLogConstants.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SESSION_LOG_FILE_NAME = 'session.md';

--- a/src/sessionLogConstants.ts
+++ b/src/sessionLogConstants.ts
@@ -15,3 +15,9 @@
  */
 
 export const SESSION_LOG_FILE_NAME = 'session.md';
+
+/**
+ * Prefix of the per-session output folder created by `SessionLog.create`.
+ * Output eviction uses this to recognise and preserve live session-log folders.
+ */
+export const SESSION_LOG_FOLDER_PREFIX = 'session-';

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -120,6 +120,12 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     entry.finished = true;
   }
 
+  // Output paths of downloads still being written; they must survive output
+  // eviction until `saveAs` resolves, since a download can outlive its tool call.
+  pendingDownloadOutputFiles(): string[] {
+    return this._downloads.filter(entry => !entry.finished).map(entry => entry.outputFile);
+  }
+
   private _clearCollectedArtifacts() {
     this._consoleMessages.length = 0;
     this._recentConsoleMessages.length = 0;

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -137,8 +137,8 @@ describe('Context', () => {
         clientInfo: { rootPath: '/tmp' } as any,
       });
 
-      context.setRunningTool('test_tool');
-      context.setRunningTool(undefined);
+      const token = context.setRunningTool('test_tool');
+      context.clearRunningTool(token);
       expect(context.isRunningTool()).toBe(false);
     });
   });

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Context } from '../src/context.js';
+import { Context, currentToolNameStorage } from '../src/context.js';
+import { Tab } from '../src/tab.js';
 import type { BrowserContextFactory } from '../src/browserContextFactory.js';
 import { EventEmitter } from 'events';
+
+function createMockPage(): any {
+  const page: any = new EventEmitter();
+  page.setDefaultNavigationTimeout = vi.fn();
+  page.setDefaultTimeout = vi.fn();
+  return page;
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
 
 describe('Context', () => {
   let mockBrowserContextFactory: BrowserContextFactory;
@@ -140,6 +153,53 @@ describe('Context', () => {
       const token = context.setRunningTool('test_tool');
       context.clearRunningTool(token);
       expect(context.isRunningTool()).toBe(false);
+    });
+  });
+
+  describe('output protection', () => {
+    it('passes the current async call\'s tool name to the context factory', async () => {
+      const context = new Context({
+        tools: [],
+        config: {} as any,
+        browserContextFactory: mockBrowserContextFactory,
+        sessionLog: undefined,
+        clientInfo: { rootPath: '/tmp' } as any,
+      });
+
+      await currentToolNameStorage.run('browser_navigate', () => context.ensureTab());
+
+      expect(mockBrowserContextFactory.createContext).toHaveBeenCalledWith(
+          expect.anything(), expect.anything(), 'browser_navigate');
+    });
+
+    it('reports in-flight downloads as protected output paths', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-ctx-download-'));
+      try {
+        const context = new Context({
+          tools: [],
+          config: { timeouts: {}, outputDir } as any,
+          browserContextFactory: mockBrowserContextFactory,
+          sessionLog: undefined,
+          clientInfo: { rootPath: undefined } as any,
+        });
+        const page = createMockPage();
+        const tab = new Tab(context, page, () => {});
+        (context as any)._tabs.push(tab);
+
+        // A download whose saveAs never resolves stays in-flight.
+        page.emit('download', {
+          suggestedFilename: () => 'export.csv',
+          saveAs: () => new Promise<void>(() => {}),
+        });
+        // The download path is allocated asynchronously (mkdir), so wait for it
+        // to register before asserting.
+        for (let i = 0; i < 50 && tab.pendingDownloadOutputFiles().length === 0; i++)
+          await tick();
+
+        expect(context.protectedOutputDirs()).toContain(path.join(outputDir, 'export.csv'));
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -19,7 +19,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OUTPUT_TRACE_FOLDER_PREFIX, evictOutputFiles, outputFile, resolveCLIConfig, resolveConfig, setProtectedOutputDirsProvider } from '../src/config.js';
-import { Context } from '../src/context.js';
+import { Context, outputEvictionGate } from '../src/context.js';
 import { SessionLog } from '../src/sessionLog.js';
 import { SESSION_LOG_FILE_NAME, SESSION_LOG_FOLDER_PREFIX } from '../src/sessionLogConstants.js';
 
@@ -65,7 +65,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 3_000 });
 
-    await expect(outputFile(config, undefined, 'next.bin')).resolves.toBe(path.join(outputDir, 'next.bin'));
+    await evictOutputFiles(config, undefined);
 
     await expect(sortedEntries(outputDir)).resolves.toEqual([
       'file-2.bin',
@@ -89,7 +89,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 1_500 });
 
-    await outputFile(config, undefined, 'next.json');
+    await evictOutputFiles(config, undefined);
 
     await expect(sortedEntries(outputDir)).resolves.toEqual(['report-2.json']);
   });
@@ -105,7 +105,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
 
-    await outputFile(config, undefined, 'next.png');
+    await evictOutputFiles(config, undefined);
 
     await expect(sortedEntries(outputDir)).resolves.toEqual([
       'screenshot-2.png',
@@ -126,7 +126,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 0 });
 
-    await outputFile(config, undefined, 'next.png');
+    await evictOutputFiles(config, undefined);
 
     await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}100`, 'trace.zip'))).resolves.toBe(false);
     await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`, 'trace.zip'))).resolves.toBe(true);
@@ -146,7 +146,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 0 });
 
-    await outputFile(config, undefined, 'next.json');
+    await evictOutputFiles(config, undefined);
 
     // Eviction triggered by either session must not delete the other's log.
     await expect(fileExists(path.join(sessionA, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
@@ -170,7 +170,7 @@ describe('outputMaxSize', () => {
 
     const config = await resolveConfig({ outputMaxSize: 0 });
 
-    await outputFile(config, undefined, 'next.png');
+    await evictOutputFiles(config, undefined);
 
     await expect(fileExists(path.join(sessionDir, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
     await expect(fileExists(path.join(sessionDir, '001.snapshot.yml'))).resolves.toBe(true);
@@ -187,15 +187,14 @@ describe('outputMaxSize', () => {
     await expect(fileExists(outputDir)).resolves.toBe(false);
   });
 
-  it('evicts an oversize previous artifact before returning the next path', async () => {
+  it('evicts the oldest artifacts until the directory is back under the limit', async () => {
     const outputDir = await createOutputDir();
-    const config = await resolveConfig({ outputDir, outputMaxSize: 100 });
+    const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
 
-    const firstFile = await outputFile(config, undefined, 'page-1.png');
-    await writeSizedFile(firstFile, 1_000, Date.now() - 1_000);
+    await writeSizedFile(path.join(outputDir, 'page-1.png'), 1_000, Date.now() - 1_000);
+    await writeSizedFile(path.join(outputDir, 'page-2.png'), 1_000, Date.now());
 
-    const secondFile = await outputFile(config, undefined, 'page-2.png');
-    await writeSizedFile(secondFile, 1_000, Date.now());
+    await evictOutputFiles(config, undefined);
 
     await expect(sortedEntries(outputDir)).resolves.toEqual(['page-2.png']);
   });
@@ -218,44 +217,52 @@ describe('outputMaxSize', () => {
     await writeSizedFile(path.join(outputRoot, 'old-2', 'artifact.bin'), 1_000, baseTime + 1);
 
     const config = await resolveConfig({ outputMaxSize: 500 });
-    const nextFile = await outputFile(config, undefined, 'next.bin');
+    await evictOutputFiles(config, undefined);
 
-    expect(nextFile.startsWith(outputRoot + path.sep)).toBe(true);
+    // Eviction sees siblings under the stable temp root, not just a fresh dir.
     await expect(fileExists(path.join(outputRoot, 'old-1', 'artifact.bin'))).resolves.toBe(false);
     await expect(fileExists(path.join(outputRoot, 'old-2', 'artifact.bin'))).resolves.toBe(false);
+
+    // New output paths are still allocated under that same stable temp root.
+    const nextFile = await outputFile(config, undefined, 'next.bin');
+    expect(nextFile.startsWith(outputRoot + path.sep)).toBe(true);
   });
 
-  it('does not evict artifacts while a tool is still producing its response', async () => {
-    const outputDir = await createOutputDir();
-    const config = await resolveConfig({ outputDir, outputMaxSize: 100 });
-    const context = new Context({
-      tools: [],
-      config,
-      browserContextFactory: {} as any,
-      sessionLog: undefined,
-      clientInfo: { name: 'test', version: '1.0.0', rootPath: undefined },
-    });
+  it('evicts only when globally idle and serializes eviction before tool bodies run', async () => {
+    const tick = () => new Promise(resolve => setImmediate(resolve));
+    const evictions: string[] = [];
+    const events: string[] = [];
 
-    const firstToken = context.setRunningTool('test_tool');
-    try {
-      const firstFile = await context.outputFile('issue-screenshot.png');
-      await writeSizedFile(firstFile, 1_000, Date.now() - 1_000);
+    // The first (outer) tool's eviction is slow: it blocks until released.
+    let releaseOuterEviction: () => void = () => {};
+    const outerEviction = new Promise<void>(resolve => { releaseOuterEviction = resolve; });
 
-      // A second, overlapping tool starts and finishes before the first one.
-      // Clearing it by token must not end the still-running first tool.
-      const secondToken = context.setRunningTool('overlapping_tool');
-      context.clearRunningTool(secondToken);
-      expect(context.isRunningTool()).toBe(true);
+    const outer = outputEvictionGate.run(
+        async () => { evictions.push('outer'); await outerEviction; },
+        async () => { events.push('outer-body'); },
+    );
+    await tick();
+    // The outer eviction started (it was globally idle) but its body is still
+    // waiting on that eviction to finish.
+    expect(evictions).toEqual(['outer']);
+    expect(events).toEqual([]);
 
-      const secondFile = await context.outputFile('report.json');
-      await writeSizedFile(secondFile, 1_000, Date.now());
+    // A second tool overlaps while the outer eviction is still running.
+    const inner = outputEvictionGate.run(
+        async () => { evictions.push('inner'); },
+        async () => { events.push('inner-body'); },
+    );
+    await tick();
+    // It must not evict (not globally idle) and must not start writing until the
+    // in-flight eviction has finished.
+    expect(evictions).toEqual(['outer']);
+    expect(events).toEqual([]);
 
-      await expect(fileExists(firstFile)).resolves.toBe(true);
-      await expect(fileExists(secondFile)).resolves.toBe(true);
-    } finally {
-      context.clearRunningTool(firstToken);
-      await context.dispose();
-    }
+    releaseOuterEviction();
+    await Promise.all([outer, inner]);
+
+    expect(evictions).toEqual(['outer']);
+    expect(events).toEqual(['outer-body', 'inner-body']);
   });
 
   it('reports its active session log folder as a protected output dir', async () => {

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -161,7 +161,7 @@ describe('outputMaxSize', () => {
   it('preserves the active session log folder nested under the default temp root', async () => {
     const tempRoot = await createOutputDir();
     vi.stubEnv('TMPDIR', tempRoot);
-    const outputRoot = path.join(tempRoot, 'playwright-mcp-output');
+    const outputRoot = path.join(tempRoot, 'playwright-mcp-output', String(process.pid));
     const baseTime = Date.now() - 10_000;
 
     // In default mode each call nests under a timestamped fallback dir, so the
@@ -233,7 +233,7 @@ describe('outputMaxSize', () => {
   it('uses the stable temp output root when evicting fallback output', async () => {
     const tempRoot = await createOutputDir();
     vi.stubEnv('TMPDIR', tempRoot);
-    const outputRoot = path.join(tempRoot, 'playwright-mcp-output');
+    const outputRoot = path.join(tempRoot, 'playwright-mcp-output', String(process.pid));
     const baseTime = Date.now() - 10_000;
 
     await writeSizedFile(path.join(outputRoot, 'old-1', 'artifact.bin'), 1_000, baseTime);

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -63,7 +63,9 @@ describe('outputMaxSize', () => {
     await writeSizedFile(path.join(outputDir, 'session-1', '001.snapshot.yml'), 1_000, baseTime - 1);
     setProtectedOutputDirsProvider(() => [path.join(outputDir, 'session-1')]);
 
-    const config = await resolveConfig({ outputDir, outputMaxSize: 3_000 });
+    // Limit 5 KB with the 2 KB session folder counted: only 3 KB of the five
+    // 1 KB files may remain, so the two oldest are evicted.
+    const config = await resolveConfig({ outputDir, outputMaxSize: 5_000 });
 
     await evictOutputFiles(config, undefined);
 
@@ -103,7 +105,9 @@ describe('outputMaxSize', () => {
     await writeSizedFile(path.join(outputDir, 'screenshot-2.png'), 1_000, baseTime + 2);
     setProtectedOutputDirsProvider(() => [path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`)]);
 
-    const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
+    // Limit 2 KB with the 1 KB trace folder counted leaves room for one
+    // screenshot, so only the oldest screenshot is evicted.
+    const config = await resolveConfig({ outputDir, outputMaxSize: 2_000 });
 
     await evictOutputFiles(config, undefined);
 
@@ -177,6 +181,25 @@ describe('outputMaxSize', () => {
     await expect(fileExists(path.join(outputRoot, '2025-01-01T00-00-00', 'old.png'))).resolves.toBe(false);
   });
 
+  it('counts protected bytes toward the budget and still evicts what it can', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    const sessionDir = path.join(outputDir, `${SESSION_LOG_FOLDER_PREFIX}1`);
+    await writeSizedFile(path.join(sessionDir, SESSION_LOG_FILE_NAME), 2_000, baseTime);
+    await writeSizedFile(path.join(outputDir, 'report.json'), 1_000, baseTime + 1);
+    setProtectedOutputDirsProvider(() => [sessionDir]);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
+
+    await evictOutputFiles(config, undefined);
+
+    // The protected 2 KB counts toward the 1 KB cap, so the evictable report is
+    // removed even though the evictable bytes alone were within the limit.
+    await expect(fileExists(path.join(outputDir, 'report.json'))).resolves.toBe(false);
+    await expect(fileExists(path.join(sessionDir, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
+  });
+
   it('does not create the output directory when no size limit is configured', async () => {
     const tempRoot = await createOutputDir();
     const outputDir = path.join(tempRoot, 'unused-output');
@@ -241,25 +264,30 @@ describe('outputMaxSize', () => {
         async () => { evictions.push('outer'); await outerEviction; },
         async () => { events.push('outer-body'); },
     );
-    await tick();
-    // The outer eviction started (it was globally idle) but its body is still
-    // waiting on that eviction to finish.
-    expect(evictions).toEqual(['outer']);
-    expect(events).toEqual([]);
+    let inner: Promise<void> | undefined;
+    try {
+      await tick();
+      // The outer eviction started (it was globally idle) but its body is still
+      // waiting on that eviction to finish.
+      expect(evictions).toEqual(['outer']);
+      expect(events).toEqual([]);
 
-    // A second tool overlaps while the outer eviction is still running.
-    const inner = outputEvictionGate.run(
-        async () => { evictions.push('inner'); },
-        async () => { events.push('inner-body'); },
-    );
-    await tick();
-    // It must not evict (not globally idle) and must not start writing until the
-    // in-flight eviction has finished.
-    expect(evictions).toEqual(['outer']);
-    expect(events).toEqual([]);
-
-    releaseOuterEviction();
-    await Promise.all([outer, inner]);
+      // A second tool overlaps while the outer eviction is still running.
+      inner = outputEvictionGate.run(
+          async () => { evictions.push('inner'); },
+          async () => { events.push('inner-body'); },
+      );
+      await tick();
+      // It must not evict (not globally idle) and must not start writing until
+      // the in-flight eviction has finished.
+      expect(evictions).toEqual(['outer']);
+      expect(events).toEqual([]);
+    } finally {
+      // Always release the shared gate so a failed assertion can't leave it
+      // stuck pending and pollute later tests.
+      releaseOuterEviction();
+      await Promise.all([outer, inner]);
+    }
 
     expect(evictions).toEqual(['outer']);
     expect(events).toEqual(['outer-body', 'inner-body']);

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -18,9 +18,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { OUTPUT_TRACE_FOLDER_PREFIX, outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
+import { OUTPUT_TRACE_FOLDER_PREFIX, evictOutputFiles, outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
 import { Context } from '../src/context.js';
-import { SESSION_LOG_FILE_NAME } from '../src/sessionLogConstants.js';
+import { SESSION_LOG_FILE_NAME, SESSION_LOG_FOLDER_PREFIX } from '../src/sessionLogConstants.js';
 
 const tempDirs: string[] = [];
 
@@ -110,6 +110,54 @@ describe('outputMaxSize', () => {
     await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`, 'trace.zip'))).resolves.toBe(true);
   });
 
+  it('evicts closed trace folders while keeping the active one', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    // An older, closed trace folder and the active (newest) one.
+    await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}100`, 'trace.zip'), 1_000, baseTime);
+    await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`, 'trace.zip'), 1_000, baseTime + 5_000);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 0 });
+
+    await outputFile(config, undefined, 'next.png');
+
+    await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}100`, 'trace.zip'))).resolves.toBe(false);
+    await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`, 'trace.zip'))).resolves.toBe(true);
+  });
+
+  it('preserves the active session log folder nested under the default temp root', async () => {
+    const tempRoot = await createOutputDir();
+    vi.stubEnv('TMPDIR', tempRoot);
+    const outputRoot = path.join(tempRoot, 'playwright-mcp-output');
+    const baseTime = Date.now() - 10_000;
+
+    // In default mode each call nests under a timestamped fallback dir, so the
+    // live session folder is not an immediate child of the eviction root.
+    const sessionDir = path.join(outputRoot, '2026-01-01T00-00-00', `${SESSION_LOG_FOLDER_PREFIX}500`);
+    await writeSizedFile(path.join(sessionDir, SESSION_LOG_FILE_NAME), 1_000, baseTime);
+    await writeSizedFile(path.join(sessionDir, '001.snapshot.yml'), 1_000, baseTime);
+    await writeSizedFile(path.join(outputRoot, '2025-01-01T00-00-00', 'old.png'), 1_000, baseTime - 1_000);
+
+    const config = await resolveConfig({ outputMaxSize: 0 });
+
+    await outputFile(config, undefined, 'next.png');
+
+    await expect(fileExists(path.join(sessionDir, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
+    await expect(fileExists(path.join(sessionDir, '001.snapshot.yml'))).resolves.toBe(true);
+    await expect(fileExists(path.join(outputRoot, '2025-01-01T00-00-00', 'old.png'))).resolves.toBe(false);
+  });
+
+  it('does not create the output directory when no size limit is configured', async () => {
+    const tempRoot = await createOutputDir();
+    const outputDir = path.join(tempRoot, 'unused-output');
+
+    const config = await resolveConfig({ outputDir });
+    await evictOutputFiles(config, undefined);
+
+    await expect(fileExists(outputDir)).resolves.toBe(false);
+  });
+
   it('evicts an oversize previous artifact before returning the next path', async () => {
     const outputDir = await createOutputDir();
     const config = await resolveConfig({ outputDir, outputMaxSize: 100 });
@@ -159,20 +207,24 @@ describe('outputMaxSize', () => {
       clientInfo: { name: 'test', version: '1.0.0', rootPath: undefined },
     });
 
+    const firstToken = context.setRunningTool('test_tool');
     try {
-      context.setRunningTool('test_tool');
       const firstFile = await context.outputFile('issue-screenshot.png');
       await writeSizedFile(firstFile, 1_000, Date.now() - 1_000);
 
-      context.setRunningTool('overlapping_tool');
-      context.setRunningTool(undefined);
+      // A second, overlapping tool starts and finishes before the first one.
+      // Clearing it by token must not end the still-running first tool.
+      const secondToken = context.setRunningTool('overlapping_tool');
+      context.clearRunningTool(secondToken);
+      expect(context.isRunningTool()).toBe(true);
+
       const secondFile = await context.outputFile('report.json');
       await writeSizedFile(secondFile, 1_000, Date.now());
 
       await expect(fileExists(firstFile)).resolves.toBe(true);
       await expect(fileExists(secondFile)).resolves.toBe(true);
     } finally {
-      context.setRunningTool(undefined);
+      context.clearRunningTool(firstToken);
       await context.dispose();
     }
   });

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -18,7 +18,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
+import { OUTPUT_TRACE_FOLDER_PREFIX, outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
 import { Context } from '../src/context.js';
 import { SESSION_LOG_FILE_NAME } from '../src/sessionLogConstants.js';
 
@@ -72,6 +72,42 @@ describe('outputMaxSize', () => {
     ]);
     await expect(fileExists(path.join(outputDir, 'session-1', SESSION_LOG_FILE_NAME))).resolves.toBe(true);
     await expect(fileExists(path.join(outputDir, 'session-1', '001.snapshot.yml'))).resolves.toBe(true);
+  });
+
+  it('evicts a stray session.md file at the output root instead of protecting the whole tree', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    // A normal artifact/download that happens to be named session.md must not
+    // mark the entire output directory as a protected session-log folder.
+    await writeSizedFile(path.join(outputDir, SESSION_LOG_FILE_NAME), 1_000, baseTime);
+    await writeSizedFile(path.join(outputDir, 'report-1.json'), 1_000, baseTime + 1);
+    await writeSizedFile(path.join(outputDir, 'report-2.json'), 1_000, baseTime + 2);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 1_500 });
+
+    await outputFile(config, undefined, 'next.json');
+
+    await expect(sortedEntries(outputDir)).resolves.toEqual(['report-2.json']);
+  });
+
+  it('preserves trace folders for the active session', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`, 'trace.zip'), 1_000, baseTime);
+    await writeSizedFile(path.join(outputDir, 'screenshot-1.png'), 1_000, baseTime + 1);
+    await writeSizedFile(path.join(outputDir, 'screenshot-2.png'), 1_000, baseTime + 2);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
+
+    await outputFile(config, undefined, 'next.png');
+
+    await expect(sortedEntries(outputDir)).resolves.toEqual([
+      'screenshot-2.png',
+      `${OUTPUT_TRACE_FOLDER_PREFIX}123`,
+    ]);
+    await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`, 'trace.zip'))).resolves.toBe(true);
   });
 
   it('evicts an oversize previous artifact before returning the next path', async () => {

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -18,8 +18,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { OUTPUT_TRACE_FOLDER_PREFIX, evictOutputFiles, outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
+import { OUTPUT_TRACE_FOLDER_PREFIX, evictOutputFiles, outputFile, resolveCLIConfig, resolveConfig, setProtectedOutputDirsProvider } from '../src/config.js';
 import { Context } from '../src/context.js';
+import { SessionLog } from '../src/sessionLog.js';
 import { SESSION_LOG_FILE_NAME, SESSION_LOG_FOLDER_PREFIX } from '../src/sessionLogConstants.js';
 
 const tempDirs: string[] = [];
@@ -47,6 +48,7 @@ async function sortedEntries(dir: string): Promise<string[]> {
 
 afterEach(async () => {
   vi.unstubAllEnvs();
+  setProtectedOutputDirsProvider(() => []);
   await Promise.all(tempDirs.splice(0).map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
 });
 
@@ -59,6 +61,7 @@ describe('outputMaxSize', () => {
       await writeSizedFile(path.join(outputDir, `file-${i}.bin`), 1_000, baseTime + i);
     await writeSizedFile(path.join(outputDir, 'session-1', SESSION_LOG_FILE_NAME), 1_000, baseTime - 1);
     await writeSizedFile(path.join(outputDir, 'session-1', '001.snapshot.yml'), 1_000, baseTime - 1);
+    setProtectedOutputDirsProvider(() => [path.join(outputDir, 'session-1')]);
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 3_000 });
 
@@ -98,6 +101,7 @@ describe('outputMaxSize', () => {
     await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`, 'trace.zip'), 1_000, baseTime);
     await writeSizedFile(path.join(outputDir, 'screenshot-1.png'), 1_000, baseTime + 1);
     await writeSizedFile(path.join(outputDir, 'screenshot-2.png'), 1_000, baseTime + 2);
+    setProtectedOutputDirsProvider(() => [path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}123`)]);
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 1_000 });
 
@@ -114,9 +118,11 @@ describe('outputMaxSize', () => {
     const outputDir = await createOutputDir();
     const baseTime = Date.now() - 10_000;
 
-    // An older, closed trace folder and the active (newest) one.
+    // An older, closed trace folder and the active one (only the active folder
+    // is reported as live).
     await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}100`, 'trace.zip'), 1_000, baseTime);
     await writeSizedFile(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`, 'trace.zip'), 1_000, baseTime + 5_000);
+    setProtectedOutputDirsProvider(() => [path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`)]);
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 0 });
 
@@ -124,6 +130,28 @@ describe('outputMaxSize', () => {
 
     await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}100`, 'trace.zip'))).resolves.toBe(false);
     await expect(fileExists(path.join(outputDir, `${OUTPUT_TRACE_FOLDER_PREFIX}200`, 'trace.zip'))).resolves.toBe(true);
+  });
+
+  it('preserves every live session folder when concurrent sessions share an output dir', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    // Two concurrent HTTP sessions, each with its own active session-log folder.
+    const sessionA = path.join(outputDir, `${SESSION_LOG_FOLDER_PREFIX}100`);
+    const sessionB = path.join(outputDir, `${SESSION_LOG_FOLDER_PREFIX}200`);
+    await writeSizedFile(path.join(sessionA, SESSION_LOG_FILE_NAME), 1_000, baseTime);
+    await writeSizedFile(path.join(sessionB, SESSION_LOG_FILE_NAME), 1_000, baseTime + 5_000);
+    await writeSizedFile(path.join(outputDir, 'old-report.json'), 1_000, baseTime - 1_000);
+    setProtectedOutputDirsProvider(() => [sessionA, sessionB]);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 0 });
+
+    await outputFile(config, undefined, 'next.json');
+
+    // Eviction triggered by either session must not delete the other's log.
+    await expect(fileExists(path.join(sessionA, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
+    await expect(fileExists(path.join(sessionB, SESSION_LOG_FILE_NAME))).resolves.toBe(true);
+    await expect(fileExists(path.join(outputDir, 'old-report.json'))).resolves.toBe(false);
   });
 
   it('preserves the active session log folder nested under the default temp root', async () => {
@@ -138,6 +166,7 @@ describe('outputMaxSize', () => {
     await writeSizedFile(path.join(sessionDir, SESSION_LOG_FILE_NAME), 1_000, baseTime);
     await writeSizedFile(path.join(sessionDir, '001.snapshot.yml'), 1_000, baseTime);
     await writeSizedFile(path.join(outputRoot, '2025-01-01T00-00-00', 'old.png'), 1_000, baseTime - 1_000);
+    setProtectedOutputDirsProvider(() => [sessionDir]);
 
     const config = await resolveConfig({ outputMaxSize: 0 });
 
@@ -226,6 +255,33 @@ describe('outputMaxSize', () => {
     } finally {
       context.clearRunningTool(firstToken);
       await context.dispose();
+    }
+  });
+
+  it('reports its active session log folder as a protected output dir', async () => {
+    const outputDir = await createOutputDir();
+    const sessionFolder = path.join(outputDir, `${SESSION_LOG_FOLDER_PREFIX}999`);
+    const withSession = new Context({
+      tools: [],
+      config: {} as any,
+      browserContextFactory: {} as any,
+      sessionLog: new SessionLog(sessionFolder),
+      clientInfo: { name: 'test', version: '1.0.0', rootPath: undefined },
+    });
+    const withoutSession = new Context({
+      tools: [],
+      config: {} as any,
+      browserContextFactory: {} as any,
+      sessionLog: undefined,
+      clientInfo: { name: 'test', version: '1.0.0', rootPath: undefined },
+    });
+
+    try {
+      expect(withSession.protectedOutputDirs()).toContain(sessionFolder);
+      expect(withoutSession.protectedOutputDirs()).toEqual([]);
+    } finally {
+      await withSession.dispose();
+      await withoutSession.dispose();
     }
   });
 });

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { outputFile, resolveConfig } from '../src/config.js';
+
+const tempDirs: string[] = [];
+
+async function createOutputDir(): Promise<string> {
+  const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-output-max-size-'));
+  tempDirs.push(outputDir);
+  return outputDir;
+}
+
+async function writeSizedFile(filePath: string, size: number, mtimeMs: number) {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.writeFile(filePath, Buffer.alloc(size, 'x'));
+  const mtime = new Date(mtimeMs);
+  await fs.promises.utimes(filePath, mtime, mtime);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  return fs.promises.access(filePath).then(() => true, () => false);
+}
+
+async function sortedEntries(dir: string): Promise<string[]> {
+  return (await fs.promises.readdir(dir)).sort();
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
+});
+
+describe('outputMaxSize', () => {
+  it('evicts the oldest evictable files and keeps session logs', async () => {
+    const outputDir = await createOutputDir();
+    const baseTime = Date.now() - 10_000;
+
+    for (let i = 0; i < 5; i++)
+      await writeSizedFile(path.join(outputDir, `file-${i}.bin`), 1_000, baseTime + i);
+    await writeSizedFile(path.join(outputDir, 'session-1', 'session.md'), 1_000, baseTime - 1);
+
+    const config = await resolveConfig({ outputDir, outputMaxSize: 3_000 });
+
+    await expect(outputFile(config, undefined, 'next.bin')).resolves.toBe(path.join(outputDir, 'next.bin'));
+
+    await expect(sortedEntries(outputDir)).resolves.toEqual([
+      'file-2.bin',
+      'file-3.bin',
+      'file-4.bin',
+      'session-1',
+    ]);
+    await expect(fileExists(path.join(outputDir, 'session-1', 'session.md'))).resolves.toBe(true);
+  });
+
+  it('evicts an oversize previous artifact before returning the next path', async () => {
+    const outputDir = await createOutputDir();
+    const config = await resolveConfig({ outputDir, outputMaxSize: 100 });
+
+    const firstFile = await outputFile(config, undefined, 'page-1.png');
+    await writeSizedFile(firstFile, 1_000, Date.now() - 1_000);
+
+    const secondFile = await outputFile(config, undefined, 'page-2.png');
+    await writeSizedFile(secondFile, 1_000, Date.now());
+
+    await expect(sortedEntries(outputDir)).resolves.toEqual(['page-2.png']);
+  });
+});

--- a/tests/output-max-size.test.ts
+++ b/tests/output-max-size.test.ts
@@ -17,8 +17,10 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { outputFile, resolveConfig } from '../src/config.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { outputFile, resolveCLIConfig, resolveConfig } from '../src/config.js';
+import { Context } from '../src/context.js';
+import { SESSION_LOG_FILE_NAME } from '../src/sessionLogConstants.js';
 
 const tempDirs: string[] = [];
 
@@ -44,17 +46,19 @@ async function sortedEntries(dir: string): Promise<string[]> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(tempDirs.splice(0).map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
 });
 
 describe('outputMaxSize', () => {
-  it('evicts the oldest evictable files and keeps session logs', async () => {
+  it('evicts the oldest evictable files and keeps session log folders', async () => {
     const outputDir = await createOutputDir();
     const baseTime = Date.now() - 10_000;
 
     for (let i = 0; i < 5; i++)
       await writeSizedFile(path.join(outputDir, `file-${i}.bin`), 1_000, baseTime + i);
-    await writeSizedFile(path.join(outputDir, 'session-1', 'session.md'), 1_000, baseTime - 1);
+    await writeSizedFile(path.join(outputDir, 'session-1', SESSION_LOG_FILE_NAME), 1_000, baseTime - 1);
+    await writeSizedFile(path.join(outputDir, 'session-1', '001.snapshot.yml'), 1_000, baseTime - 1);
 
     const config = await resolveConfig({ outputDir, outputMaxSize: 3_000 });
 
@@ -66,7 +70,8 @@ describe('outputMaxSize', () => {
       'file-4.bin',
       'session-1',
     ]);
-    await expect(fileExists(path.join(outputDir, 'session-1', 'session.md'))).resolves.toBe(true);
+    await expect(fileExists(path.join(outputDir, 'session-1', SESSION_LOG_FILE_NAME))).resolves.toBe(true);
+    await expect(fileExists(path.join(outputDir, 'session-1', '001.snapshot.yml'))).resolves.toBe(true);
   });
 
   it('evicts an oversize previous artifact before returning the next path', async () => {
@@ -80,5 +85,59 @@ describe('outputMaxSize', () => {
     await writeSizedFile(secondFile, 1_000, Date.now());
 
     await expect(sortedEntries(outputDir)).resolves.toEqual(['page-2.png']);
+  });
+
+  it('rejects invalid outputMaxSize values from config and CLI/env sources', async () => {
+    await expect(resolveConfig({ outputMaxSize: -1 })).rejects.toThrow('outputMaxSize must be a non-negative number');
+    await expect(resolveCLIConfig({ outputMaxSize: Number.NaN })).rejects.toThrow('outputMaxSize must be a non-negative number');
+
+    vi.stubEnv('PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE', 'not-a-number');
+    await expect(resolveCLIConfig({})).rejects.toThrow('outputMaxSize must be a non-negative number');
+  });
+
+  it('uses the stable temp output root when evicting fallback output', async () => {
+    const tempRoot = await createOutputDir();
+    vi.stubEnv('TMPDIR', tempRoot);
+    const outputRoot = path.join(tempRoot, 'playwright-mcp-output');
+    const baseTime = Date.now() - 10_000;
+
+    await writeSizedFile(path.join(outputRoot, 'old-1', 'artifact.bin'), 1_000, baseTime);
+    await writeSizedFile(path.join(outputRoot, 'old-2', 'artifact.bin'), 1_000, baseTime + 1);
+
+    const config = await resolveConfig({ outputMaxSize: 500 });
+    const nextFile = await outputFile(config, undefined, 'next.bin');
+
+    expect(nextFile.startsWith(outputRoot + path.sep)).toBe(true);
+    await expect(fileExists(path.join(outputRoot, 'old-1', 'artifact.bin'))).resolves.toBe(false);
+    await expect(fileExists(path.join(outputRoot, 'old-2', 'artifact.bin'))).resolves.toBe(false);
+  });
+
+  it('does not evict artifacts while a tool is still producing its response', async () => {
+    const outputDir = await createOutputDir();
+    const config = await resolveConfig({ outputDir, outputMaxSize: 100 });
+    const context = new Context({
+      tools: [],
+      config,
+      browserContextFactory: {} as any,
+      sessionLog: undefined,
+      clientInfo: { name: 'test', version: '1.0.0', rootPath: undefined },
+    });
+
+    try {
+      context.setRunningTool('test_tool');
+      const firstFile = await context.outputFile('issue-screenshot.png');
+      await writeSizedFile(firstFile, 1_000, Date.now() - 1_000);
+
+      context.setRunningTool('overlapping_tool');
+      context.setRunningTool(undefined);
+      const secondFile = await context.outputFile('report.json');
+      await writeSizedFile(secondFile, 1_000, Date.now());
+
+      await expect(fileExists(firstFile)).resolves.toBe(true);
+      await expect(fileExists(secondFile)).resolves.toBe(true);
+    } finally {
+      context.setRunningTool(undefined);
+      await context.dispose();
+    }
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `outputMaxSize` to cap total generated output size, configurable via CLI and environment variables.
  * Added eviction protection that preserves live session logs, active trace outputs, and pending download outputs.

* **Bug Fixes**
  * Prevented output eviction from interfering with in-progress tool execution, ensuring active artifacts aren’t removed.
  * Improved trace/session output handling so eviction can correctly account for protected bytes and files.

* **Documentation**
  * Updated README with `outputMaxSize` and the corresponding CLI flags.

* **Tests**
  * Expanded coverage for eviction ordering, protection rules, invalid inputs, and no-op behavior when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Solves https://github.com/JustasMonkev/mcp-accessibility-scanner/issues/94