### PR TITLE
feat: add scale option to browser_take_screenshot (mirror upstream Playwright MCP #41465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ Evaluate a JavaScript expression on the page, or on a specific element when a `r
 
 #### `browser_take_screenshot`
 Take a screenshot of the current page.
-- Parameters: `filename` (optional), `type` (`png` or `jpeg`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
+- Parameters: `filename` (optional), `type` (`png` or `jpeg`), `scale` (`css` or `device`, default `css`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
+- `scale: device` captures a high-resolution screenshot using device pixels (accounts for the device pixel ratio); `scale: css` keeps the image sized in CSS pixels.
 
 #### `browser_pdf_save`
 Save page as PDF.

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -24,6 +24,7 @@ import type * as playwright from 'playwright';
 
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
+  scale: z.enum(['css', 'device']).default('css').describe(`Image resolution scale. 'css' produces a screenshot sized in CSS pixels (smaller, consistent across devices). 'device' produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.`),
   filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
@@ -56,7 +57,7 @@ const screenshot = defineTabTool({
     const options: playwright.PageScreenshotOptions = {
       type: fileType,
       quality: fileType === 'png' ? undefined : 90,
-      scale: 'css',
+      scale: params.scale,
       path: fileName,
       ...(params.fullPage !== undefined && { fullPage: params.fullPage })
     };

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import screenshotTools from '../src/tools/screenshot.js';
+import { Response } from '../src/response.js';
+import type { Context } from '../src/context.js';
+
+describe('Screenshot Tools', () => {
+  const screenshotTool = screenshotTools.find(t => t.schema.name === 'browser_take_screenshot')!;
+
+  let mockContext: Context;
+  let mockTab: any;
+  let mockPage: any;
+  let response: Response;
+
+  beforeEach(() => {
+    mockPage = {
+      url: () => 'https://example.com',
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-image')),
+    };
+
+    mockTab = {
+      page: mockPage,
+      context: { outputFile: vi.fn().mockResolvedValue('/out/page.png') },
+      modalStates: () => [],
+    };
+
+    mockContext = {
+      currentTabOrDie: () => mockTab,
+    } as any;
+
+    response = new Response(mockContext, 'browser_take_screenshot', {});
+  });
+
+  it('should exist with the expected schema', () => {
+    expect(screenshotTool).toBeDefined();
+    expect(screenshotTool.schema.name).toBe('browser_take_screenshot');
+    expect(screenshotTool.schema.type).toBe('readOnly');
+  });
+
+  it('should expose a scale option defaulting to css', () => {
+    const params = screenshotTool.schema.inputSchema.parse({});
+    expect(params.scale).toBe('css');
+  });
+
+  it('should reject an invalid scale value', () => {
+    expect(() => screenshotTool.schema.inputSchema.parse({ scale: 'retina' })).toThrow();
+  });
+
+  it('should default the screenshot to css scale', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({});
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ scale: 'css' }));
+  });
+
+  it('should pass device scale through to page.screenshot', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ scale: 'device' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ scale: 'device' }));
+  });
+});


### PR DESCRIPTION
## Upstream reference

- Commit: [microsoft/playwright@2a7febde — "feat(mcp): add scale option to screenshot, --hires to playwright-cli (#41465)"](https://github.com/microsoft/playwright/commit/2a7febde)
- Touches upstream `packages/playwright-core/src/tools/backend/screenshot.ts` — the file this fork's `src/tools/screenshot.ts` is derived from.

_Detected by the upstream-monitoring routine. This is the first new MCP-backend change to land on `microsoft/playwright` main after PR #96 (data: URL truncation, #41450)._

## What changed upstream

Upstream #41465 adds a `scale` option to the MCP `browser_take_screenshot` tool, replacing the previously **hardcoded** `scale: 'css'` screenshot option:

- New tool param: `scale: 'css' | 'device'`, default `'css'`.
- `'css'` → image sized in CSS pixels (smaller, consistent across devices).
- `'device'` → high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio).
- The value is passed straight through to Playwright's `PageScreenshotOptions.scale`.

It also adds a `--hires` flag to the separate **`playwright-cli`** one-shot screenshot command (sets `scale: 'device'`).

## Why it matters here

This fork ships the same `browser_take_screenshot` tool, and `src/tools/screenshot.ts` had the identical hardcoded line:

```ts
const options: playwright.PageScreenshotOptions = {
  type: fileType,
  quality: fileType === 'png' ? undefined : 90,
  scale: 'css',          // <- hardcoded, no way to opt into device-pixel output
  path: fileName,
  ...
};
```

There was no way for a caller to request a high-DPI screenshot. For an accessibility-focused server this is genuinely useful — device-pixel captures preserve fine visual detail (small focus rings, low-contrast text, sub-pixel rendering) that matters when reviewing a page visually alongside the axe results.

## Implemented change (minimal, backward-compatible)

- `src/tools/screenshot.ts`: add a `scale` enum param (`'css' | 'device'`, default `'css'`) to the input schema and pass `params.scale` into `page.screenshot()`.
- `README.md`: document the new `scale` parameter under `browser_take_screenshot`.
- `tests/tools-screenshot.test.ts`: new focused Vitest coverage — schema defaults to `css`, rejects invalid values, and `device` flows through to `page.screenshot()`.

The default remains `'css'`, so **existing behavior is unchanged**; `device` is strictly opt-in.

### Not ported (and why)

The upstream `--hires` CLI flag targets the `playwright-cli` one-shot screenshot command, a surface this fork does not expose — its CLI is the MCP-server launcher (`cli.js` / `src/program.ts`), and `scale` is naturally a per-call tool parameter rather than a server-launch flag. Keeping scope to the tool schema, matching the existing ESM/TypeScript style.

## Testing

- `npx vitest run tests/tools-screenshot.test.ts` — 5 passed
- `npm test` — 288 passed, 2 skipped (no regressions)
- `npm run lint` (eslint + tsgo typecheck) — clean
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWiBoDdJNbBC6HkvmA1KcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWiBoDdJNbBC6HkvmA1KcL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional screenshot scale setting, letting screenshots use either CSS pixels or device pixels.
  * Improved element and full-page screenshot handling guidance in the tool docs.

* **Documentation**
  * Updated the README with clearer parameter details and default behavior for screenshot scaling.

* **Tests**
  * Added coverage for scale validation, default values, and screenshot option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->