### PR TITLE
feat: add browser_snapshot compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ Set default operation timeout for existing tabs.
 #### `browser_snapshot`
 Capture accessibility snapshot of the current page (better than screenshot for analysis).
 Large `data:` URL payloads in snapshot output are truncated to their media type prefix.
+- Parameters: `compress` (optional boolean, default false)
+  - When true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response after the first 10 examples.
+  - Use `browser_evaluate()` to retrieve the full uncompressed list when needed.
 
 #### `browser_click`
 Perform click on a web page element.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Set default operation timeout for existing tabs.
 Capture accessibility snapshot of the current page (better than screenshot for analysis).
 Large `data:` URL payloads in snapshot output are truncated to their media type prefix.
 - Parameters: `compress` (optional boolean, default false)
-  - When true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response after the first 10 examples.
+  - When true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response when a repeated structural pattern appears more than 100 times. The first 10 examples of each collapsed pattern are kept.
   - Use `browser_evaluate()` to retrieve the full uncompressed list when needed.
 
 #### `browser_click`

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,6 +19,7 @@ import { pathToFileURL } from 'node:url';
 import debug from 'debug';
 
 import { renderModalStates } from './tab.js';
+import { compressAriaSnapshot } from './utils/ariaCompression.js';
 import { truncateDataUrls } from './utils/dataUrl.js';
 
 import type { Tab, TabSnapshot } from './tab.js';
@@ -41,6 +42,7 @@ export class Response {
   private _resourceLinks: ResourceLink[] = [];
   private _context: Context;
   private _includeSnapshot = false;
+  private _includeSnapshotCompress: boolean | undefined;
   private _includeTabs = false;
   private _tabSnapshot: TabSnapshot | undefined;
   private _requestContext: CallToolRequestContext | undefined;
@@ -123,8 +125,9 @@ export class Response {
     return this._structuredContent;
   }
 
-  setIncludeSnapshot() {
+  setIncludeSnapshot(compress?: boolean) {
     this._includeSnapshot = true;
+    this._includeSnapshotCompress = compress;
   }
 
   setIncludeTabs() {
@@ -195,7 +198,7 @@ ${this._code.join('\n')}
       response.push(...renderModalStates(this._context, this._tabSnapshot.modalStates));
       response.push('');
     } else if (this._tabSnapshot) {
-      response.push(renderTabSnapshot(this._tabSnapshot));
+      response.push(renderTabSnapshot(this._tabSnapshot, { compress: this._includeSnapshotCompress }));
       response.push('');
     }
 
@@ -221,8 +224,9 @@ ${this._code.join('\n')}
   }
 }
 
-function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
+function renderTabSnapshot(tabSnapshot: TabSnapshot, options: { compress?: boolean } = {}): string {
   const lines: string[] = [];
+  const ariaSnapshot = options.compress ? compressAriaSnapshot(tabSnapshot.ariaSnapshot).output : tabSnapshot.ariaSnapshot;
 
   if (tabSnapshot.consoleMessages.length) {
     lines.push(`### New console messages`);
@@ -247,7 +251,7 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
   lines.push(`- Page Title: ${truncateDataUrls(tabSnapshot.title)}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
-  lines.push(truncateDataUrls(tabSnapshot.ariaSnapshot));
+  lines.push(truncateDataUrls(ariaSnapshot));
   lines.push('```');
 
   return lines.join('\n');

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -28,6 +28,10 @@ const scanPageSchema = z.object({
       .describe('Array of tags to filter violations by. If not specified, all violations are returned.')
 });
 
+const snapshotSchema = z.object({
+  compress: z.boolean().optional().describe('Collapse repeated non-interactive ARIA nodes in large snapshots. Keeps the first 10 examples of repeated structural patterns. Use browser_evaluate() to retrieve the full list if needed.'),
+});
+
 const scanPage = defineTool({
   capability: 'core',
   schema: {
@@ -67,13 +71,13 @@ const snapshot = defineTool({
     name: 'browser_snapshot',
     title: 'Page snapshot',
     description: 'Capture accessibility snapshot of the current page, this is better than screenshot',
-    inputSchema: z.object({}),
+    inputSchema: snapshotSchema,
     type: 'readOnly',
   },
 
   handle: async (context, params, response) => {
     await context.ensureTab();
-    response.setIncludeSnapshot();
+    response.setIncludeSnapshot(params.compress);
   },
 });
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -29,7 +29,7 @@ const scanPageSchema = z.object({
 });
 
 const snapshotSchema = z.object({
-  compress: z.boolean().optional().describe('Collapse repeated non-interactive ARIA nodes in large snapshots. Keeps the first 10 examples of repeated structural patterns. Use browser_evaluate() to retrieve the full list if needed.'),
+  compress: z.boolean().optional().describe('Collapse repeated non-interactive ARIA nodes in large snapshots when a repeated structural pattern appears more than 100 times. Keeps the first 10 examples of each collapsed pattern. Use browser_evaluate() to retrieve the full list if needed.'),
 });
 
 const scanPage = defineTool({

--- a/src/utils/ariaCompression.ts
+++ b/src/utils/ariaCompression.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const FIRE_THRESHOLD = 100;
 const KEEP_N = 10;
 
@@ -38,11 +54,23 @@ const PROTECTED_LINE_ROLES = new Set([
   'tab',
   'textbox',
   'tree',
+  'treegrid',
   'treeitem',
   'region',
 ]);
 const REF_PROTECTED_LINE_ROLES = new Set([
   'grid',
+  'gridcell',
+  'scrollbar',
+  'separator',
+  'treegrid',
+]);
+const REF_PROTECTED_DESCENDANT_ROLES = new Set([
+  'columnheader',
+  'gridcell',
+  'rowheader',
+  'scrollbar',
+  'separator',
 ]);
 const PROTECTED_SUBTREE_ROLES = new Set([
   'button',
@@ -161,8 +189,8 @@ function parseSnapshotLines(yaml: string): SnapshotLine[] {
       hasRef,
       signature: signature(text),
       selfHasProtectedLineRole: shouldKeepLine(role, hasRef),
-      containsProtectedSubtreeRole: shouldKeepSubtree(role),
-      selfHasProtectedSubtreeRole: shouldKeepSubtree(role),
+      containsProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef),
+      selfHasProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef),
       insideProtectedSubtree: false,
     };
   });
@@ -181,7 +209,7 @@ function parseSnapshotLines(yaml: string): SnapshotLine[] {
   }
 
   for (const line of lines) {
-    if (line.role === 'row' && line.hasRef && hasAncestorRole(lines, line, 'grid')) {
+    if (line.role === 'row' && line.hasRef && hasAncestorRole(lines, line, ROW_CONTAINER_ROLES)) {
       line.selfHasProtectedLineRole = true;
       line.containsProtectedSubtreeRole = true;
       line.selfHasProtectedSubtreeRole = true;
@@ -244,9 +272,16 @@ function shouldKeepSubtree(role: string | undefined): boolean {
   return role !== undefined && PROTECTED_SUBTREE_ROLES.has(role);
 }
 
-function hasAncestorRole(lines: SnapshotLine[], line: SnapshotLine, role: string): boolean {
+function shouldKeepRefProtectedDescendants(role: string | undefined, hasRef: boolean): boolean {
+  return role !== undefined && hasRef && REF_PROTECTED_DESCENDANT_ROLES.has(role);
+}
+
+const ROW_CONTAINER_ROLES = new Set(['grid', 'treegrid']);
+
+function hasAncestorRole(lines: SnapshotLine[], line: SnapshotLine, roles: Set<string>): boolean {
   for (let parentIndex = line.parentIndex; parentIndex !== -1; parentIndex = lines[parentIndex].parentIndex) {
-    if (lines[parentIndex].role === role)
+    const role = lines[parentIndex].role;
+    if (role !== undefined && roles.has(role))
       return true;
   }
   return false;

--- a/src/utils/ariaCompression.ts
+++ b/src/utils/ariaCompression.ts
@@ -1,0 +1,257 @@
+const FIRE_THRESHOLD = 100;
+const KEEP_N = 10;
+
+const KEEP_REF_ALL = /\[ref=[^\]]+\]/g;
+const HAS_REF = /\[ref=[^\]]+\]/;
+const ROLE_PREFIX_RE = /^\s*-\s*([a-z][a-z0-9-]*)\b/i;
+const PROTECTED_LINE_ROLES = new Set([
+  'alert',
+  'banner',
+  'button',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'dialog',
+  'form',
+  'grid',
+  'gridcell',
+  'heading',
+  'input',
+  'link',
+  'listbox',
+  'main',
+  'menu',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'navigation',
+  'option',
+  'radio',
+  'rowheader',
+  'search',
+  'searchbox',
+  'select',
+  'slider',
+  'spinbutton',
+  'status',
+  'switch',
+  'tab',
+  'textbox',
+  'tree',
+  'treeitem',
+  'region',
+]);
+const REF_PROTECTED_LINE_ROLES = new Set([
+  'grid',
+]);
+const PROTECTED_SUBTREE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'input',
+  'link',
+  'listbox',
+  'menu',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'select',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'tree',
+  'treeitem',
+]);
+
+type SnapshotLine = {
+  text: string;
+  indent: number;
+  parentIndex: number;
+  role: string | undefined;
+  hasRef: boolean;
+  signature: string;
+  selfHasProtectedLineRole: boolean;
+  containsProtectedSubtreeRole: boolean;
+  selfHasProtectedSubtreeRole: boolean;
+  insideProtectedSubtree: boolean;
+};
+
+export type CompressResult = {
+  output: string;
+  removed: number;
+};
+
+export function compressAriaSnapshot(yaml: string): CompressResult {
+  const lines = parseSnapshotLines(yaml);
+  const preCounts = new Map<string, number>();
+  for (const line of lines) {
+    if (!line.text.trim() || isProtectedLine(line))
+      continue;
+    const key = compressionKey(line);
+    preCounts.set(key, (preCounts.get(key) ?? 0) + 1);
+  }
+
+  let maxCount = 0;
+  for (const value of preCounts.values())
+    maxCount = Math.max(maxCount, value);
+
+  if (maxCount <= FIRE_THRESHOLD)
+    return { output: yaml, removed: 0 };
+
+  const sigCounts = new Map<string, number>();
+  const output: string[] = [];
+  let totalRemoved = 0;
+  let skipBelowIndent: number | undefined;
+
+  for (const line of lines) {
+    if (!line.text.trim()) {
+      if (skipBelowIndent === undefined)
+        output.push(line.text);
+      else
+        totalRemoved++;
+      continue;
+    }
+
+    if (skipBelowIndent !== undefined && line.indent <= skipBelowIndent)
+      skipBelowIndent = undefined;
+
+    if (skipBelowIndent !== undefined) {
+      totalRemoved++;
+      continue;
+    }
+
+    if (isProtectedLine(line)) {
+      output.push(line.text);
+      continue;
+    }
+
+    const key = compressionKey(line);
+    const lineCount = (sigCounts.get(key) ?? 0) + 1;
+    sigCounts.set(key, lineCount);
+
+    if (lineCount > KEEP_N && (preCounts.get(key) ?? 0) > FIRE_THRESHOLD) {
+      totalRemoved++;
+      skipBelowIndent = line.indent;
+    } else {
+      output.push(line.text);
+    }
+  }
+
+  if (totalRemoved === 0)
+    return { output: yaml, removed: 0 };
+
+  const note = `\n[playwright-compress: ${totalRemoved} repeated ARIA nodes collapsed - use browser_evaluate() to enumerate the full list]`;
+  return { output: output.join('\n') + note, removed: totalRemoved };
+}
+
+function parseSnapshotLines(yaml: string): SnapshotLine[] {
+  const lines = yaml.split('\n').map((text): SnapshotLine => {
+    const role = roleOf(text);
+    const hasRef = HAS_REF.test(text);
+    return {
+      text,
+      indent: indentOf(text),
+      parentIndex: -1,
+      role,
+      hasRef,
+      signature: signature(text),
+      selfHasProtectedLineRole: shouldKeepLine(role, hasRef),
+      containsProtectedSubtreeRole: shouldKeepSubtree(role),
+      selfHasProtectedSubtreeRole: shouldKeepSubtree(role),
+      insideProtectedSubtree: false,
+    };
+  });
+
+  const stack: number[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line.text.trim())
+      continue;
+
+    while (stack.length && lines[stack[stack.length - 1]].indent >= line.indent)
+      stack.pop();
+
+    line.parentIndex = stack[stack.length - 1] ?? -1;
+    stack.push(index);
+  }
+
+  for (const line of lines) {
+    if (line.role === 'row' && line.hasRef && hasAncestorRole(lines, line, 'grid')) {
+      line.selfHasProtectedLineRole = true;
+      line.containsProtectedSubtreeRole = true;
+      line.selfHasProtectedSubtreeRole = true;
+    }
+  }
+
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    if (!line.containsProtectedSubtreeRole || line.parentIndex === -1)
+      continue;
+    lines[line.parentIndex].containsProtectedSubtreeRole = true;
+  }
+
+  let protectedIndent: number | undefined;
+  for (const line of lines) {
+    if (!line.text.trim())
+      continue;
+
+    if (protectedIndent !== undefined && line.indent <= protectedIndent)
+      protectedIndent = undefined;
+
+    const insideProtectedSubtree = protectedIndent !== undefined;
+    if (insideProtectedSubtree)
+      line.insideProtectedSubtree = true;
+
+    if (!insideProtectedSubtree && line.selfHasProtectedSubtreeRole)
+      protectedIndent = line.indent;
+  }
+
+  return lines;
+}
+
+function isProtectedLine(line: SnapshotLine): boolean {
+  return line.selfHasProtectedLineRole || line.containsProtectedSubtreeRole || line.insideProtectedSubtree;
+}
+
+function compressionKey(line: SnapshotLine): string {
+  return `${line.parentIndex}:${line.indent}:${line.signature}`;
+}
+
+function signature(line: string): string {
+  let result = line.trimEnd().replace(KEEP_REF_ALL, '[ref=?]');
+  result = result.replace(/"[^"]*"/g, '""');
+  result = result.replace(/'[^']*'/g, "''");
+  result = result.replace(/\b\d+\b/g, 'N');
+  return result.trimStart().slice(0, 80);
+}
+
+function roleOf(line: string): string | undefined {
+  return ROLE_PREFIX_RE.exec(line)?.[1]?.toLowerCase();
+}
+
+function shouldKeepLine(role: string | undefined, hasRef: boolean): boolean {
+  if (role === undefined)
+    return false;
+  return PROTECTED_LINE_ROLES.has(role) || hasRef && REF_PROTECTED_LINE_ROLES.has(role);
+}
+
+function shouldKeepSubtree(role: string | undefined): boolean {
+  return role !== undefined && PROTECTED_SUBTREE_ROLES.has(role);
+}
+
+function hasAncestorRole(lines: SnapshotLine[], line: SnapshotLine, role: string): boolean {
+  for (let parentIndex = line.parentIndex; parentIndex !== -1; parentIndex = lines[parentIndex].parentIndex) {
+    if (lines[parentIndex].role === role)
+      return true;
+  }
+  return false;
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length;
+}

--- a/src/utils/ariaCompression.ts
+++ b/src/utils/ariaCompression.ts
@@ -19,6 +19,7 @@ const KEEP_N = 10;
 
 const KEEP_REF_ALL = /\[ref=[^\]]+\]/g;
 const HAS_REF = /\[ref=[^\]]+\]/;
+const HAS_CURSOR_POINTER = /\[cursor=pointer\]/;
 const ROLE_PREFIX_RE = /^\s*-\s*([a-z][a-z0-9-]*)\b/i;
 const PROTECTED_LINE_ROLES = new Set([
   'alert',
@@ -102,6 +103,7 @@ type SnapshotLine = {
   parentIndex: number;
   role: string | undefined;
   hasRef: boolean;
+  hasCursorPointer: boolean;
   signature: string;
   selfHasProtectedLineRole: boolean;
   containsProtectedSubtreeRole: boolean;
@@ -173,7 +175,7 @@ export function compressAriaSnapshot(yaml: string): CompressResult {
   if (totalRemoved === 0)
     return { output: yaml, removed: 0 };
 
-  const note = `\n[playwright-compress: ${totalRemoved} repeated ARIA nodes collapsed - use browser_evaluate() to enumerate the full list]`;
+  const note = `\n# playwright-compress: ${totalRemoved} repeated ARIA nodes collapsed - use browser_evaluate() to enumerate the full list`;
   return { output: output.join('\n') + note, removed: totalRemoved };
 }
 
@@ -181,16 +183,18 @@ function parseSnapshotLines(yaml: string): SnapshotLine[] {
   const lines = yaml.split('\n').map((text): SnapshotLine => {
     const role = roleOf(text);
     const hasRef = HAS_REF.test(text);
+    const hasCursorPointer = HAS_CURSOR_POINTER.test(text);
     return {
       text,
       indent: indentOf(text),
       parentIndex: -1,
       role,
       hasRef,
+      hasCursorPointer,
       signature: signature(text),
-      selfHasProtectedLineRole: shouldKeepLine(role, hasRef),
-      containsProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef),
-      selfHasProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef),
+      selfHasProtectedLineRole: shouldKeepLine(role, hasRef, hasCursorPointer),
+      containsProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef) || shouldKeepCursorPointerRef(hasRef, hasCursorPointer),
+      selfHasProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef) || shouldKeepCursorPointerRef(hasRef, hasCursorPointer),
       insideProtectedSubtree: false,
     };
   });
@@ -262,7 +266,9 @@ function roleOf(line: string): string | undefined {
   return ROLE_PREFIX_RE.exec(line)?.[1]?.toLowerCase();
 }
 
-function shouldKeepLine(role: string | undefined, hasRef: boolean): boolean {
+function shouldKeepLine(role: string | undefined, hasRef: boolean, hasCursorPointer: boolean): boolean {
+  if (shouldKeepCursorPointerRef(hasRef, hasCursorPointer))
+    return true;
   if (role === undefined)
     return false;
   return PROTECTED_LINE_ROLES.has(role) || hasRef && REF_PROTECTED_LINE_ROLES.has(role);
@@ -274,6 +280,10 @@ function shouldKeepSubtree(role: string | undefined): boolean {
 
 function shouldKeepRefProtectedDescendants(role: string | undefined, hasRef: boolean): boolean {
   return role !== undefined && hasRef && REF_PROTECTED_DESCENDANT_ROLES.has(role);
+}
+
+function shouldKeepCursorPointerRef(hasRef: boolean, hasCursorPointer: boolean): boolean {
+  return hasRef && hasCursorPointer;
 }
 
 const ROW_CONTAINER_ROLES = new Set(['grid', 'treegrid']);

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -402,6 +402,50 @@ describe('Response', () => {
       expect(textContent.text).toContain('Example Page');
     });
 
+    it('should compress rendered snapshot output when requested', async () => {
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com',
+        title: 'Example Page',
+        ariaSnapshot: repeatedListSnapshot(150),
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot(true);
+      await response.finish();
+      const serialized = response.serialize();
+      const textContent = expectTextContent(serialized.content[0]);
+
+      expect(response.tabSnapshot()?.ariaSnapshot).toContain('Item 150');
+      expect(textContent.text).toContain('Item 10');
+      expect(textContent.text).not.toContain('Item 11');
+      expect(textContent.text).not.toContain('Item 150');
+      expect(textContent.text).toContain('playwright-compress:');
+      expect(textContent.text).toContain('browser_evaluate()');
+    });
+
+    it('should leave rendered snapshot output uncompressed when disabled', async () => {
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com',
+        title: 'Example Page',
+        ariaSnapshot: repeatedListSnapshot(150),
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot(false);
+      await response.finish();
+      const serialized = response.serialize();
+      const textContent = expectTextContent(serialized.content[0]);
+
+      expect(textContent.text).toContain('Item 150');
+      expect(textContent.text).not.toContain('playwright-compress:');
+    });
+
     it('should truncate data URL payloads in rendered snapshot output', async () => {
       const payload = Buffer.from('<p>hello</p>').toString('base64');
       const dataUrl = `data:text/html;base64,${payload}`;
@@ -553,3 +597,7 @@ describe('Response', () => {
     });
   });
 });
+
+function repeatedListSnapshot(count: number): string {
+  return Array.from({ length: count }, (_, index) => `- listitem: Item ${index + 1}`).join('\n');
+}

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, it, vi } from 'vitest';
 import type { JSONSchema7 } from 'json-schema';
 import snapshotTools from '../src/tools/snapshot.js';
@@ -16,6 +32,7 @@ describe('Snapshot Tools', () => {
     expect(jsonSchema.type).toBe('object');
     expect(jsonSchema.required ?? []).toEqual([]);
     expect(compressSchema.type).toBe('boolean');
+    expect(compressSchema.description).toContain('more than 100 times');
     expect(snapshotTool.schema.inputSchema.parse({})).toEqual({});
     expect(snapshotTool.schema.inputSchema.parse({ compress: true })).toEqual({ compress: true });
     expect(snapshotTool.schema.inputSchema.parse({ compress: false })).toEqual({ compress: false });

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JSONSchema7 } from 'json-schema';
+import snapshotTools from '../src/tools/snapshot.js';
+import { toMcpTool } from '../src/mcp/tool.js';
+
+describe('Snapshot Tools', () => {
+  const snapshotTool = snapshotTools.find(tool => tool.schema.name === 'browser_snapshot')!;
+
+  it('should expose browser_snapshot with optional compression', () => {
+    const mcpTool = toMcpTool(snapshotTool.schema);
+    const jsonSchema = mcpTool.inputSchema as JSONSchema7;
+    const compressSchema = jsonSchema.properties?.compress as JSONSchema7;
+
+    expect(snapshotTool).toBeDefined();
+    expect(snapshotTool.schema.type).toBe('readOnly');
+    expect(jsonSchema.type).toBe('object');
+    expect(jsonSchema.required ?? []).toEqual([]);
+    expect(compressSchema.type).toBe('boolean');
+    expect(snapshotTool.schema.inputSchema.parse({})).toEqual({});
+    expect(snapshotTool.schema.inputSchema.parse({ compress: true })).toEqual({ compress: true });
+    expect(snapshotTool.schema.inputSchema.parse({ compress: false })).toEqual({ compress: false });
+  });
+
+  it('should request the current snapshot flow with compression disabled by default', async () => {
+    const context = {
+      ensureTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const response = {
+      setIncludeSnapshot: vi.fn(),
+    };
+
+    await snapshotTool.handle(context as any, {}, response as any);
+
+    expect(context.ensureTab).toHaveBeenCalled();
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should pass the compression option to the snapshot response', async () => {
+    const context = {
+      ensureTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const response = {
+      setIncludeSnapshot: vi.fn(),
+    };
+
+    await snapshotTool.handle(context as any, { compress: true }, response as any);
+
+    expect(context.ensureTab).toHaveBeenCalled();
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(true);
+  });
+
+  it('should pass explicit compression opt-out to the snapshot response', async () => {
+    const context = {
+      ensureTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const response = {
+      setIncludeSnapshot: vi.fn(),
+    };
+
+    await snapshotTool.handle(context as any, { compress: false }, response as any);
+
+    expect(context.ensureTab).toHaveBeenCalled();
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(false);
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -329,6 +329,19 @@ describe('Utils', () => {
       expect(result.output).toContain('Action 150');
     });
 
+    it('should keep repeated focusable range widget refs', () => {
+      const snapshot = [
+        ...Array.from({ length: 150 }, (_, index) => `- scrollbar "List scroll ${index + 1}" [ref=scroll-${index + 1}]`),
+        ...Array.from({ length: 150 }, (_, index) => `- separator "Pane splitter ${index + 1}" [ref=splitter-${index + 1}]`),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('List scroll 150');
+      expect(result.output).toContain('Pane splitter 150');
+    });
+
     it('should keep repeated non-interactive subtrees that contain interactive descendants', () => {
       const snapshot = Array.from({ length: 150 }, (_, index) => [
         '- listitem:',
@@ -343,6 +356,36 @@ describe('Utils', () => {
       expect(result.output).toContain('Item 11');
       expect(result.output).toContain('Item 150');
       expect(result.output).toContain('Action 150');
+    });
+
+    it('should keep repeated rows with protected gridcell descendants', () => {
+      const snapshot = [
+        '- grid:',
+        ...Array.from({ length: 150 }, (_, index) => [
+          '  - row:',
+          `    - gridcell "Order ${index + 1}" [ref=cell-${index + 1}]`,
+        ].join('\n')),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Order 150');
+    });
+
+    it('should keep repeated actionable treegrid rows', () => {
+      const snapshot = [
+        '- treegrid:',
+        ...Array.from({ length: 150 }, (_, index) => [
+          `  - row "Order ${index + 1}" [ref=row-${index + 1}]:`,
+          `    - gridcell "Order ${index + 1}"`,
+        ].join('\n')),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Order 150');
     });
 
     it('should collapse repeated non-interactive nodes even when they have refs', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -294,7 +294,7 @@ describe('Utils', () => {
       expect(result.output).toContain('Item 10');
       expect(result.output).not.toContain('Item 11');
       expect(result.output).not.toContain('Item 150');
-      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+      expect(result.output).toContain('# playwright-compress: 140 repeated ARIA nodes collapsed');
       expect(result.output).toContain('browser_evaluate()');
     });
 
@@ -340,6 +340,18 @@ describe('Utils', () => {
       expect(result).toEqual({ output: snapshot, removed: 0 });
       expect(result.output).toContain('List scroll 150');
       expect(result.output).toContain('Pane splitter 150');
+    });
+
+    it('should keep repeated cursor-pointer refs', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => [
+        `- listitem "Card ${index + 1}" [ref=card-${index + 1}] [cursor=pointer]:`,
+        `  - text: Card ${index + 1}`,
+      ].join('\n')).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Card 150');
     });
 
     it('should keep repeated non-interactive subtrees that contain interactive descendants', () => {
@@ -397,7 +409,7 @@ describe('Utils', () => {
       expect(result.output).toContain('Item 10');
       expect(result.output).not.toContain('Item 11');
       expect(result.output).not.toContain('Item 150');
-      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+      expect(result.output).toContain('# playwright-compress: 140 repeated ARIA nodes collapsed');
     });
 
     it('should keep descendants of interactive nodes', () => {
@@ -619,7 +631,7 @@ describe('Utils', () => {
       expect(result.output).toContain('Item 10');
       expect(result.output).not.toContain('Item 11');
       expect(result.output).not.toContain('Item 150');
-      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+      expect(result.output).toContain('# playwright-compress: 140 repeated ARIA nodes collapsed');
     });
 
     it('should not preserve non-interactive lines based on text content only', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -14,9 +14,33 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import { chromium, type Browser } from 'playwright';
 import { describe, it, expect } from 'vitest';
 import { createGuid, createHash } from '../src/utils/guid.js';
+import { compressAriaSnapshot } from '../src/utils/ariaCompression.js';
 import { truncateDataUrl, truncateDataUrls } from '../src/utils/dataUrl.js';
+
+const hasBundledChromium = fs.existsSync(chromium.executablePath());
+async function canLaunchBundledChromium(): Promise<boolean> {
+  if (!hasBundledChromium)
+    return false;
+
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      chromiumSandbox: false,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await browser?.close().catch(() => undefined);
+  }
+}
+
+const canRunAriaSnapshotIntegration = await canLaunchBundledChromium();
 
 describe('Utils', () => {
   describe('createGuid', () => {
@@ -260,4 +284,314 @@ describe('Utils', () => {
       expect(truncateDataUrls(text)).toBe('[LOG] url(data:text/plain,...) done');
     });
   });
+
+  describe('ARIA snapshot compression', () => {
+    it('should collapse repeated non-interactive ARIA nodes', () => {
+      const result = compressAriaSnapshot(repeatedListSnapshot(150));
+
+      expect(result.removed).toBe(140);
+      expect(result.output).toContain('Item 1');
+      expect(result.output).toContain('Item 10');
+      expect(result.output).not.toContain('Item 11');
+      expect(result.output).not.toContain('Item 150');
+      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+      expect(result.output).toContain('browser_evaluate()');
+    });
+
+    it('should not compress snapshots below the safety threshold', () => {
+      const snapshot = repeatedListSnapshot(50);
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+    });
+
+    it('should collapse repeated ARIA node subtrees', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => [
+        '- listitem:',
+        `  - text: Item ${index + 1}`,
+      ].join('\n')).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result.removed).toBe(280);
+      expect(result.output).toContain('Item 10');
+      expect(result.output).not.toContain('Item 11');
+      expect(result.output).not.toContain('Item 150');
+    });
+
+    it('should keep repeated interactive ARIA nodes', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => `- button "Action ${index + 1}" [ref=e${index + 1}]`).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Action 150');
+    });
+
+    it('should keep repeated non-interactive subtrees that contain interactive descendants', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => [
+        '- listitem:',
+        `  - text: Item ${index + 1}`,
+        `  - button "Action ${index + 1}" [ref=action-${index + 1}]`,
+      ].join('\n')).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Item 10');
+      expect(result.output).toContain('Item 11');
+      expect(result.output).toContain('Item 150');
+      expect(result.output).toContain('Action 150');
+    });
+
+    it('should collapse repeated non-interactive nodes even when they have refs', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => `- listitem [ref=e${index + 1}]: Item ${index + 1}`).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result.removed).toBe(140);
+      expect(result.output).toContain('Item 10');
+      expect(result.output).not.toContain('Item 11');
+      expect(result.output).not.toContain('Item 150');
+      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+    });
+
+    it('should keep descendants of interactive nodes', () => {
+      const snapshot = [
+        '- link "Order" [ref=order-link]:',
+        ...Array.from({ length: 150 }, (_, index) => `  - text: Detail ${index + 1}`),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Detail 11');
+      expect(result.output).toContain('Detail 150');
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should compress real Playwright list snapshots with non-actionable refs', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const items = Array.from({ length: 150 }, (_, index) => `<li>Item ${index + 1}</li>`).join('');
+        await page.setContent(`<ul>${items}</ul>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('[ref=');
+        expect(snapshot).toContain('Item 150');
+        expect(result.removed).toBeGreaterThan(0);
+        expect(result.output).toContain('Item 10');
+        expect(result.output).not.toContain('Item 11');
+        expect(result.output).not.toContain('Item 150');
+        expect(result.output).toContain('playwright-compress:');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should compress real Playwright lists inside landmarks', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const items = Array.from({ length: 150 }, (_, index) => `<li>Item ${index + 1}</li>`).join('');
+        await page.setContent(`<main><ul>${items}</ul></main>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('main');
+        expect(snapshot).toContain('Item 150');
+        expect(result.removed).toBeGreaterThan(0);
+        expect(result.output).toContain('main');
+        expect(result.output).toContain('Item 10');
+        expect(result.output).not.toContain('Item 11');
+        expect(result.output).not.toContain('Item 150');
+        expect(result.output).toContain('playwright-compress:');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should compress real Playwright repeated cards with headings', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const cards = Array.from({ length: 150 }, (_, index) => [
+          '<article>',
+          `<h2>Title ${index + 1}</h2>`,
+          `<p>Summary ${index + 1}</p>`,
+          '</article>',
+        ].join('')).join('');
+        await page.setContent(`<main>${cards}</main>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('Title 150');
+        expect(result.removed).toBeGreaterThan(0);
+        expect(result.output).toContain('Title 10');
+        expect(result.output).not.toContain('Title 11');
+        expect(result.output).not.toContain('Title 150');
+        expect(result.output).toContain('playwright-compress:');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should preserve real Playwright slider controls', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const sliders = Array.from({ length: 150 }, (_, index) => `<input type="range" aria-label="Volume ${index + 1}" min="0" max="100" value="50">`).join('');
+        await page.setContent(`<main>${sliders}</main>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('Volume 150');
+        expect(result).toEqual({ output: snapshot, removed: 0 });
+        expect(result.output).toContain('Volume 11');
+        expect(result.output).toContain('Volume 150');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should preserve real Playwright combobox controls', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const selects = Array.from({ length: 150 }, (_, index) => [
+          `<select aria-label="Choice ${index + 1}">`,
+          '<option>One</option>',
+          '<option>Two</option>',
+          '</select>',
+        ].join('')).join('');
+        await page.setContent(`<main>${selects}</main>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('Choice 150');
+        expect(result).toEqual({ output: snapshot, removed: 0 });
+        expect(result.output).toContain('Choice 11');
+        expect(result.output).toContain('Choice 150');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should preserve real Playwright actionable grid rows', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const rows = Array.from({ length: 150 }, (_, index) => [
+          `<div role="row" tabindex="0" aria-label="Order ${index + 1}">`,
+          `<span role="gridcell">Order ${index + 1}</span>`,
+          `<span role="gridcell">Status ${index + 1}</span>`,
+          '</div>',
+        ].join('')).join('');
+        await page.setContent(`<div role="grid">${rows}</div>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('Order 150');
+        expect(result).toEqual({ output: snapshot, removed: 0 });
+        expect(result.output).toContain('Order 11');
+        expect(result.output).toContain('Order 150');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it.skipIf(!canRunAriaSnapshotIntegration)('should compress real Playwright plain table rows', async () => {
+      let browser: Browser | undefined;
+      try {
+        browser = await chromium.launch({
+          headless: true,
+          chromiumSandbox: false,
+        });
+        const page = await browser.newPage();
+        const rows = Array.from({ length: 150 }, (_, index) => [
+          '<tr>',
+          `<td>Order ${index + 1}</td>`,
+          `<td>Status ${index + 1}</td>`,
+          '</tr>',
+        ].join('')).join('');
+        await page.setContent(`<table><tbody>${rows}</tbody></table>`);
+
+        const snapshot = await page.ariaSnapshot({ mode: 'ai' });
+        const result = compressAriaSnapshot(snapshot);
+
+        expect(snapshot).toContain('Order 150');
+        expect(result.removed).toBeGreaterThan(0);
+        expect(result.output).toContain('Order 10');
+        expect(result.output).not.toContain('Order 11');
+        expect(result.output).not.toContain('Order 150');
+        expect(result.output).toContain('playwright-compress:');
+      } finally {
+        await browser?.close().catch(() => undefined);
+      }
+    });
+
+    it('should compress unrelated repeated siblings under a shared parent with refs', () => {
+      const snapshot = [
+        '- document:',
+        '  - button "Save" [ref=save]',
+        ...Array.from({ length: 150 }, (_, index) => `  - text: Item ${index + 1}`),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result.removed).toBe(140);
+      expect(result.output).toContain('button "Save" [ref=save]');
+      expect(result.output).toContain('Item 10');
+      expect(result.output).not.toContain('Item 11');
+      expect(result.output).not.toContain('Item 150');
+      expect(result.output).toContain('playwright-compress: 140 repeated ARIA nodes collapsed');
+    });
+
+    it('should not preserve non-interactive lines based on text content only', () => {
+      const snapshot = Array.from({ length: 150 }, (_, index) => `- text: Press the button ${index + 1}`).join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result.removed).toBe(140);
+      expect(result.output).not.toContain('Press the button 11');
+      expect(result.output).not.toContain('Press the button 150');
+      expect(result.output).toContain('Press the button 10');
+    });
+  });
 });
+
+function repeatedListSnapshot(count: number): string {
+  return Array.from({ length: count }, (_, index) => `- listitem: Item ${index + 1}`).join('\n');
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional compression setting for browser snapshots to reduce repeated accessibility content in large outputs.
  * Compressed snapshots now keep a concise view while still allowing access to the full uncompressed snapshot when needed.

* **Bug Fixes**
  * Improved snapshot rendering so large accessibility trees are easier to read and less repetitive.

* **Documentation**
  * Updated snapshot documentation to explain the new compression option and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->