### PR TITLE
Fix streamable HTTP listRoots initialization race

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 export async function createConnection(userConfig: Config = {}, contextGetter?: () => Promise<BrowserContext>): Promise<Server> {
   const config = await resolveConfig(userConfig);
   const factory = contextGetter ? new SimpleBrowserContextFactory(contextGetter) : contextFactory(config);
-  return mcpServer.createServer('Playwright', packageJSON.version, new BrowserServerBackend(config, factory), false, { title: 'Accessibility Scanner', instructions: serverInstructions });
+  return mcpServer.createServer('Playwright', packageJSON.version, new BrowserServerBackend(config, factory), Promise.resolve(), false, { title: 'Accessibility Scanner', instructions: serverInstructions });
 }
 
 class SimpleBrowserContextFactory implements BrowserContextFactory {

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -29,6 +29,7 @@ import type { ServerBackendFactory } from './server.js';
 
 const testDebug = debug('pw:mcp:test');
 const allowedLoopbackHostnamePattern = /^127(?:\.\d{1,3}){3}$/;
+type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void>, fallbackStarted: boolean };
 
 export async function startHttpServer(config: { host?: string, port?: number }, abortSignal?: AbortSignal): Promise<http.Server> {
   const host = config.host ?? 'localhost';
@@ -59,7 +60,7 @@ export function httpAddressToString(address: string | net.AddressInfo | null): s
 }
 
 export async function installHttpTransport(httpServer: http.Server, serverBackendFactory: ServerBackendFactory) {
-  const streamableSessions = new Map<string, { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> }>();
+  const streamableSessions = new Map<string, StreamableSessionInfo>();
   httpServer.on('request', async (req, res) => {
     const validationError = validateRequestHeaders(httpServer, req);
     if (validationError) {
@@ -77,7 +78,7 @@ export async function installHttpTransport(httpServer: http.Server, serverBacken
   });
 }
 
-async function handleStreamable(serverBackendFactory: ServerBackendFactory, req: http.IncomingMessage, res: http.ServerResponse, sessions: Map<string, { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> }>) {
+async function handleStreamable(serverBackendFactory: ServerBackendFactory, req: http.IncomingMessage, res: http.ServerResponse, sessions: Map<string, StreamableSessionInfo>) {
   const routingError = validateRequestRouting(req, !!req.headers['mcp-session-id']);
   if (routingError) {
     res.statusCode = routingError.statusCode;
@@ -92,8 +93,12 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       res.end('Session not found');
       return;
     }
-    if (req.method === 'GET')
+    if (req.method === 'GET' && acceptsEventStream(req)) {
       sessionInfo.transportInitialized.resolve();
+    } else if (req.method === 'POST' && !sessionInfo.fallbackStarted) {
+      sessionInfo.fallbackStarted = true;
+      setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
+    }
     return await sessionInfo.transport.handleRequest(req, res);
   }
 
@@ -102,8 +107,7 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>() };
-        setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
+        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>(), fallbackStarted: false };
         sessions.set(sessionId, sessionInfo);
         await mcpServer.connect(serverBackendFactory, transport, sessionInfo.transportInitialized, true);
       }
@@ -122,6 +126,11 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
 
   res.statusCode = 400;
   res.end('Invalid request');
+}
+
+function acceptsEventStream(req: http.IncomingMessage): boolean {
+  const accept = req.headers.accept;
+  return Array.isArray(accept) ? accept.some(value => value.includes('text/event-stream')) : !!accept?.includes('text/event-stream');
 }
 
 function decorateServer(server: net.Server) {

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -23,6 +23,7 @@ import debug from 'debug';
 
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import * as mcpServer from './server.js';
+import { ManualPromise } from './manualPromise.js';
 
 import type { ServerBackendFactory } from './server.js';
 
@@ -58,7 +59,7 @@ export function httpAddressToString(address: string | net.AddressInfo | null): s
 }
 
 export async function installHttpTransport(httpServer: http.Server, serverBackendFactory: ServerBackendFactory) {
-  const streamableSessions = new Map();
+  const streamableSessions = new Map<string, { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> }>();
   httpServer.on('request', async (req, res) => {
     const validationError = validateRequestHeaders(httpServer, req);
     if (validationError) {
@@ -76,7 +77,7 @@ export async function installHttpTransport(httpServer: http.Server, serverBacken
   });
 }
 
-async function handleStreamable(serverBackendFactory: ServerBackendFactory, req: http.IncomingMessage, res: http.ServerResponse, sessions: Map<string, StreamableHTTPServerTransport>) {
+async function handleStreamable(serverBackendFactory: ServerBackendFactory, req: http.IncomingMessage, res: http.ServerResponse, sessions: Map<string, { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> }>) {
   const routingError = validateRequestRouting(req, !!req.headers['mcp-session-id']);
   if (routingError) {
     res.statusCode = routingError.statusCode;
@@ -85,13 +86,15 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
   }
   const sessionId = req.headers['mcp-session-id'] as string | undefined;
   if (sessionId) {
-    const transport = sessions.get(sessionId);
-    if (!transport) {
+    const sessionInfo = sessions.get(sessionId);
+    if (!sessionInfo) {
       res.statusCode = 404;
       res.end('Session not found');
       return;
     }
-    return await transport.handleRequest(req, res);
+    if (req.method === 'GET')
+      sessionInfo.transportInitialized.resolve();
+    return await sessionInfo.transport.handleRequest(req, res);
   }
 
   if (req.method === 'POST') {
@@ -99,8 +102,10 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        await mcpServer.connect(serverBackendFactory, transport, true);
-        sessions.set(sessionId, transport);
+        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>() };
+        setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
+        sessions.set(sessionId, sessionInfo);
+        await mcpServer.connect(serverBackendFactory, transport, sessionInfo.transportInitialized, true);
       }
     });
 

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -29,7 +29,7 @@ import type { ServerBackendFactory } from './server.js';
 
 const testDebug = debug('pw:mcp:test');
 const allowedLoopbackHostnamePattern = /^127(?:\.\d{1,3}){3}$/;
-type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void>, fallbackStarted: boolean };
+type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> };
 
 export async function startHttpServer(config: { host?: string, port?: number }, abortSignal?: AbortSignal): Promise<http.Server> {
   const host = config.host ?? 'localhost';
@@ -93,12 +93,10 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       res.end('Session not found');
       return;
     }
-    if (req.method === 'GET' && acceptsEventStream(req)) {
+    if (req.method === 'GET' && acceptsEventStream(req))
       sessionInfo.transportInitialized.resolve();
-    } else if (req.method === 'POST' && !sessionInfo.fallbackStarted) {
-      sessionInfo.fallbackStarted = true;
+    else if (req.method === 'POST')
       setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
-    }
     return await sessionInfo.transport.handleRequest(req, res);
   }
 
@@ -107,7 +105,7 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>(), fallbackStarted: false };
+        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>() };
         sessions.set(sessionId, sessionInfo);
         await mcpServer.connect(serverBackendFactory, transport, sessionInfo.transportInitialized, true);
       }

--- a/src/mcp/mdb.ts
+++ b/src/mcp/mdb.ts
@@ -163,7 +163,7 @@ export async function runMainBackend(backendFactory: mcpServer.ServerBackendFact
     return url;
 
   // Start stdio conditionally.
-  await mcpServer.connect(factory, new StdioServerTransport(), false);
+  await mcpServer.connect(factory, new StdioServerTransport(), Promise.resolve(), false);
 }
 
 export async function runOnPauseBackendLoop(mdbUrl: string, backend: ServerBackendOnPause, introMessage: string) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -56,17 +56,17 @@ export type ServerBackendFactory = ServerMetadata & {
   create: () => ServerBackend;
 };
 
-export async function connect(factory: ServerBackendFactory, transport: Transport, runHeartbeat: boolean) {
-  const server = createServer(factory.name, factory.version, factory.create(), runHeartbeat, factory);
+export async function connect(factory: ServerBackendFactory, transport: Transport, transportInitialized: Promise<void>, runHeartbeat: boolean) {
+  const server = createServer(factory.name, factory.version, factory.create(), transportInitialized, runHeartbeat, factory);
   await server.connect(transport);
 }
 
 export async function wrapInProcess(backend: ServerBackend): Promise<Transport> {
-  const server = createServer('Internal', '0.0.0', backend, false);
+  const server = createServer('Internal', '0.0.0', backend, Promise.resolve(), false);
   return new InProcessTransport(server);
 }
 
-export function createServer(name: string, version: string, backend: ServerBackend, runHeartbeat: boolean, metadata?: ServerMetadata): Server {
+export function createServer(name: string, version: string, backend: ServerBackend, transportInitialized: Promise<void>, runHeartbeat: boolean, metadata?: ServerMetadata): Server {
   let initializedPromiseResolve = () => {};
   const initializedPromise = new Promise<void>(resolve => initializedPromiseResolve = resolve);
   const server = new Server({ name, version, title: metadata?.title }, {
@@ -113,17 +113,12 @@ export function createServer(name: string, version: string, backend: ServerBacke
       const capabilities = server.getClientCapabilities();
       let clientRoots: Root[] = [];
       if (capabilities?.roots) {
-        // mcp sdk opens the standalone SSE channel lazily after sending `initialized`.
-        // If the first tool call comes before, `listRoots` is dropped on the server with no stream to send it on.
-        for (let i = 0; i < 2; i++) {
-          try {
-            const { roots } = await server.listRoots(undefined, { timeout: 2_000 });
-            clientRoots = roots;
-            break;
-          } catch (e) {
-            serverDebug(e);
-          }
-        }
+        await transportInitialized;
+        const { roots } = await server.listRoots(undefined, { timeout: 2_000 }).catch(e => {
+          serverDebug(e);
+          return { roots: [] };
+        });
+        clientRoots = roots;
       }
       const clientVersion = server.getClientVersion() ?? { name: 'unknown', version: 'unknown' };
       const context: ServerBackendContext = {
@@ -190,7 +185,7 @@ function addServerListener(server: Server, event: 'close' | 'initialized', liste
 
 export async function start(serverBackendFactory: ServerBackendFactory, options: { host?: string; port?: number }) {
   if (options.port === undefined) {
-    await connect(serverBackendFactory, new StdioServerTransport(), false);
+    await connect(serverBackendFactory, new StdioServerTransport(), Promise.resolve(), false);
     return;
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -113,11 +113,12 @@ export function createServer(name: string, version: string, backend: ServerBacke
       const capabilities = server.getClientCapabilities();
       let clientRoots: Root[] = [];
       if (capabilities?.roots) {
-        await transportInitialized;
-        const { roots } = await server.listRoots(undefined, { timeout: 2_000 }).catch(e => {
-          serverDebug(e);
-          return { roots: [] };
-        });
+        const { roots } = await transportInitialized
+            .then(() => server.listRoots(undefined, { timeout: 2_000 }))
+            .catch(e => {
+              serverDebug(e);
+              return { roots: [] };
+            });
         clientRoots = roots;
       }
       const clientVersion = server.getClientVersion() ?? { name: 'unknown', version: 'unknown' };

--- a/src/vscode/main.ts
+++ b/src/vscode/main.ts
@@ -64,6 +64,7 @@ async function main(config: FullConfig, connectionString: string, lib: string) {
         version: 'unused'
       },
       new StdioServerTransport(),
+      Promise.resolve(),
       false
   );
 }

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -15,8 +15,12 @@
  */
 
 import http from 'http';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { ListRootsRequestSchema, PingRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { httpAddressToString, installHttpTransport, startHttpServer } from '../src/mcp/http.js';
+import { ManualPromise } from '../src/mcp/manualPromise.js';
 
 import type { ServerBackendFactory } from '../src/mcp/server.js';
 
@@ -57,10 +61,10 @@ describe('mcp http transport hardening', () => {
     expect(httpAddressToString({ address: '::', family: 'IPv6', port: 1234 })).toBe('http://[::]:1234');
   });
 
-  async function startServer() {
+  async function startServer(serverBackendFactory = testBackendFactory) {
     const server = await startHttpServer({ host: '127.0.0.1', port: 0 });
     servers.add(server);
-    await installHttpTransport(server, testBackendFactory);
+    await installHttpTransport(server, serverBackendFactory);
     const address = server.address();
     if (!address || typeof address === 'string')
       throw new Error('Expected TCP server address');
@@ -209,5 +213,103 @@ describe('mcp http transport hardening', () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.body).toBe('Invalid request');
+  });
+
+  it('waits for the streamable HTTP event stream before listing roots', async () => {
+    const roots = [{ uri: 'file:///workspace', name: 'workspace' }];
+    let initializedRoots: unknown[] | undefined;
+    const callTool = vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
+    const { port } = await startServer({
+      ...testBackendFactory,
+      create: () => ({
+        async initialize(_context, _clientVersion, clientRoots) {
+          initializedRoots = clientRoots;
+        },
+        async listTools() {
+          return [];
+        },
+        callTool,
+      }),
+    });
+
+    const sawGet = new ManualPromise<void>();
+    const releaseGet = new ManualPromise<void>();
+    const delayedFetch: typeof fetch = async (input, init) => {
+      if (init?.method === 'GET') {
+        sawGet.resolve();
+        await releaseGet;
+      }
+      return fetch(input, init);
+    };
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler(ListRootsRequestSchema, () => ({ roots }));
+    client.setRequestHandler(PingRequestSchema, () => ({}));
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: delayedFetch });
+    await client.connect(transport);
+
+    try {
+      const callPromise = client.callTool({ name: 'probe', arguments: {} });
+      await sawGet;
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(callTool).not.toHaveBeenCalled();
+
+      releaseGet.resolve();
+      await callPromise;
+
+      expect(initializedRoots).toEqual(roots);
+      expect(callTool).toHaveBeenCalledTimes(1);
+    } finally {
+      await transport.terminateSession();
+      await client.close();
+    }
+  });
+
+  it('falls back when the streamable HTTP event stream never opens', async () => {
+    let initializedRoots: unknown[] | undefined;
+    const callTool = vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
+    const listRoots = vi.fn(() => ({ roots: [{ uri: 'file:///workspace' }] }));
+    const { port } = await startServer({
+      ...testBackendFactory,
+      create: () => ({
+        async initialize(_context, _clientVersion, clientRoots) {
+          initializedRoots = clientRoots;
+        },
+        async listTools() {
+          return [];
+        },
+        callTool,
+      }),
+    });
+
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 5000 || timeout === 2000)
+        return originalSetTimeout(handler, 0, ...args);
+      return originalSetTimeout(handler, timeout, ...args);
+    }) as typeof setTimeout);
+    const noStreamFetch: typeof fetch = async (input, init) => {
+      if (init?.method === 'GET') {
+        return await new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      }
+      return fetch(input, init);
+    };
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler(ListRootsRequestSchema, listRoots);
+    client.setRequestHandler(PingRequestSchema, () => ({}));
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
+    await client.connect(transport);
+
+    try {
+      await client.callTool({ name: 'probe', arguments: {} });
+
+      expect(initializedRoots).toEqual([]);
+      expect(listRoots).not.toHaveBeenCalled();
+      expect(callTool).toHaveBeenCalledTimes(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      await client.close();
+    }
   });
 });

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -71,7 +71,7 @@ describe('mcp http transport hardening', () => {
     return { server, port: address.port };
   }
 
-  async function sendRequest(port: number, options?: { method?: string, path?: string, hostHeader?: string, origin?: string }) {
+  async function sendRequest(port: number, options?: { method?: string, path?: string, hostHeader?: string, origin?: string, sessionId?: string, accept?: string }) {
     const response = await new Promise<{ statusCode: number, body: string }>((resolve, reject) => {
       const req = http.request({
         host: '127.0.0.1',
@@ -81,6 +81,8 @@ describe('mcp http transport hardening', () => {
         headers: {
           ...(options?.hostHeader ? { host: options.hostHeader } : {}),
           ...(options?.origin ? { origin: options.origin } : {}),
+          ...(options?.sessionId ? { 'mcp-session-id': options.sessionId } : {}),
+          ...(options?.accept ? { accept: options.accept } : {}),
         },
       }, res => {
         const chunks: Buffer[] = [];
@@ -248,6 +250,11 @@ describe('mcp http transport hardening', () => {
     await client.connect(transport);
 
     try {
+      if (!transport.sessionId)
+        throw new Error('Expected initialized session');
+      const invalidGet = await sendRequest(port, { sessionId: transport.sessionId, accept: 'application/json' });
+      expect(invalidGet.statusCode).toBe(406);
+
       const callPromise = client.callTool({ name: 'probe', arguments: {} });
       await sawGet;
       await new Promise(resolve => setTimeout(resolve, 50));

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -282,11 +282,6 @@ describe('mcp http transport hardening', () => {
     });
 
     const originalSetTimeout = globalThis.setTimeout;
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
-      if (timeout === 5000 || timeout === 2000)
-        return originalSetTimeout(handler, 0, ...args);
-      return originalSetTimeout(handler, timeout, ...args);
-    }) as typeof setTimeout);
     const noStreamFetch: typeof fetch = async (input, init) => {
       if (init?.method === 'GET') {
         return await new Promise<Response>((_resolve, reject) => {
@@ -299,9 +294,14 @@ describe('mcp http transport hardening', () => {
     client.setRequestHandler(ListRootsRequestSchema, listRoots);
     client.setRequestHandler(PingRequestSchema, () => ({}));
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
-    await client.connect(transport);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 5000 || timeout === 2000)
+        return originalSetTimeout(handler, 0, ...args);
+      return originalSetTimeout(handler, timeout, ...args);
+    }) as typeof setTimeout);
 
     try {
+      await client.connect(transport);
       await client.callTool({ name: 'probe', arguments: {} });
 
       expect(initializedRoots).toEqual([]);

--- a/tests/mcp-server-errors.test.ts
+++ b/tests/mcp-server-errors.test.ts
@@ -29,7 +29,7 @@ async function connectClient(backend: unknown) {
 }
 
 async function connectHeartbeatClient(backend: unknown, pingHandler: () => object | Promise<object>) {
-  const server = createServer('Test', '1.0.0', backend as any, true);
+  const server = createServer('Test', '1.0.0', backend as any, Promise.resolve(), true);
   const client = new Client({ name: 'test-client', version: '1.0.0' });
   client.setRequestHandler(PingRequestSchema, pingHandler);
   await client.connect(new InProcessTransport(server));
@@ -111,7 +111,7 @@ describe('mcp server error mapping', () => {
 
     const { createServer } = await import('../src/mcp/server.js');
     const { InProcessTransport } = await import('../src/mcp/inProcessTransport.js');
-    const server = createServer('Test', '1.0.0', backend as any, false, {
+    const server = createServer('Test', '1.0.0', backend as any, Promise.resolve(), false, {
       title: 'Test Title',
       instructions: 'Use the tools wisely.',
     });


### PR DESCRIPTION
Fixes #108.

## Summary
- wait for the Streamable HTTP GET event stream before server-initiated listRoots
- keep stdio and in-process paths immediately initialized
- cover delayed-event-stream and fallback-no-stream cases

## Validation
- npm test -- tests/mcp-http.test.ts
- npm run lint
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection startup handling so server sessions are ready before requests are processed.
  * Made HTTP streaming more reliable, reducing cases where early requests could race ahead of session initialization.
  * Added fallback behavior when a streaming event feed does not open in time.

* **Tests**
  * Expanded coverage for streamable HTTP session readiness and timeout fallback behavior.
  * Updated connection tests to match the revised startup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->