### PR TITLE
feat: surface non-2xx navigation status in page state (upstream #41589)

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -249,6 +249,9 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot, options: { compress?: boole
   lines.push(`### Page state`);
   lines.push(`- Page URL: ${truncateDataUrls(tabSnapshot.url)}`);
   lines.push(`- Page Title: ${truncateDataUrls(tabSnapshot.title)}`);
+  const status = tabSnapshot.mainDocumentStatus;
+  if (status && (status.status < 200 || status.status >= 300))
+    lines.push(`- HTTP status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
   lines.push(truncateDataUrls(ariaSnapshot));

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -39,6 +39,7 @@ export type TabSnapshot = {
   modalStates: ModalState[];
   consoleMessages: ConsoleMessage[];
   downloads: { download: playwright.Download, finished: boolean, outputFile: string }[];
+  mainDocumentStatus?: { status: number, statusText: string };
 };
 
 export class Tab extends EventEmitter<TabEventsInterface> {
@@ -48,6 +49,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _consoleMessages: ConsoleMessage[] = [];
   private _recentConsoleMessages: ConsoleMessage[] = [];
   private _requests: Map<playwright.Request, playwright.Response | null> = new Map();
+  private _mainDocumentStatus: { status: number, statusText: string } | undefined;
   private _onPageClose: (tab: Tab) => void;
   private _modalStates: ModalState[] = [];
   private _downloads: { download: playwright.Download, finished: boolean, outputFile: string }[] = [];
@@ -62,7 +64,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     page.on('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     page.on('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
     page.on('request', request => this._requests.set(request, null));
-    page.on('response', response => this._requests.set(response.request(), response));
+    page.on('response', response => this._handleResponse(response));
     page.on('close', () => this._onClose());
     page.on('filechooser', chooser => {
       this.setModalState({
@@ -124,6 +126,15 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._consoleMessages.length = 0;
     this._recentConsoleMessages.length = 0;
     this._requests.clear();
+    this._mainDocumentStatus = undefined;
+  }
+
+  private _handleResponse(response: playwright.Response) {
+    const request = response.request();
+    this._requests.set(request, response);
+    // Ignore redirect hops so only the final main-document response is reported.
+    if (request.isNavigationRequest() && response.frame() === this.page.mainFrame() && !request.redirectedTo())
+      this._mainDocumentStatus = { status: response.status(), statusText: response.statusText() };
   }
 
   private _handleConsoleMessage(message: ConsoleMessage) {
@@ -230,6 +241,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
         modalStates: [],
         consoleMessages: [],
         downloads: this._downloads,
+        mainDocumentStatus: this._mainDocumentStatus,
       };
     });
     if (tabSnapshot) {

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -402,6 +402,42 @@ describe('Response', () => {
       expect(textContent.text).toContain('Example Page');
     });
 
+    it('should surface non-2xx navigation status in page state', async () => {
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com/missing',
+        title: 'Not Found',
+        ariaSnapshot: 'document',
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+        mainDocumentStatus: { status: 404, statusText: 'Not Found' },
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+      await response.finish();
+      const textContent = expectTextContent(response.serialize().content[0]);
+      expect(textContent.text).toContain('- HTTP status: 404 Not Found');
+    });
+
+    it('should omit HTTP status for successful navigations', async () => {
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com',
+        title: 'Example Page',
+        ariaSnapshot: 'document',
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+        mainDocumentStatus: { status: 200, statusText: 'OK' },
+      });
+
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+      await response.finish();
+      const textContent = expectTextContent(response.serialize().content[0]);
+      expect(textContent.text).not.toContain('HTTP status');
+    });
+
     it('should compress rendered snapshot output when requested', async () => {
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
         url: 'https://example.com',

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -320,7 +320,7 @@ describe('Tab', () => {
     it('should track network requests', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
-      const mockRequest = { url: () => 'https://api.example.com' } as any;
+      const mockRequest = { url: () => 'https://api.example.com', isNavigationRequest: () => false } as any;
       const mockResponse = { status: () => 200, request: () => mockRequest } as any;
 
       mockPage.emit('request', mockRequest);
@@ -328,6 +328,50 @@ describe('Tab', () => {
 
       expect(tab.requests().size).toBe(1);
       expect(tab.requests().get(mockRequest)).toBe(mockResponse);
+    });
+  });
+
+  describe('main document HTTP status', () => {
+    const mainFrame = {};
+
+    function emitResponse(options: { status?: number, statusText?: string, navigation?: boolean, redirectedTo?: unknown, frame?: unknown } = {}) {
+      const request = {
+        isNavigationRequest: () => options.navigation ?? true,
+        redirectedTo: () => options.redirectedTo ?? null,
+      };
+      mockPage.emit('response', {
+        request: () => request,
+        frame: () => options.frame ?? mainFrame,
+        status: () => options.status ?? 200,
+        statusText: () => options.statusText ?? '',
+      });
+    }
+
+    beforeEach(() => {
+      mockPage.mainFrame = vi.fn().mockReturnValue(mainFrame);
+    });
+
+    it('captures the main document navigation status', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      emitResponse({ status: 404, statusText: 'Not Found' });
+      const snapshot = await tab.captureSnapshot();
+      expect(snapshot.mainDocumentStatus).toEqual({ status: 404, statusText: 'Not Found' });
+    });
+
+    it('ignores redirect hops and keeps the final response status', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      emitResponse({ status: 301, statusText: 'Moved Permanently', redirectedTo: {} });
+      emitResponse({ status: 200, statusText: 'OK' });
+      const snapshot = await tab.captureSnapshot();
+      expect(snapshot.mainDocumentStatus).toEqual({ status: 200, statusText: 'OK' });
+    });
+
+    it('ignores non-navigation and subframe responses', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      emitResponse({ status: 500, navigation: false });
+      emitResponse({ status: 500, frame: {} });
+      const snapshot = await tab.captureSnapshot();
+      expect(snapshot.mainDocumentStatus).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Upstream reference

- Merged upstream PR: [microsoft/playwright#41589 — "feat(mcp): surface non-2xx navigation status"](https://github.com/microsoft/playwright/pull/41589) (merged 2026-07-02)

_Detected by the upstream-monitoring routine._

## What changed upstream

Playwright MCP now tracks the HTTP status of the main document's final navigation response per tab (ignoring redirect hops and subframe/non-navigation responses) and reports it in the tab's page-state markdown when it falls outside the 2xx range, e.g. `- HTTP status: 404 Not Found`. This lets MCP clients/agents detect that a navigation "succeeded" at the browser level but the server returned an error page.

## Why it matters here

This fork renders the equivalent `### Page state` section in `src/response.ts` (`renderTabSnapshot`), but had no notion of the navigation's HTTP status — a `browser_navigate` to a 404/500 page looked identical to a successful load. For an accessibility scanner this is doubly relevant: agents could otherwise scan an error page believing it's the target page.

## Implemented fix (minimal port)

- `src/tab.ts`: the `response` listener now goes through `_handleResponse()`, which records `{ status, statusText }` for main-frame navigation responses that are not redirect hops; the value is cleared with the other collected artifacts and included in `TabSnapshot` as `mainDocumentStatus`.
- `src/response.ts`: `renderTabSnapshot` appends `- HTTP status: <status> <statusText>` after the Page URL/Title lines only when the status is outside 200–299, mirroring upstream's rendering.
- Tests: new `tab.test.ts` cases (captures main-document status, keeps only the final response of a redirect chain, ignores subframe/non-navigation responses) and `response.test.ts` cases (404 rendered, 200 omitted). One existing request-tracking mock gained an `isNavigationRequest` stub to satisfy the new handler.

`npm run lint` (eslint + typecheck) and the full `vitest` suite pass (330 passed / 9 skipped).

## Also reviewed from this monitoring window (no action needed)

- [#41560 "fix(mcp): close isolated HTTP client context on disconnect"](https://github.com/microsoft/playwright/pull/41560) (merged 2026-07-01, was being watched from #108) — upstream's leak was an early `return` in their shared-browser disposal wrapper in `program.ts`. This fork's disconnect path (`Context.dispose()` → `closeBrowserContext()` → factory `close()`) always closes the disconnecting client's own context and only closes the browser when no contexts remain, so the bug doesn't exist here.
- [#41537 "chore(mcp): remove roots support"](https://github.com/microsoft/playwright/pull/41537) — closed **without** merging; roots support stays upstream, so the `transportInitialized` port from #109 remains aligned.
- [#41577](https://github.com/microsoft/playwright/pull/41577) / [#41580](https://github.com/microsoft/playwright/pull/41580) — upstream `playwright` CLI packaging (`playwright mcp`, `init-skills`); not applicable to this fork's own CLI.
- [#41507](https://github.com/microsoft/playwright/pull/41507) `browser_snapshot` compress option — still open upstream; this fork already ships its own compression (#107, tracked in #106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzvFh1WoJ3BJ6Z8MtVGBvo

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzvFh1WoJ3BJ6Z8MtVGBvo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page snapshots now include the main document’s HTTP status when a navigation ends with an error or non-2xx response.
  * Redirect chains are handled so the final page status is shown, not intermediate redirect responses.

* **Bug Fixes**
  * Improved snapshot details for page loads that fail or return unexpected status codes.
  * Successful page loads no longer show an HTTP status line in the page state summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->