### PR TITLE
feat: mirror Playwright MCP find and status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Audits real keyboard focus behavior by pressing Tab (and optional Shift+Tab) wit
 #### `browser_navigate`
 Navigate to a URL.
 - Parameters: `url` (string)
+- Non-2xx main-document responses are shown as an `HTTP status` line in page state.
 
 #### `browser_navigate_back`
 Go back to the previous page.
@@ -295,6 +296,11 @@ Large `data:` URL payloads in snapshot output are truncated to their media type 
 - Parameters: `compress` (optional boolean, default false)
   - When true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response when a repeated structural pattern appears more than 100 times. The first 10 examples of each collapsed pattern are kept.
   - Use `browser_evaluate()` to retrieve the full uncompressed list when needed.
+
+#### `browser_find`
+Search the current page accessibility snapshot without returning the full snapshot.
+- Parameters: `text` (case-insensitive substring) or `regex` (regular expression, supports `/pattern/flags`)
+- Returns matching snapshot lines with surrounding context.
 
 #### `browser_click`
 Perform click on a web page element.

--- a/src/response.ts
+++ b/src/response.ts
@@ -249,6 +249,9 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot, options: { compress?: boole
   lines.push(`### Page state`);
   lines.push(`- Page URL: ${truncateDataUrls(tabSnapshot.url)}`);
   lines.push(`- Page Title: ${truncateDataUrls(tabSnapshot.title)}`);
+  const status = tabSnapshot.mainDocumentStatus;
+  if (status && (status.status < 200 || status.status >= 300))
+    lines.push(`- HTTP status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
   lines.push(truncateDataUrls(ariaSnapshot));

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -205,6 +205,11 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     await this.waitForLoadState('load', { timeout: 5000 });
   }
 
+  goBack(options?: Parameters<playwright.Page['goBack']>[0]) {
+    this._mainDocumentStatus = undefined;
+    return this.page.goBack(options);
+  }
+
   consoleMessages(): ConsoleMessage[] {
     return this._consoleMessages;
   }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -35,6 +35,7 @@ export type TabEventsInterface = {
 export type TabSnapshot = {
   url: string;
   title: string;
+  mainDocumentStatus?: { status: number, statusText: string };
   ariaSnapshot: string;
   modalStates: ModalState[];
   consoleMessages: ConsoleMessage[];
@@ -48,6 +49,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _consoleMessages: ConsoleMessage[] = [];
   private _recentConsoleMessages: ConsoleMessage[] = [];
   private _requests: Map<playwright.Request, playwright.Response | null> = new Map();
+  private _mainDocumentStatus: { status: number, statusText: string } | undefined;
   private _onPageClose: (tab: Tab) => void;
   private _modalStates: ModalState[] = [];
   private _downloads: { download: playwright.Download, finished: boolean, outputFile: string }[] = [];
@@ -62,7 +64,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     page.on('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     page.on('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
     page.on('request', request => this._requests.set(request, null));
-    page.on('response', response => this._requests.set(response.request(), response));
+    page.on('response', response => this._handleResponse(response));
     page.on('close', () => this._onClose());
     page.on('filechooser', chooser => {
       this.setModalState({
@@ -124,11 +126,19 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._consoleMessages.length = 0;
     this._recentConsoleMessages.length = 0;
     this._requests.clear();
+    this._mainDocumentStatus = undefined;
   }
 
   private _handleConsoleMessage(message: ConsoleMessage) {
     this._consoleMessages.push(message);
     this._recentConsoleMessages.push(message);
+  }
+
+  private _handleResponse(response: playwright.Response) {
+    const request = response.request();
+    this._requests.set(request, response);
+    if (request.isNavigationRequest() && response.frame() === this.page.mainFrame() && !request.redirectedTo())
+      this._mainDocumentStatus = { status: response.status(), statusText: response.statusText() };
   }
 
   private _onClose() {
@@ -226,6 +236,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot = {
         url: this.page.url(),
         title,
+        mainDocumentStatus: this._mainDocumentStatus,
         ariaSnapshot: snapshot,
         modalStates: [],
         consoleMessages: [],
@@ -240,6 +251,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     return tabSnapshot ?? {
       url: this.page.url(),
       title: '',
+      mainDocumentStatus: this._mainDocumentStatus,
       ariaSnapshot: '',
       modalStates,
       consoleMessages: [],

--- a/src/tools/auditKeyboard.ts
+++ b/src/tools/auditKeyboard.ts
@@ -376,7 +376,7 @@ const auditKeyboard = defineTabTool({
       },
       getCurrentUrl: async () => tab.page.url(),
       goBack: async () => {
-        await tab.page.goBack({ waitUntil: 'domcontentloaded' });
+        await tab.goBack({ waitUntil: 'domcontentloaded' });
       },
       captureScreenshot,
     });

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -53,7 +53,7 @@ const goBack = defineTabTool({
     // History traversal / bfcache restore can update the URL without Playwright
     // observing the `load` lifecycle event, so wait only for the navigation to
     // commit to avoid spurious timeouts. See microsoft/playwright#41153.
-    await tab.page.goBack({ waitUntil: 'commit' });
+    await tab.goBack({ waitUntil: 'commit' });
     response.setIncludeSnapshot();
     response.addCode(`await page.goBack();`);
   },

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -32,6 +32,11 @@ const snapshotSchema = z.object({
   compress: z.boolean().optional().describe('Collapse repeated non-interactive ARIA nodes in large snapshots when a repeated structural pattern appears more than 100 times. Keeps the first 10 examples of each collapsed pattern. Use browser_evaluate() to retrieve the full list if needed.'),
 });
 
+const findSchema = z.object({
+  text: z.string().optional().describe('Plain text to search for in the page snapshot (case-insensitive substring match). Provide either text or regex, not both.'),
+  regex: z.string().optional().refine(value => !value || isValidRegex(value), { message: 'Invalid regular expression' }).describe('Regular expression to search for in the page snapshot. Matching is case-sensitive by default; wrap the pattern in slashes to add flags, e.g. "/error/i" for case-insensitive. Provide either text or regex, not both.'),
+});
+
 const scanPage = defineTool({
   capability: 'core',
   schema: {
@@ -80,6 +85,86 @@ const snapshot = defineTool({
     response.setIncludeSnapshot(params.compress);
   },
 });
+
+const find = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_find',
+    title: 'Find in page snapshot',
+    description: 'Search the accessibility snapshot of the current page for text or a regular expression. Returns matching snapshot nodes with a few lines of surrounding context.',
+    inputSchema: findSchema,
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    if (!params.text && !params.regex) {
+      response.addError('Provide either "text" or "regex" to search for.');
+      return;
+    }
+    if (params.text && params.regex) {
+      response.addError('Provide only one of "text" or "regex", not both.');
+      return;
+    }
+
+    let query: string;
+    let matches: (line: string) => boolean;
+    if (params.regex) {
+      const regex = compileRegex(params.regex);
+      query = String(regex);
+      matches = line => {
+        regex.lastIndex = 0;
+        return regex.test(line);
+      };
+    } else {
+      query = `"${params.text}"`;
+      const needle = params.text!.toLowerCase();
+      matches = line => line.toLowerCase().includes(needle);
+    }
+
+    const lines = (await tab.page.ariaSnapshot({ mode: 'ai' })).split('\n');
+    const matchedLines: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (matches(lines[i]))
+        matchedLines.push(i);
+    }
+
+    if (!matchedLines.length) {
+      response.addResult(`No matches found for ${query}.`);
+      return;
+    }
+
+    const windows: { start: number, end: number }[] = [];
+    for (const line of matchedLines) {
+      const start = Math.max(0, line - 3);
+      const end = Math.min(lines.length - 1, line + 3);
+      const last = windows[windows.length - 1];
+      if (last && start <= last.end + 1)
+        last.end = Math.max(last.end, end);
+      else
+        windows.push({ start, end });
+    }
+
+    const snippets = windows.map(window => lines.slice(window.start, window.end + 1).join('\n'));
+    const matchWord = matchedLines.length === 1 ? 'match' : 'matches';
+    response.addResult(`Found ${matchedLines.length} ${matchWord} for ${query}:\n\n${snippets.join('\n\n----\n\n')}`);
+  },
+});
+
+function compileRegex(source: string): RegExp {
+  const literal = /^\/(.*)\/([a-z]*)$/.exec(source);
+  const pattern = literal ? literal[1] : source;
+  const flags = literal ? literal[2].replace(/g/g, '') : '';
+  return new RegExp(pattern, flags);
+}
+
+function isValidRegex(source: string): boolean {
+  try {
+    compileRegex(source);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export const elementSchema = z.object({
   element: z.string().describe('Human-readable element description used to obtain permission to interact with the element'),
@@ -204,6 +289,7 @@ const selectOption = defineTabTool({
 
 export default [
   snapshot,
+  find,
   click,
   drag,
   hover,

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import RE2 from 're2';
 import { z } from 'zod';
 import { defineTabTool, defineTool } from './tool.js';
 import * as javascript from '../utils/codegen.js';
 import { generateLocator } from './utils.js';
 import { axeTagValues, dedupeAxeNodes, runAxeScan } from './axe.js';
+import { truncateDataUrls } from '../utils/dataUrl.js';
 
 const scanPageSchema = z.object({
   violationsTag: z
@@ -109,12 +111,9 @@ const find = defineTabTool({
     let query: string;
     let matches: (line: string) => boolean;
     if (params.regex) {
-      const regex = compileRegex(params.regex);
-      query = String(regex);
-      matches = line => {
-        regex.lastIndex = 0;
-        return regex.test(line);
-      };
+      const { regex, display } = compileRegex(params.regex);
+      query = display;
+      matches = line => regex.test(line);
     } else {
       query = `"${params.text}"`;
       const needle = params.text!.toLowerCase();
@@ -144,17 +143,20 @@ const find = defineTabTool({
         windows.push({ start, end });
     }
 
-    const snippets = windows.map(window => lines.slice(window.start, window.end + 1).join('\n'));
+    const snippets = windows.map(window => truncateDataUrls(lines.slice(window.start, window.end + 1).join('\n')));
     const matchWord = matchedLines.length === 1 ? 'match' : 'matches';
     response.addResult(`Found ${matchedLines.length} ${matchWord} for ${query}:\n\n${snippets.join('\n\n----\n\n')}`);
   },
 });
 
-function compileRegex(source: string): RegExp {
+function compileRegex(source: string): { regex: RE2, display: string } {
   const literal = /^\/(.*)\/([a-z]*)$/.exec(source);
   const pattern = literal ? literal[1] : source;
   const flags = literal ? literal[2].replace(/g/g, '') : '';
-  return new RegExp(pattern, flags);
+  return {
+    regex: new RE2(pattern, flags),
+    display: literal ? `/${pattern}/${flags}` : `/${pattern}/`,
+  };
 }
 
 function isValidRegex(source: string): boolean {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -37,6 +37,11 @@ const snapshotSchema = z.object({
 const findSchema = z.object({
   text: z.string().optional().describe('Plain text to search for in the page snapshot (case-insensitive substring match). Provide either text or regex, not both.'),
   regex: z.string().optional().refine(value => !value || isValidRegex(value), { message: 'Invalid regular expression' }).describe('Regular expression to search for in the page snapshot. Matching is case-sensitive by default; wrap the pattern in slashes to add flags, e.g. "/error/i" for case-insensitive. Provide either text or regex, not both.'),
+}).superRefine((params, context) => {
+  if (!params.text && !params.regex)
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Provide either "text" or "regex" to search for.' });
+  if (params.text && params.regex)
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Provide only one of "text" or "regex", not both.' });
 });
 
 const scanPage = defineTool({

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -149,6 +149,39 @@ describe('Response', () => {
       await response.finish();
       expect(mockTab.captureSnapshot).toHaveBeenCalled();
     });
+
+    it('renders non-2xx HTTP status in page state only', async () => {
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com/locked',
+        title: 'Payment Required',
+        mainDocumentStatus: { status: 402, statusText: 'Payment Required' },
+        ariaSnapshot: 'text "Pay up"',
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+      });
+      const response = new Response(mockContext, 'test_tool', {});
+      response.setIncludeSnapshot();
+
+      await response.finish();
+
+      expect(expectTextContent(response.serialize().content[0]).text).toContain('- HTTP status: 402 Payment Required');
+
+      mockTab.captureSnapshot = vi.fn().mockResolvedValue({
+        url: 'https://example.com',
+        title: 'Example Page',
+        mainDocumentStatus: { status: 200, statusText: 'OK' },
+        ariaSnapshot: 'button "Submit"',
+        modalStates: [],
+        consoleMessages: [],
+        downloads: [],
+      });
+      const okResponse = new Response(mockContext, 'test_tool', {});
+      okResponse.setIncludeSnapshot();
+      await okResponse.finish();
+
+      expect(expectTextContent(okResponse.serialize().content[0]).text).not.toContain('HTTP status');
+    });
   });
 
   describe('setIncludeTabs', () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -28,6 +28,7 @@ describe('Tab', () => {
     mockPage = new EventEmitter();
     mockPage.url = vi.fn().mockReturnValue('https://example.com');
     mockPage.title = vi.fn().mockResolvedValue('Example Page');
+    mockPage.mainFrame = vi.fn().mockReturnValue('main-frame');
     mockPage.waitForTimeout = vi.fn().mockResolvedValue(undefined);
     mockPage._wrapApiCall = vi.fn(async (callback: () => Promise<unknown>) => await callback());
     mockPage.setDefaultNavigationTimeout = vi.fn();
@@ -320,7 +321,7 @@ describe('Tab', () => {
     it('should track network requests', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
-      const mockRequest = { url: () => 'https://api.example.com' } as any;
+      const mockRequest = { url: () => 'https://api.example.com', isNavigationRequest: () => false } as any;
       const mockResponse = { status: () => 200, request: () => mockRequest } as any;
 
       mockPage.emit('request', mockRequest);
@@ -328,6 +329,35 @@ describe('Tab', () => {
 
       expect(tab.requests().size).toBe(1);
       expect(tab.requests().get(mockRequest)).toBe(mockResponse);
+    });
+
+    it('tracks only the final main-document HTTP status', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      const redirectedRequest = {
+        isNavigationRequest: () => true,
+        redirectedTo: () => ({}),
+      } as any;
+      const finalRequest = {
+        isNavigationRequest: () => true,
+        redirectedTo: () => null,
+      } as any;
+
+      mockPage.emit('response', {
+        request: () => redirectedRequest,
+        frame: () => mockPage.mainFrame(),
+        status: () => 302,
+        statusText: () => 'Found',
+      });
+      mockPage.emit('response', {
+        request: () => finalRequest,
+        frame: () => mockPage.mainFrame(),
+        status: () => 402,
+        statusText: () => 'Payment Required',
+      });
+
+      const snapshot = await tab.captureSnapshot();
+
+      expect(snapshot.mainDocumentStatus).toEqual({ status: 402, statusText: 'Payment Required' });
     });
   });
 

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -33,6 +33,7 @@ describe('Tab', () => {
     mockPage._wrapApiCall = vi.fn(async (callback: () => Promise<unknown>) => await callback());
     mockPage.setDefaultNavigationTimeout = vi.fn();
     mockPage.setDefaultTimeout = vi.fn();
+    mockPage.goBack = vi.fn().mockResolvedValue(null);
     mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
     mockPage.locator = vi.fn().mockReturnValue({
       describe: vi.fn().mockReturnValue({}),
@@ -358,6 +359,27 @@ describe('Tab', () => {
       const snapshot = await tab.captureSnapshot();
 
       expect(snapshot.mainDocumentStatus).toEqual({ status: 402, statusText: 'Payment Required' });
+    });
+
+    it('clears main-document status before history navigation', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      const request = {
+        isNavigationRequest: () => true,
+        redirectedTo: () => null,
+      } as any;
+
+      mockPage.emit('response', {
+        request: () => request,
+        frame: () => mockPage.mainFrame(),
+        status: () => 402,
+        statusText: () => 'Payment Required',
+      });
+
+      await tab.goBack({ waitUntil: 'commit' });
+      const snapshot = await tab.captureSnapshot();
+
+      expect(mockPage.goBack).toHaveBeenCalledWith({ waitUntil: 'commit' });
+      expect(snapshot.mainDocumentStatus).toBeUndefined();
     });
   });
 

--- a/tests/tools-navigate.test.ts
+++ b/tests/tools-navigate.test.ts
@@ -35,6 +35,7 @@ describe('Navigate Tools', () => {
     mockTab = {
       page: mockPage,
       navigate: vi.fn().mockResolvedValue(undefined),
+      goBack: vi.fn(async options => await mockPage.goBack(options)),
       modalStates: vi.fn().mockReturnValue([]),
     } as any;
 

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -89,6 +89,8 @@ describe('Snapshot Tools', () => {
     expect(findTool.schema.type).toBe('readOnly');
     expect(jsonSchema.properties?.text).toBeDefined();
     expect(jsonSchema.properties?.regex).toBeDefined();
+    expect(() => findTool.schema.inputSchema.parse({})).toThrow();
+    expect(() => findTool.schema.inputSchema.parse({ text: 'Submit', regex: 'Submit' })).toThrow();
     expect(() => findTool.schema.inputSchema.parse({ regex: '(' })).toThrow();
     expect(() => findTool.schema.inputSchema.parse({ regex: '(?=a)a' })).toThrow();
   });
@@ -111,6 +113,25 @@ describe('Snapshot Tools', () => {
     await findTool.handle(context as any, { regex: '/apples/i' }, response as any);
 
     expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 1 match for /apples/i:'));
+  });
+
+  it('should merge overlapping browser_find context windows', async () => {
+    const context = findContext(['- text "Alpha"', '- text "One"', '- text "Two"', '- text "Beta"'].join('\n'));
+    const response = findResponse();
+
+    await findTool.handle(context as any, { regex: '/Alpha|Beta/' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 2 matches for /Alpha|Beta/:'));
+    expect(response.addResult).not.toHaveBeenCalledWith(expect.stringContaining('----'));
+  });
+
+  it('should report when browser_find has no matches', async () => {
+    const context = findContext('- button "Submit"');
+    const response = findResponse();
+
+    await findTool.handle(context as any, { text: 'Cancel' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith('No matches found for "Cancel".');
   });
 
   it('should truncate data URLs in browser_find snippets', async () => {

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -90,6 +90,7 @@ describe('Snapshot Tools', () => {
     expect(jsonSchema.properties?.text).toBeDefined();
     expect(jsonSchema.properties?.regex).toBeDefined();
     expect(() => findTool.schema.inputSchema.parse({ regex: '(' })).toThrow();
+    expect(() => findTool.schema.inputSchema.parse({ regex: '(?=a)a' })).toThrow();
   });
 
   it('should find snapshot lines by case-insensitive text', async () => {
@@ -110,6 +111,17 @@ describe('Snapshot Tools', () => {
     await findTool.handle(context as any, { regex: '/apples/i' }, response as any);
 
     expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 1 match for /apples/i:'));
+  });
+
+  it('should truncate data URLs in browser_find snippets', async () => {
+    const payload = '<svg viewBox="0 0 10 10"><text>Hello</text></svg>';
+    const context = findContext(`- link "Logo" [ref=e1]:\n  - /url: data:image/svg+xml,${payload}\n- button "Next" [ref=e2]`);
+    const response = findResponse();
+
+    await findTool.handle(context as any, { text: 'Logo' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('data:image/svg+xml,...'));
+    expect(response.addResult).not.toHaveBeenCalledWith(expect.stringContaining(payload));
   });
 
   it('should report browser_find argument errors', async () => {

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -21,6 +21,7 @@ import { toMcpTool } from '../src/mcp/tool.js';
 
 describe('Snapshot Tools', () => {
   const snapshotTool = snapshotTools.find(tool => tool.schema.name === 'browser_snapshot')!;
+  const findTool = snapshotTools.find(tool => tool.schema.name === 'browser_find')!;
 
   it('should expose browser_snapshot with optional compression', () => {
     const mcpTool = toMcpTool(snapshotTool.schema);
@@ -79,4 +80,65 @@ describe('Snapshot Tools', () => {
     expect(context.ensureTab).toHaveBeenCalled();
     expect(response.setIncludeSnapshot).toHaveBeenCalledWith(false);
   });
+
+  it('should expose browser_find with text and regex search options', () => {
+    const mcpTool = toMcpTool(findTool.schema);
+    const jsonSchema = mcpTool.inputSchema as JSONSchema7;
+
+    expect(findTool).toBeDefined();
+    expect(findTool.schema.type).toBe('readOnly');
+    expect(jsonSchema.properties?.text).toBeDefined();
+    expect(jsonSchema.properties?.regex).toBeDefined();
+    expect(() => findTool.schema.inputSchema.parse({ regex: '(' })).toThrow();
+  });
+
+  it('should find snapshot lines by case-insensitive text', async () => {
+    const context = findContext(`- heading "Groceries"\n- list:\n  - listitem: Apples\n  - listitem: Bananas\n  - listitem: Cherries`);
+    const response = findResponse();
+
+    await findTool.handle(context as any, { text: 'bananas' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 1 match for "bananas":'));
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Apples'));
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Cherries'));
+  });
+
+  it('should find snapshot lines by regex with flags', async () => {
+    const context = findContext(`- heading "Groceries"\n- listitem: Apples\n- listitem: Bananas`);
+    const response = findResponse();
+
+    await findTool.handle(context as any, { regex: '/apples/i' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 1 match for /apples/i:'));
+  });
+
+  it('should report browser_find argument errors', async () => {
+    const context = findContext('- button "Submit"');
+    const response = findResponse();
+
+    await findTool.handle(context as any, {}, response as any);
+    await findTool.handle(context as any, { text: 'Submit', regex: 'Submit' }, response as any);
+
+    expect(response.addError).toHaveBeenCalledWith('Provide either "text" or "regex" to search for.');
+    expect(response.addError).toHaveBeenCalledWith('Provide only one of "text" or "regex", not both.');
+  });
 });
+
+function findContext(snapshot: string) {
+  const tab = {
+    modalStates: vi.fn().mockReturnValue([]),
+    page: {
+      ariaSnapshot: vi.fn().mockResolvedValue(snapshot),
+    },
+  };
+  return {
+    currentTabOrDie: vi.fn().mockReturnValue(tab),
+  };
+}
+
+function findResponse() {
+  return {
+    addResult: vi.fn(),
+    addError: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Summary

- Add `browser_find` to search the current accessibility snapshot by text or regex and return surrounding context.
- Show `HTTP status` in page state for final non-2xx main-document responses.
- Document the new tool/output behavior and add focused coverage.

## Upstream

- Mirrors https://github.com/microsoft/playwright/pull/41605, committed as https://github.com/microsoft/playwright/commit/9725152dac40ed511098664fcd253b545f67e7f0, which added `browser_find` for searching page snapshots without returning the full snapshot.
- Mirrors https://github.com/microsoft/playwright/pull/41589, committed as https://github.com/microsoft/playwright/commit/45897ce666dc8a551f1f7e1879890eb2d6e72bfb, which surfaces non-2xx navigation status in MCP page state.

## Why it matters here

- This package exposes the same browser snapshot and navigation MCP surfaces, so agents benefit from the same lower-token snapshot search and clearer failed-navigation signal.

## Validation

- `npm test -- tests/tools-snapshot.test.ts tests/tab.test.ts tests/response.test.ts tests/program.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page-snapshot search tool that finds matching text or patterns in the current page and returns nearby context.
  * Page state can now show the main document’s HTTP status when a navigation returns a non-success response.

* **Bug Fixes**
  * Improved handling of navigation responses so the final page status is captured correctly after redirects.

* **Tests**
  * Expanded coverage for status rendering and the new page-snapshot search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->