### PR TITLE
fix: bind Docker Compose MCP port to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Without the `-v` mount, output files only exist inside the container and are los
 docker compose up -d
 ```
 
+The Compose configuration publishes the unauthenticated MCP HTTP transport on `127.0.0.1:8931` only. Do not expose this port to untrusted networks.
+
 #### Build from source
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,8 @@ services:
       - --output-dir
       - /app/output
     ports:
-      - "8931:8931"
+      # Bind the unauthenticated MCP HTTP transport to localhost only.
+      - "127.0.0.1:8931:8931"
     volumes:
       - ./output:/app/output
     restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the unauthenticated MCP HTTP transport when running the provided Compose file by restricting the published port to the host loopback.

### Description
- Modify `docker-compose.yaml` to publish `127.0.0.1:8931:8931` instead of `8931:8931` and add a short warning to `README.md` stating that the Compose configuration publishes an unauthenticated MCP HTTP transport and should not be exposed to untrusted networks.

### Testing
- Ran `npm run lint` (passed) and `npm test` (most tests passed, one CLI help-text test timed out in this environment), and `npm run test:docker` / `docker compose` were not executed here because the Docker CLI is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0f8af4c4833383dad5ef4e6f077c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Docker Compose setup to show that the MCP HTTP transport is intended to be accessible only from `127.0.0.1:8931`.
  * Added guidance warning against exposing this port to untrusted networks.

* **Bug Fixes**
  * Updated the default port binding so the service listens on localhost only, reducing accidental external exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->