### PR TITLE
Fix HTTP session fallback timer accumulation

### DIFF
--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -29,7 +29,7 @@ import type { ServerBackendFactory } from './server.js';
 
 const testDebug = debug('pw:mcp:test');
 const allowedLoopbackHostnamePattern = /^127(?:\.\d{1,3}){3}$/;
-type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> };
+type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void>, fallbackStarted: boolean };
 
 export async function startHttpServer(config: { host?: string, port?: number }, abortSignal?: AbortSignal): Promise<http.Server> {
   const host = config.host ?? 'localhost';
@@ -93,10 +93,12 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       res.end('Session not found');
       return;
     }
-    if (req.method === 'GET' && acceptsEventStream(req))
+    if (req.method === 'GET' && acceptsEventStream(req)) {
       sessionInfo.transportInitialized.resolve();
-    else if (req.method === 'POST')
+    } else if (req.method === 'POST' && !sessionInfo.fallbackStarted) {
+      sessionInfo.fallbackStarted = true;
       setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
+    }
     return await sessionInfo.transport.handleRequest(req, res);
   }
 
@@ -105,7 +107,7 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>() };
+        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>(), fallbackStarted: false };
         sessions.set(sessionId, sessionInfo);
         await mcpServer.connect(serverBackendFactory, transport, sessionInfo.transportInitialized, true);
       }

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -301,8 +301,14 @@ describe('mcp http transport hardening', () => {
     client.setRequestHandler(ListRootsRequestSchema, listRoots);
     client.setRequestHandler(PingRequestSchema, () => ({}));
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
+    let fallbackTimerCount = 0;
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
-      if (timeout === 5000 || timeout === 2000)
+      if (timeout === 5000) {
+        if (new Error().stack?.includes('/src/mcp/http.ts'))
+          ++fallbackTimerCount;
+        return originalSetTimeout(handler, 0, ...args);
+      }
+      if (timeout === 2000)
         return originalSetTimeout(handler, 0, ...args);
       return originalSetTimeout(handler, timeout, ...args);
     }) as typeof setTimeout);
@@ -311,6 +317,7 @@ describe('mcp http transport hardening', () => {
       await client.connect(transport);
       await client.callTool({ name: 'probe', arguments: {} });
 
+      expect(fallbackTimerCount).toBe(1);
       expect(initializedRoots).toEqual([]);
       expect(listRoots).not.toHaveBeenCalled();
       expect(callTool).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Motivation
- Prevent a resource-exhaustion issue where every POST to an existing Streamable HTTP session scheduled a redundant 5s fallback timer, allowing unauthenticated clients to accumulate timers and degrade availability.

### Description
- Restore per-session fallback state by adding `fallbackStarted: boolean` to `StreamableSessionInfo` and initialize it to `false` when creating a new session in `src/mcp/http.ts`.
- Only schedule the 5-second fallback `setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000)` for existing-session POSTs if `fallbackStarted` is `false`, and set it to `true` once scheduled, ensuring at-most-one fallback timer per session.
- Update tests in `tests/mcp-http.test.ts` to detect and assert that the server creates a single 5s fallback timer for the fallback path while preserving existing fallback behavior.

### Testing
- Ran the focused transport tests with `npx vitest run tests/mcp-http.test.ts --reporter=verbose`, and the modified HTTP tests passed (all transport-related assertions succeeded).
- Ran linter and build with `npm run lint` and `npm run build`, both succeeded after formatting fixups.
- Ran the full test suite with `npm test`; the target change passed but the full run surfaced an unrelated flaky CLI help test (`tests/program.test.ts`) that timed out causing the overall `npm test` to fail (unrelated to this fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ddde13108333be4ce935bfaf1b59)