### PR TITLE
fix: avoid quadratic snapshot compression

### DIFF
--- a/src/utils/ariaCompression.ts
+++ b/src/utils/ariaCompression.ts
@@ -109,6 +109,7 @@ type SnapshotLine = {
   containsProtectedSubtreeRole: boolean;
   selfHasProtectedSubtreeRole: boolean;
   insideProtectedSubtree: boolean;
+  hasRowContainerAncestor: boolean;
 };
 
 export type CompressResult = {
@@ -196,6 +197,7 @@ function parseSnapshotLines(yaml: string): SnapshotLine[] {
       containsProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef) || shouldKeepCursorPointerRef(hasRef, hasCursorPointer),
       selfHasProtectedSubtreeRole: shouldKeepSubtree(role) || shouldKeepRefProtectedDescendants(role, hasRef) || shouldKeepCursorPointerRef(hasRef, hasCursorPointer),
       insideProtectedSubtree: false,
+      hasRowContainerAncestor: false,
     };
   });
 
@@ -209,11 +211,13 @@ function parseSnapshotLines(yaml: string): SnapshotLine[] {
       stack.pop();
 
     line.parentIndex = stack[stack.length - 1] ?? -1;
+    const parent = line.parentIndex === -1 ? undefined : lines[line.parentIndex];
+    line.hasRowContainerAncestor = parent !== undefined && (parent.hasRowContainerAncestor || isRowContainerRole(parent.role));
     stack.push(index);
   }
 
   for (const line of lines) {
-    if (line.role === 'row' && line.hasRef && hasAncestorRole(lines, line, ROW_CONTAINER_ROLES)) {
+    if (line.role === 'row' && line.hasRef && line.hasRowContainerAncestor) {
       line.selfHasProtectedLineRole = true;
       line.containsProtectedSubtreeRole = true;
       line.selfHasProtectedSubtreeRole = true;
@@ -288,13 +292,8 @@ function shouldKeepCursorPointerRef(hasRef: boolean, hasCursorPointer: boolean):
 
 const ROW_CONTAINER_ROLES = new Set(['grid', 'treegrid']);
 
-function hasAncestorRole(lines: SnapshotLine[], line: SnapshotLine, roles: Set<string>): boolean {
-  for (let parentIndex = line.parentIndex; parentIndex !== -1; parentIndex = lines[parentIndex].parentIndex) {
-    const role = lines[parentIndex].role;
-    if (role !== undefined && roles.has(role))
-      return true;
-  }
-  return false;
+function isRowContainerRole(role: string | undefined): boolean {
+  return role !== undefined && ROW_CONTAINER_ROLES.has(role);
 }
 
 function indentOf(line: string): number {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -400,6 +400,18 @@ describe('Utils', () => {
       expect(result.output).toContain('Order 150');
     });
 
+    it('should keep deeply nested actionable grid rows without ancestor walks', () => {
+      const snapshot = [
+        '- grid:',
+        ...Array.from({ length: 1500 }, (_, index) => `${'  '.repeat(index + 1)}- row "Order ${index + 1}" [ref=row-${index + 1}]:`),
+      ].join('\n');
+
+      const result = compressAriaSnapshot(snapshot);
+
+      expect(result).toEqual({ output: snapshot, removed: 0 });
+      expect(result.output).toContain('Order 1500');
+    });
+
     it('should collapse repeated non-interactive nodes even when they have refs', () => {
       const snapshot = Array.from({ length: 150 }, (_, index) => `- listitem [ref=e${index + 1}]: Item ${index + 1}`).join('\n');
 


### PR DESCRIPTION
### Motivation
- Prevent an algorithmic-complexity DoS in ARIA snapshot compression where per-row ancestor walks could produce O(n^2) work on deeply nested attacker-controlled trees.

### Description
- Compute and cache a `hasRowContainerAncestor` flag while building parent links in `parseSnapshotLines()` instead of walking the ancestor chain for each referenced `row` in `src/utils/ariaCompression.ts`.
- Replace the runtime ancestor-walk check with the cached flag and remove the costly `hasAncestorRole()` usage, adding a small helper `isRowContainerRole()`.
- Extend the `SnapshotLine` type with `hasRowContainerAncestor` and update compression logic to preserve existing behavior for actionable grid/treegrid rows.
- Add a regression test `should keep deeply nested actionable grid rows without ancestor walks` to `tests/utils.test.ts` to ensure correctness on deeply nested snapshots.

### Testing
- Ran `npm test -- tests/utils.test.ts` which completed successfully (tests in that file passed: 48 passed | 7 skipped in the run observed). 
- Ran `npm run lint` (ESLint + typecheck) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49de01bb5083338652eceae9489b4d)