### PR TITLE
feat: mirror Playwright MCP find and mobile updates

### DIFF
--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -51,6 +51,13 @@ const tests = [
     assertText(result, /Hello MCP/);
   }),
 
+  test('browser_find', async () => {
+    await navigate('<title>Find</title><main><h1>Groceries</h1><ul><li>Apples</li><li>Bananas</li><li>Cherries</li></ul></main>');
+    const result = await callTool('browser_find', { text: 'Bananas' });
+    assertText(result, /Found 1 match for "Bananas"/);
+    assertText(result, /Groceries|listitem.*Bananas/s);
+  }),
+
   test('browser_evaluate', async () => {
     await navigate('<title>Evaluate</title><h1 id="answer">OK</h1>');
     const result = await callTool('browser_evaluate', { function: '() => 2 + 2' });

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Interactive mode. Type "<tool-name> <json>" to call a tool. Ctrl+D to exit.
 
 Each line is `<tool-name> <json-arguments>`. Omit the JSON to pass `{}`.
 Global browser connection flags still apply here, for example `npx mcp-accessibility-scanner --headless interactive`.
+Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`.
 
 ### Discovering available tools (`list-tools` subcommand)
 
@@ -302,7 +303,7 @@ Large `data:` URL payloads in snapshot output are truncated to their media type 
 #### `browser_find`
 Search the current page accessibility snapshot without returning the full snapshot.
 - Parameters: `text` (case-insensitive substring) or `regex` (regular expression, supports `/pattern/flags`)
-- Returns matching snapshot lines with surrounding context.
+- Returns matching snapshot lines with surrounding context, shown under their path from the root of the tree; `...` marks truncated off-path context.
 
 #### `browser_click`
 Perform click on a web page element.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Interactive mode. Type "<tool-name> <json>" to call a tool. Ctrl+D to exit.
 
 Each line is `<tool-name> <json-arguments>`. Omit the JSON to pass `{}`.
 Global browser connection flags still apply here, for example `npx mcp-accessibility-scanner --headless interactive`.
-Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`.
+Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`, CDP attach/launch modes, or `--extension`.
 
 ### Discovering available tools (`list-tools` subcommand)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Interactive mode. Type "<tool-name> <json>" to call a tool. Ctrl+D to exit.
 
 Each line is `<tool-name> <json-arguments>`. Omit the JSON to pass `{}`.
 Global browser connection flags still apply here, for example `npx mcp-accessibility-scanner --headless interactive`.
-Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`, CDP attach/launch modes, or `--extension`.
+Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`, CDP attach/launch modes, remote browser endpoints, or `--extension`.
 
 ### Discovering available tools (`list-tools` subcommand)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ export type CLIOptions = {
     ignoreHttpsErrors?: boolean;
     isolated?: boolean;
     imageResponses?: 'allow' | 'omit';
+    mobile?: boolean;
     sandbox?: boolean;
     outputDir?: string;
     port?: number;
@@ -156,14 +157,24 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
       launchOptions.proxy.bypass = cliOptions.proxyBypass;
   }
 
-  if (cliOptions.device && cliOptions.cdpEndpoint)
+  let device = cliOptions.device;
+  const resolvedBrowserName = browserName ?? 'chromium';
+  if (cliOptions.mobile) {
+    if (device)
+      throw new Error('Cannot use --mobile together with --device, pick one.');
+    if (resolvedBrowserName === 'firefox')
+      throw new Error('--mobile is not supported with the Firefox browser.');
+    device = resolvedBrowserName === 'webkit' ? 'iPhone 17' : 'Pixel 10';
+  }
+
+  if (device && cliOptions.cdpEndpoint)
     throw new Error('Device emulation is not supported with cdpEndpoint.');
 
   if (cliOptions.cdpEndpoint && cliOptions.cdpLaunchCommand)
     throw new Error('CDP launch is not supported with cdpEndpoint.');
 
   // Context options
-  const contextOptions: BrowserContextOptions = cliOptions.device ? devices[cliOptions.device] : {};
+  const contextOptions: BrowserContextOptions = device ? devices[device] : {};
   if (cliOptions.storageState)
     contextOptions.storageState = cliOptions.storageState;
 
@@ -251,6 +262,7 @@ function configFromEnv(): Config {
   options.isolated = envToBoolean(process.env.PLAYWRIGHT_MCP_ISOLATED);
   if (process.env.PLAYWRIGHT_MCP_IMAGE_RESPONSES === 'omit')
     options.imageResponses = 'omit';
+  options.mobile = envToBoolean(process.env.PLAYWRIGHT_MCP_MOBILE);
   options.sandbox = envToBoolean(process.env.PLAYWRIGHT_MCP_SANDBOX);
   options.outputDir = envToString(process.env.PLAYWRIGHT_MCP_OUTPUT_DIR);
   options.port = envToNumber(process.env.PLAYWRIGHT_MCP_PORT);

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,8 @@ function applyMobileConfig(resolved: FullConfig, configInFile: Config, envOverri
     throw new Error('--mobile is not supported with the Firefox browser.');
   if (resolved.browser.cdpEndpoint)
     throw new Error('Mobile emulation is not supported with cdpEndpoint.');
+  if (resolved.browser.remoteEndpoint)
+    throw new Error('Mobile emulation is not supported with remoteEndpoint.');
   if (resolved.browser.cdpLaunch)
     throw new Error('Mobile emulation is not supported with --cdp-launch-command.');
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export type CLIOptions = {
     config?: string;
     device?: string;
     executablePath?: string;
+    extension?: boolean;
     headless?: boolean;
     host?: string;
     ignoreHttpsErrors?: boolean;
@@ -105,13 +106,46 @@ export async function resolveConfig(config: Config): Promise<FullConfig> {
 
 export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConfig> {
   const configInFile = await loadConfig(cliOptions.config);
-  const envOverrides = configFromEnv();
+  const envOptions = cliOptionsFromEnv();
+  const envOverrides = configFromCLIOptions(envOptions);
   const cliOverrides = configFromCLIOptions(cliOptions);
+  const result = mergeCLIConfigSources(configInFile, envOverrides, cliOverrides);
+  return applyMobileConfig(result, configInFile, envOverrides, cliOverrides, envOptions, cliOptions);
+}
+
+type MobileSource = 'env' | 'cli';
+
+function mergeCLIConfigSources(configInFile: Config, envOverrides: Config, cliOverrides: Config, mobileOverride?: Config, mobileSource?: MobileSource): FullConfig {
   let result = defaultConfig;
   result = mergeConfig(result, configInFile);
+  if (mobileSource === 'env' && mobileOverride)
+    result = mergeConfig(result, mobileOverride);
   result = mergeConfig(result, envOverrides);
+  if (mobileSource === 'cli' && mobileOverride)
+    result = mergeConfig(result, mobileOverride);
   result = mergeConfig(result, cliOverrides);
   return result;
+}
+
+function applyMobileConfig(resolved: FullConfig, configInFile: Config, envOverrides: Config, cliOverrides: Config, envOptions: CLIOptions, cliOptions: CLIOptions): FullConfig {
+  const source = cliOptions.mobile !== undefined ? (cliOptions.mobile ? 'cli' : undefined) : (envOptions.mobile ? 'env' : undefined);
+  if (!source)
+    return resolved;
+
+  if (cliOptions.device || envOptions.device)
+    throw new Error('Cannot use --mobile together with --device, pick one.');
+  if (cliOptions.extension)
+    throw new Error('Mobile emulation is not supported with --extension.');
+  if (resolved.browser.browserName === 'firefox')
+    throw new Error('--mobile is not supported with the Firefox browser.');
+  if (resolved.browser.cdpEndpoint)
+    throw new Error('Mobile emulation is not supported with cdpEndpoint.');
+  if (resolved.browser.cdpLaunch)
+    throw new Error('Mobile emulation is not supported with --cdp-launch-command.');
+
+  const device = resolved.browser.browserName === 'webkit' ? 'iPhone 17' : 'Pixel 10';
+  const mobileOverride: Config = { browser: { contextOptions: devices[device] } };
+  return mergeCLIConfigSources(configInFile, envOverrides, cliOverrides, mobileOverride, source);
 }
 
 export function configFromCLIOptions(cliOptions: CLIOptions): Config {
@@ -157,24 +191,14 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
       launchOptions.proxy.bypass = cliOptions.proxyBypass;
   }
 
-  let device = cliOptions.device;
-  const resolvedBrowserName = browserName ?? 'chromium';
-  if (cliOptions.mobile) {
-    if (device)
-      throw new Error('Cannot use --mobile together with --device, pick one.');
-    if (resolvedBrowserName === 'firefox')
-      throw new Error('--mobile is not supported with the Firefox browser.');
-    device = resolvedBrowserName === 'webkit' ? 'iPhone 17' : 'Pixel 10';
-  }
-
-  if (device && cliOptions.cdpEndpoint)
+  if (cliOptions.device && cliOptions.cdpEndpoint)
     throw new Error('Device emulation is not supported with cdpEndpoint.');
 
   if (cliOptions.cdpEndpoint && cliOptions.cdpLaunchCommand)
     throw new Error('CDP launch is not supported with cdpEndpoint.');
 
   // Context options
-  const contextOptions: BrowserContextOptions = device ? devices[device] : {};
+  const contextOptions: BrowserContextOptions = cliOptions.device ? devices[cliOptions.device] : {};
   if (cliOptions.storageState)
     contextOptions.storageState = cliOptions.storageState;
 
@@ -238,7 +262,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
   };
 }
 
-function configFromEnv(): Config {
+function cliOptionsFromEnv(): CLIOptions {
   const options: CLIOptions = {};
   options.allowedOrigins = semicolonSeparatedList(process.env.PLAYWRIGHT_MCP_ALLOWED_ORIGINS);
   options.blockedOrigins = semicolonSeparatedList(process.env.PLAYWRIGHT_MCP_BLOCKED_ORIGINS);
@@ -275,7 +299,7 @@ function configFromEnv(): Config {
   options.viewportSize = envToString(process.env.PLAYWRIGHT_MCP_VIEWPORT_SIZE);
   options.navigationTimeout = envToNumber(process.env.PLAYWRIGHT_MCP_NAVIGATION_TIMEOUT);
   options.defaultTimeout = envToNumber(process.env.PLAYWRIGHT_MCP_DEFAULT_TIMEOUT);
-  return configFromCLIOptions(options);
+  return options;
 }
 
 async function loadConfig(configFile: string | undefined): Promise<Config> {

--- a/src/program.ts
+++ b/src/program.ts
@@ -91,7 +91,7 @@ function configureBaseProgram() {
       .option('--ignore-https-errors', 'ignore https errors')
       .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".')
-      .option('--mobile', 'emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Cannot be combined with --device, CDP attach/launch modes, or --extension.')
+      .option('--mobile', 'emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Cannot be combined with --device, CDP attach/launch modes, remote browser endpoints, or --extension.')
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
       .option('--port <port>', 'port to listen on for MCP Streamable HTTP transport.')

--- a/src/program.ts
+++ b/src/program.ts
@@ -91,7 +91,7 @@ function configureBaseProgram() {
       .option('--ignore-https-errors', 'ignore https errors')
       .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".')
-      .option('--mobile', 'emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Cannot be combined with --device.')
+      .option('--mobile', 'emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Cannot be combined with --device, CDP attach/launch modes, or --extension.')
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
       .option('--port <port>', 'port to listen on for MCP Streamable HTTP transport.')

--- a/src/program.ts
+++ b/src/program.ts
@@ -91,6 +91,7 @@ function configureBaseProgram() {
       .option('--ignore-https-errors', 'ignore https errors')
       .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".')
+      .option('--mobile', 'emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Cannot be combined with --device.')
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
       .option('--port <port>', 'port to listen on for MCP Streamable HTTP transport.')

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -149,15 +149,13 @@ const find = defineTabTool({
         windows.push({ start, end });
     }
 
+    const parents = parentIndices(lines, indents);
     const path = new Set<number>();
-    for (const match of matchedLines) {
-      path.add(match);
-      for (const ancestor of ancestorIndices(lines, indents, match))
-        path.add(ancestor);
-    }
+    for (const match of matchedLines)
+      addPath(path, parents, match);
 
     const snippets = windows.map(window => {
-      const indices = ancestorIndices(lines, indents, window.start);
+      const indices = ancestorIndices(parents, window.start);
       for (let i = window.start; i <= window.end; i++)
         indices.push(i);
 
@@ -198,17 +196,28 @@ function indentOf(line: string): number {
   return line.length - line.trimStart().length;
 }
 
-function ancestorIndices(lines: string[], indents: number[], index: number): number[] {
-  const result: number[] = [];
-  let indent = indents[index];
-  for (let i = index - 1; i >= 0 && indent > 0; i--) {
-    if (!lines[i].trim())
-      continue;
-    if (indents[i] < indent) {
-      result.push(i);
-      indent = indents[i];
-    }
+function parentIndices(lines: string[], indents: number[]): number[] {
+  const parents = new Array<number>(lines.length).fill(-1);
+  const stack: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    while (stack.length && indents[stack[stack.length - 1]] >= indents[i])
+      stack.pop();
+    parents[i] = stack[stack.length - 1] ?? -1;
+    if (lines[i].trim())
+      stack.push(i);
   }
+  return parents;
+}
+
+function addPath(path: Set<number>, parents: number[], index: number) {
+  for (let current = index; current !== -1 && !path.has(current); current = parents[current])
+    path.add(current);
+}
+
+function ancestorIndices(parents: number[], index: number): number[] {
+  const result: number[] = [];
+  for (let current = parents[index]; current !== -1; current = parents[current])
+    result.push(current);
   return result.reverse();
 }
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -98,7 +98,7 @@ const find = defineTabTool({
   schema: {
     name: 'browser_find',
     title: 'Find in page snapshot',
-    description: 'Search the accessibility snapshot of the current page for text or a regular expression. Returns matching snapshot nodes with a few lines of surrounding context.',
+    description: 'Search the accessibility snapshot of the current page for text or a regular expression. Returns matching snapshot nodes with a few lines of surrounding context, each shown under its path from the root of the tree.',
     inputSchema: findSchema,
     type: 'readOnly',
   },
@@ -126,6 +126,7 @@ const find = defineTabTool({
     }
 
     const lines = (await tab.page.ariaSnapshot({ mode: 'ai' })).split('\n');
+    const indents = lines.map(indentOf);
     const matchedLines: number[] = [];
     for (let i = 0; i < lines.length; i++) {
       if (matches(lines[i]))
@@ -148,7 +149,27 @@ const find = defineTabTool({
         windows.push({ start, end });
     }
 
-    const snippets = windows.map(window => truncateDataUrls(lines.slice(window.start, window.end + 1).join('\n')));
+    const path = new Set<number>();
+    for (const match of matchedLines) {
+      path.add(match);
+      for (const ancestor of ancestorIndices(lines, indents, match))
+        path.add(ancestor);
+    }
+
+    const snippets = windows.map(window => {
+      const indices = ancestorIndices(lines, indents, window.start);
+      for (let i = window.start; i <= window.end; i++)
+        indices.push(i);
+
+      const out: string[] = [];
+      for (let i = 0; i < indices.length; i++) {
+        const index = indices[i];
+        if (i > 0 && index > indices[i - 1] + 1 && !path.has(index) && !path.has(indices[i - 1]))
+          out.push(' '.repeat(indents[index]) + '...');
+        out.push(lines[index]);
+      }
+      return truncateDataUrls(out.join('\n'));
+    });
     const matchWord = matchedLines.length === 1 ? 'match' : 'matches';
     response.addResult(`Found ${matchedLines.length} ${matchWord} for ${query}:\n\n${snippets.join('\n\n----\n\n')}`);
   },
@@ -171,6 +192,24 @@ function isValidRegex(source: string): boolean {
   } catch {
     return false;
   }
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+function ancestorIndices(lines: string[], indents: number[], index: number): number[] {
+  const result: number[] = [];
+  let indent = indents[index];
+  for (let i = index - 1; i >= 0 && indent > 0; i--) {
+    if (!lines[i].trim())
+      continue;
+    if (indents[i] < indent) {
+      result.push(i);
+      indent = indents[i];
+    }
+  }
+  return result.reverse();
 }
 
 export const elementSchema = z.object({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -297,6 +297,13 @@ describe('Config', () => {
           .rejects.toThrow('Mobile emulation is not supported with cdpEndpoint.');
     });
 
+    it('rejects mobile emulation with a config-file remote endpoint', async () => {
+      const configFile = await writeConfigFile({ browser: { remoteEndpoint: 'ws://127.0.0.1:3000' } });
+
+      await expect(resolveCLIConfig({ config: configFile, mobile: true }))
+          .rejects.toThrow('Mobile emulation is not supported with remoteEndpoint.');
+    });
+
     it('rejects mobile emulation with CDP launch', async () => {
       await expect(resolveCLIConfig({ mobile: true, cdpLaunchCommand: 'echo' }))
           .rejects.toThrow('Mobile emulation is not supported with --cdp-launch-command.');

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -197,6 +197,50 @@ describe('Config', () => {
     });
   });
 
+  describe('resolveCLIConfig mobile', () => {
+    const savedMobile = process.env.PLAYWRIGHT_MCP_MOBILE;
+
+    afterEach(() => {
+      if (savedMobile === undefined)
+        delete process.env.PLAYWRIGHT_MCP_MOBILE;
+      else
+        process.env.PLAYWRIGHT_MCP_MOBILE = savedMobile;
+    });
+
+    it('uses a Chromium mobile device by default', async () => {
+      const config = await resolveCLIConfig({ mobile: true });
+
+      expect(config.browser.contextOptions.isMobile).toBe(true);
+      expect(config.browser.contextOptions.userAgent).toContain('Pixel 10');
+    });
+
+    it('uses a WebKit mobile device for WebKit', async () => {
+      const config = await resolveCLIConfig({ mobile: true, browser: 'webkit' });
+
+      expect(config.browser.contextOptions.isMobile).toBe(true);
+      expect(config.browser.contextOptions.viewport).toEqual({ width: 402, height: 681 });
+    });
+
+    it('reads mobile emulation from the environment', async () => {
+      process.env.PLAYWRIGHT_MCP_MOBILE = '1';
+
+      const config = await resolveCLIConfig({});
+
+      expect(config.browser.contextOptions.isMobile).toBe(true);
+      expect(config.browser.contextOptions.userAgent).toContain('Pixel 10');
+    });
+
+    it('rejects mobile emulation with Firefox', async () => {
+      await expect(resolveCLIConfig({ mobile: true, browser: 'firefox' }))
+          .rejects.toThrow('--mobile is not supported with the Firefox browser.');
+    });
+
+    it('rejects mobile emulation with an explicit device', async () => {
+      await expect(resolveCLIConfig({ mobile: true, device: 'iPhone 15' }))
+          .rejects.toThrow('Cannot use --mobile together with --device');
+    });
+  });
+
   describe('outputFile', () => {
     it('should generate output file path with filename', async () => {
       const config = await resolveConfig({});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, it, expect } from 'vitest';
 import { resolveConfig, resolveCLIConfig, outputFile, parseCdpHeaders } from '../src/config.js';
 import type { Config } from '../config.js';
+
+async function writeConfigFile(config: Config): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-config-test-'));
+  const configFile = path.join(dir, 'config.json');
+  await fs.promises.writeFile(configFile, JSON.stringify(config), 'utf-8');
+  return configFile;
+}
 
 describe('Config', () => {
   describe('resolveConfig', () => {
@@ -198,13 +208,22 @@ describe('Config', () => {
   });
 
   describe('resolveCLIConfig mobile', () => {
-    const savedMobile = process.env.PLAYWRIGHT_MCP_MOBILE;
+    const envKeys = [
+      'PLAYWRIGHT_MCP_CDP_ENDPOINT',
+      'PLAYWRIGHT_MCP_DEVICE',
+      'PLAYWRIGHT_MCP_MOBILE',
+    ];
+    const saved: Record<string, string | undefined> = {};
+    for (const key of envKeys)
+      saved[key] = process.env[key];
 
     afterEach(() => {
-      if (savedMobile === undefined)
-        delete process.env.PLAYWRIGHT_MCP_MOBILE;
-      else
-        process.env.PLAYWRIGHT_MCP_MOBILE = savedMobile;
+      for (const key of envKeys) {
+        if (saved[key] === undefined)
+          delete process.env[key];
+        else
+          process.env[key] = saved[key];
+      }
     });
 
     it('uses a Chromium mobile device by default', async () => {
@@ -221,6 +240,23 @@ describe('Config', () => {
       expect(config.browser.contextOptions.viewport).toEqual({ width: 402, height: 681 });
     });
 
+    it('uses the config-file browser when selecting the mobile device', async () => {
+      const configFile = await writeConfigFile({ browser: { browserName: 'webkit' } });
+
+      const config = await resolveCLIConfig({ config: configFile, mobile: true });
+
+      expect(config.browser.browserName).toBe('webkit');
+      expect(config.browser.contextOptions.isMobile).toBe(true);
+      expect(config.browser.contextOptions.userAgent).toContain('iPhone');
+    });
+
+    it('lets explicit CLI context options override the inferred mobile device', async () => {
+      const config = await resolveCLIConfig({ mobile: true, viewportSize: '800,600' });
+
+      expect(config.browser.contextOptions.isMobile).toBe(true);
+      expect(config.browser.contextOptions.viewport).toEqual({ width: 800, height: 600 });
+    });
+
     it('reads mobile emulation from the environment', async () => {
       process.env.PLAYWRIGHT_MCP_MOBILE = '1';
 
@@ -235,9 +271,40 @@ describe('Config', () => {
           .rejects.toThrow('--mobile is not supported with the Firefox browser.');
     });
 
+    it('rejects mobile emulation with a config-file Firefox browser', async () => {
+      const configFile = await writeConfigFile({ browser: { browserName: 'firefox' } });
+
+      await expect(resolveCLIConfig({ config: configFile, mobile: true }))
+          .rejects.toThrow('--mobile is not supported with the Firefox browser.');
+    });
+
     it('rejects mobile emulation with an explicit device', async () => {
       await expect(resolveCLIConfig({ mobile: true, device: 'iPhone 15' }))
           .rejects.toThrow('Cannot use --mobile together with --device');
+    });
+
+    it('rejects mobile emulation with an environment device', async () => {
+      process.env.PLAYWRIGHT_MCP_DEVICE = 'iPhone 15';
+
+      await expect(resolveCLIConfig({ mobile: true }))
+          .rejects.toThrow('Cannot use --mobile together with --device');
+    });
+
+    it('rejects mobile emulation with a merged CDP endpoint', async () => {
+      process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT = 'http://127.0.0.1:9222';
+
+      await expect(resolveCLIConfig({ mobile: true }))
+          .rejects.toThrow('Mobile emulation is not supported with cdpEndpoint.');
+    });
+
+    it('rejects mobile emulation with CDP launch', async () => {
+      await expect(resolveCLIConfig({ mobile: true, cdpLaunchCommand: 'echo' }))
+          .rejects.toThrow('Mobile emulation is not supported with --cdp-launch-command.');
+    });
+
+    it('rejects mobile emulation with extension mode', async () => {
+      await expect(resolveCLIConfig({ mobile: true, extension: true }))
+          .rejects.toThrow('Mobile emulation is not supported with --extension.');
     });
   });
 

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -60,6 +60,7 @@ describe('CLI command dispatch contract', () => {
       expect(help).toContain('--browser');
       expect(help).toContain('--config');
       expect(help).toContain('--headless');
+      expect(help).toContain('--mobile');
     });
   });
 

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -125,6 +125,69 @@ describe('Snapshot Tools', () => {
     expect(response.addResult).not.toHaveBeenCalledWith(expect.stringContaining('----'));
   });
 
+  it('should show browser_find matches under their path from the root', async () => {
+    const context = findContext([
+      '- main [ref=e1]:',
+      '  - region "Sidebar" [ref=e2]:',
+      '    - navigation "Primary" [ref=e3]:',
+      '      - list [ref=e4]:',
+      '        - listitem [ref=e5]:',
+      '          - link "Home" [ref=e6]',
+      '        - listitem [ref=e7]:',
+      '          - link "Products" [ref=e8]',
+      '        - listitem [ref=e9]:',
+      '          - link "About" [ref=e10]',
+      '        - listitem [ref=e11]:',
+      '          - link "Contact" [ref=e12]',
+      '        - listitem [ref=e13]:',
+      '          - link "Careers" [ref=e14]',
+      '        - listitem [ref=e15]:',
+      '          - link "Deep Target Link" [ref=e16]',
+    ].join('\n'));
+    const response = findResponse();
+
+    await findTool.handle(context as any, { text: 'Deep Target Link' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining([
+      'Found 1 match for "Deep Target Link":',
+      '',
+      '- main [ref=e1]:',
+      '  - region "Sidebar" [ref=e2]:',
+      '    - navigation "Primary" [ref=e3]:',
+      '      - list [ref=e4]:',
+      '        - listitem [ref=e13]:',
+      '          - link "Careers" [ref=e14]',
+      '        - listitem [ref=e15]:',
+      '          - link "Deep Target Link" [ref=e16]',
+    ].join('\n')));
+  });
+
+  it('should mark gaps inside off-path browser_find context', async () => {
+    const context = findContext([
+      '- main [ref=e1]:',
+      '  - group "Toolbar" [ref=e2]:',
+      '    - button "One" [ref=e3]',
+      '    - button "Two" [ref=e4]',
+      '    - button "Three" [ref=e5]',
+      '    - button "Four" [ref=e6]',
+      '  - group "Content" [ref=e7]:',
+      '    - button "Target Button" [ref=e8]',
+    ].join('\n'));
+    const response = findResponse();
+
+    await findTool.handle(context as any, { text: 'Target Button' }, response as any);
+
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining([
+      '- main [ref=e1]:',
+      '  - group "Toolbar" [ref=e2]:',
+      '    ...',
+      '    - button "Three" [ref=e5]',
+      '    - button "Four" [ref=e6]',
+      '  - group "Content" [ref=e7]:',
+      '    - button "Target Button" [ref=e8]',
+    ].join('\n')));
+  });
+
   it('should report when browser_find has no matches', async () => {
     const context = findContext('- button "Submit"');
     const response = findResponse();

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -188,6 +188,21 @@ describe('Snapshot Tools', () => {
     ].join('\n')));
   });
 
+  it('should keep broad deep browser_find queries near-linear', async () => {
+    const lines = [];
+    for (let i = 0; i < 3000; i++)
+      lines.push(`${'  '.repeat(i)}- group "Target ${i}":`);
+    const context = findContext(lines.join('\n'));
+    const response = findResponse();
+
+    const start = performance.now();
+    await findTool.handle(context as any, { text: 'Target' }, response as any);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(1500);
+    expect(response.addResult).toHaveBeenCalledWith(expect.stringContaining('Found 3000 matches for "Target":'));
+  });
+
   it('should report when browser_find has no matches', async () => {
     const context = findContext('- button "Submit"');
     const response = findResponse();


### PR DESCRIPTION
## Summary

- Mirror upstream `browser_find` path-aware snippets from https://github.com/microsoft/playwright/pull/41654 and https://github.com/microsoft/playwright/commit/32b60a7d9bb9f278897a6028699c9e8496ad32b0.
- Add upstream-compatible `--mobile` / `PLAYWRIGHT_MCP_MOBILE` device emulation from https://github.com/microsoft/playwright/pull/41657 and https://github.com/microsoft/playwright/commit/5de136532765e4e7c254fa47417de0de20d2f4d9.
- Document the new find output and mobile CLI behavior.

## Monitored upstream items

- https://github.com/microsoft/playwright/pull/41652 / https://github.com/microsoft/playwright/commit/810cb7fd1ea930eeef4cec704265749c6e22af11: no local change needed; this repo already defaults Chromium sandboxing on in `src/config.ts`.
- https://github.com/microsoft/playwright/issues/41661: no code change yet because the upstream config/CLI shape is still open; local tracking issue: https://github.com/JustasMonkev/mcp-accessibility-scanner/issues/119.

## Why

Playwright MCP now renders find results under the accessibility-tree path and offers a mobile shortcut over device emulation. This server exposes matching MCP tool and CLI surfaces, so keeping them aligned avoids divergent behavior.

## Validation

- `npm test -- tests/tools-snapshot.test.ts tests/config.test.ts tests/program.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--mobile` option to emulate a generic mobile device, including support via an environment variable.
  * Improved `browser_find` results to show matching content with surrounding context and clearer tree-path context.

* **Bug Fixes**
  * Added validation for incompatible mobile-emulation combinations to prevent unsupported setups.

* **Documentation**
  * Updated help and README guidance for mobile emulation and `browser_find` output details.

* **Tests**
  * Expanded coverage for mobile behavior and added more `browser_find` search and performance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->