### PR TITLE
fix: preserve CDP browser defaults on attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Create a `config.json` file with the following options:
 - `browser.cdpHeaders`: Map of HTTP headers to send with the CDP connect request, e.g. `{ "Authorization": "Bearer <token>" }`, for endpoints that require header-based authentication
 - `browser.cdpTimeout`: Maximum time in milliseconds to wait when connecting to the CDP endpoint (default: `30000`)
 - `browser.cdpLaunch`: Launch a Chromium-family desktop app with CDP enabled, wait for the endpoint, and manage the child process lifecycle
+- CDP attach modes preserve the target browser's existing default-context settings instead of applying Playwright's defaults.
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -144,6 +144,7 @@ class CdpContextFactory extends BaseContextFactory {
     return playwright.chromium.connectOverCDP(this.config.browser.cdpEndpoint!, {
       headers: cdpConnectHeaders(clientInfo, this.config.browser),
       timeout: this.config.browser.cdpTimeout,
+      noDefaults: true,
     });
   }
 
@@ -211,6 +212,7 @@ class CdpLaunchContextFactory implements BrowserContextFactory {
     const connectOptions: playwright.ConnectOverCDPOptions = {
       headers: cdpConnectHeaders(clientInfo, this.config.browser),
       timeout: this.config.browser.cdpTimeout,
+      noDefaults: true,
     };
     for (;;) {
       try {

--- a/tests/browserContextFactory.test.ts
+++ b/tests/browserContextFactory.test.ts
@@ -128,6 +128,7 @@ describe('browserContextFactory', () => {
         'Authorization': 'Bearer token:with:colons',
       },
       timeout: 1234,
+      noDefaults: true,
     });
   });
 
@@ -160,6 +161,7 @@ describe('browserContextFactory', () => {
         'Authorization': 'Bearer abc',
       },
       timeout: 4321,
+      noDefaults: true,
     });
   });
 
@@ -203,6 +205,7 @@ describe('browserContextFactory', () => {
       headers: {
         'User-Agent': 'vitest/1.0.0',
       },
+      noDefaults: true,
     });
 
     await result.close();


### PR DESCRIPTION
## Summary
- Mirror upstream Playwright MCP change https://github.com/microsoft/playwright/pull/41676 / https://github.com/microsoft/playwright/commit/39a418adf4f28feed1d2e72b4923e51e9a8e874c.
- Pass `noDefaults: true` for both `--cdp-endpoint` and `--cdp-launch` CDP attaches.
- Update CDP factory expectations so the attach options stay covered.

## Why it matters
Attaching to an existing browser should not override its default context settings, and some CDP targets reject default browser setup commands.

## Validation
- `npm test -- tests/browserContextFactory.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to existing or newly launched browser sessions using CDP, including startup and retry paths.
  * Reduced connection issues so browser automation attaches more consistently in desktop and remote scenarios.
* **Documentation**
  * Updated the “Configuration Options” section to clarify that CDP attach modes preserve the target browser’s existing default-context settings instead of applying Playwright defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->