### PR TITLE
feat: sync browser_drop, evaluate, and network request tools

### DIFF
--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -152,6 +152,12 @@ const tests = [
     await callTool('browser_network_requests', {});
   }),
 
+  test('browser_network_request', async () => {
+    await callTool('browser_navigate', { url: `${state.fixtureOrigin}/audit-site` });
+    const result = await callTool('browser_network_request', { index: 1 });
+    assertText(result, /\[GET\]|General|status:/i);
+  }),
+
   test('browser_take_screenshot', async () => {
     await navigate('<title>Screenshot</title><h1>Screenshot OK</h1>');
     const result = await callTool('browser_take_screenshot', {
@@ -185,6 +191,19 @@ const tests = [
       endElement: 'Drop target',
       endRef,
     });
+  }),
+
+  test('browser_drop', async () => {
+    const snapshot = await navigate([
+      '<title>Drop</title>',
+      '<div aria-label="Drop zone" style="width:120px;height:60px;background:#cfa" ',
+      'ondragover="event.preventDefault()" ',
+      'ondrop="event.preventDefault();document.body.dataset.dropped=event.dataTransfer.getData(\'text/plain\')">Drop zone</div>',
+    ].join(''));
+    const ref = refFor(snapshot, 'Drop zone');
+    await callTool('browser_drop', { element: 'Drop zone', ref, data: { 'text/plain': 'mcp-drop-ok' } });
+    const result = await callTool('browser_evaluate', { function: '() => document.body.dataset.dropped' });
+    assertText(result, /mcp-drop-ok/);
   }),
 
   test('browser_hover', async () => {

--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -164,13 +164,13 @@ const tests = [
 
   test('browser_network_requests', async () => {
     await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-json` });
-    const result = await callTool('browser_network_requests', {});
+    const result = await callTool('browser_network_requests', { static: true });
     assertText(result, /network-json/);
   }),
 
   test('browser_network_request', async () => {
     await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-json` });
-    const list = await callTool('browser_network_requests', {});
+    const list = await callTool('browser_network_requests', { static: true });
     const match = resultText(list).match(/^(\d+)\. \[GET\] .*\/network-json/m);
     if (!match)
       throw new Error(`Could not find /network-json in network list:\n${resultText(list).slice(0, 4000)}`);

--- a/README.md
+++ b/README.md
@@ -321,6 +321,12 @@ Hover over element on page.
 Perform drag and drop between two elements.
 - Parameters: `startElement`, `startRef`, `endElement`, `endRef`
 
+#### `browser_drop`
+Drop files or MIME-typed data onto one element, as if dragged from outside the page.
+- Parameters: `element`, `ref`, `paths` (optional array of absolute file paths), `data` (optional map of MIME type to string value)
+- At least one non-empty `paths` or `data` value is required.
+- File paths must resolve inside the MCP client's filesystem root or the configured output directory.
+
 #### `browser_select_option`
 Select an option in a dropdown.
 - Parameters: `element`, `ref`, `values` (array)
@@ -334,8 +340,8 @@ Press a key on the keyboard.
 - Parameters: `key` (e.g., 'ArrowLeft' or 'a')
 
 #### `browser_evaluate`
-Evaluate a JavaScript expression on the page, or on a specific element when a `ref` is provided. The function's return value is serialized back as the result.
-- Parameters: `function` (e.g., `() => document.title` or `(element) => element.textContent`), `element` (optional), `ref` (optional)
+Evaluate JavaScript on the page, or on a specific element when a `ref` is provided. The input may be a function or a plain expression, and promises are awaited.
+- Parameters: `function` (e.g., `() => document.title`, `(element) => element.textContent`, or `document.title`), `element` (optional), `ref` (optional)
 
 ### Screenshot & Visual Tools
 
@@ -376,8 +382,17 @@ Returns all console messages from the page.
 Large `data:` URL payloads in console messages are truncated to their media type prefix.
 
 #### `browser_network_requests`
-Returns all network requests since loading the page.
+Returns a numbered list of network requests since loading the page. Successful static resources are hidden by default; failed resources and fetch/XHR requests remain visible. The displayed numbers are stable indexes for `browser_network_request`.
+- Parameters: `static` (optional boolean, default `false`), `filter` (optional URL regular expression), `filename` (optional output filename)
 Large `data:` URL payloads in request URLs are truncated to their media type prefix.
+
+#### `browser_network_request`
+Returns metadata and headers for one request, or one specific request/response part. Bodies are read only when a body part is requested.
+- Parameters: `index` (1-based index from `browser_network_requests`), `part` (optional: `request-headers`, `request-body`, `response-headers`, or `response-body`), `filename` (optional output filename), `includeSensitiveHeaders` (optional boolean, default `false`), `allowCompressedBody` (optional boolean, default `false`)
+- Authorization, cookie, API-key, token, and secret header values are redacted by default.
+- Text request/response bodies are returned inline unless `filename` is provided. Binary bodies are saved byte-for-byte to an output file and returned as a file resource link.
+- Inline text bodies are limited to 1 MiB; provide `filename` for larger text. Body reads are capped at 25 MiB, and response reads fail closed when Playwright cannot report their size.
+- Compressed response bodies require explicit `allowCompressedBody: true` because their decoded size cannot be bounded before Playwright materializes them.
 
 ### Utility Tools
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -205,11 +205,12 @@ These tools are always available and work in the interactive REPL.
 | `browser_press_key` | Press key: `{"key": "Enter"}` |
 | `browser_hover` | Hover over element |
 | `browser_drag` | Drag between elements |
+| `browser_drop` | Drop files or MIME data onto an element |
 | `browser_select_option` | Select dropdown option |
 | `browser_fill_form` | Fill multiple form fields at once |
 | `browser_file_upload` | Upload files: `{"paths": ["/path/to/file"]}` |
 | `browser_handle_dialog` | Handle browser dialog: `{"accept": true}` |
-| `browser_evaluate` | Run JavaScript on page |
+| `browser_evaluate` | Run a JavaScript function or plain expression on page |
 
 ### Tabs & Config
 
@@ -224,7 +225,8 @@ These tools are always available and work in the interactive REPL.
 | Tool | Description |
 |------|-------------|
 | `browser_console_messages` | Get all console messages |
-| `browser_network_requests` | Get all network requests |
+| `browser_network_requests` | List network requests with stable indexes |
+| `browser_network_request` | Inspect headers or body for one indexed request |
 
 ### Optional Tools (require `--caps`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"@stylistic/eslint-plugin": "^5.10.0",
 				"@types/chrome": "^0.1.42",
 				"@types/debug": "^4.1.13",
-				"@types/node": "^25.9.5",
+				"@types/node": "^25.9.1",
 				"@types/ws": "^8.18.1",
 				"@typescript-eslint/eslint-plugin": "^8.60.0",
 				"@typescript-eslint/parser": "^8.60.0",
@@ -988,9 +988,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
-			"integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"@stylistic/eslint-plugin": "^5.10.0",
 				"@types/chrome": "^0.1.42",
 				"@types/debug": "^4.1.13",
-				"@types/node": "^25.9.1",
+				"@types/node": "^25.9.5",
 				"@types/ws": "^8.18.1",
 				"@typescript-eslint/eslint-plugin": "^8.60.0",
 				"@typescript-eslint/parser": "^8.60.0",
@@ -988,9 +988,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"version": "25.9.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+			"integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/chrome": "^0.1.42",
 		"@types/debug": "^4.1.13",
-		"@types/node": "^25.9.5",
+		"@types/node": "^25.9.1",
 		"@types/ws": "^8.18.1",
 		"@typescript-eslint/eslint-plugin": "^8.60.0",
 		"@typescript-eslint/parser": "^8.60.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/chrome": "^0.1.42",
 		"@types/debug": "^4.1.13",
-		"@types/node": "^25.9.1",
+		"@types/node": "^25.9.5",
 		"@types/ws": "^8.18.1",
 		"@typescript-eslint/eslint-plugin": "^8.60.0",
 		"@typescript-eslint/parser": "^8.60.0",

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -17,7 +17,6 @@
 import { z } from 'zod';
 
 import { defineTabTool } from './tool.js';
-import * as javascript from '../utils/codegen.js';
 import { generateLocator } from './utils.js';
 
 import type * as playwright from 'playwright';
@@ -42,25 +41,55 @@ const evaluate = defineTabTool({
     response.setIncludeSnapshot();
 
     let locator: playwright.Locator | undefined;
-    if (params.ref && params.element) {
+    if (params.ref && params.element)
       locator = await tab.refLocator({ ref: params.ref, element: params.element });
-      response.addCode(`await page.${await generateLocator(locator)}.evaluate(${javascript.quote(params.function)});`);
-    } else {
-      response.addCode(`await page.evaluate(${javascript.quote(params.function)});`);
-    }
 
-    await tab.waitForCompletion(async () => {
-      // playwright-core 1.59 removed the private `_evaluateFunction` helper
-      // (microsoft/playwright#39646). The public `evaluate()` serializes its
-      // argument via `Function.prototype.toString`, so hand it an empty function
-      // whose `toString()` returns the user-supplied source instead.
-      const func = new Function() as any;
-      func.toString = () => params.function;
-      const result = locator ? await locator.evaluate(func) : await tab.page.evaluate(func);
-      response.addResult(JSON.stringify(result, null, 2) || 'undefined');
-    });
+    try {
+      await tab.waitForCompletion(async () => {
+        let evalResult: { result: unknown, isFunction: boolean };
+        if (locator) {
+          evalResult = await locator.evaluate(async (element, source) => {
+            const value = eval(`(${source})`);
+            const isFunction = typeof value === 'function';
+            const result = await (isFunction ? value(element) : value);
+            return { result, isFunction };
+          }, params.function);
+        } else {
+          evalResult = await tab.page.evaluate(async source => {
+            const value = eval(`(${source})`);
+            const isFunction = typeof value === 'function';
+            const result = await (isFunction ? value() : value);
+            return { result, isFunction };
+          }, params.function);
+        }
+
+        const codeExpression = evalResult.isFunction
+          ? params.function
+          : locator ? `(element) => (${params.function})` : `() => (${params.function})`;
+        if (locator)
+          response.addCode(`await page.${await generateLocator(locator)}.evaluate(${codeExpression});`);
+        else
+          response.addCode(`await page.evaluate(${codeExpression});`);
+
+        response.addResult(stringifyResult(evalResult.result));
+      });
+    } catch (error) {
+      response.addError(error instanceof Error ? error.message : String(error));
+    }
   },
 });
+
+function stringifyResult(result: unknown): string {
+  try {
+    return JSON.stringify(result, null, 2) ?? 'undefined';
+  } catch {
+    try {
+      return String(result);
+    } catch {
+      return 'undefined';
+    }
+  }
+}
 
 export default [
   evaluate,

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -14,8 +14,94 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { z } from 'zod';
+
+import * as javascript from '../utils/codegen.js';
 import { defineTabTool } from './tool.js';
+import { elementSchema } from './snapshot.js';
+import { generateLocator } from './utils.js';
+
+import type { Tab } from '../tab.js';
+
+const dropSchema = elementSchema.extend({
+  paths: z.array(z.string().min(1).refine(filePath => path.isAbsolute(filePath), { message: 'Drop file paths must be absolute.' })).optional().describe('Absolute paths to files to drop onto the element.'),
+  data: z.record(z.string(), z.string()).optional().describe('Data to drop, as a map of MIME type to string value (e.g. {"text/plain": "hello", "text/uri-list": "https://example.com"}).'),
+}).superRefine((params, context) => {
+  if (!params.paths?.length && !Object.keys(params.data ?? {}).length)
+    context.addIssue({ code: 'custom', message: 'At least one of "paths" or "data" must be provided' });
+});
+
+const drop = defineTabTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_drop',
+    title: 'Drop files or data onto an element',
+    description: 'Drop files or MIME-typed data onto an element, as if dragged from outside the page. At least one of "paths" or "data" must be provided.',
+    inputSchema: dropSchema,
+    type: 'destructive',
+  },
+
+  handle: async (tab, params, response) => {
+    if (!params.paths?.length && !Object.keys(params.data ?? {}).length) {
+      response.addError('At least one of "paths" or "data" must be provided');
+      return;
+    }
+
+    response.setIncludeSnapshot();
+
+    const locator = await tab.refLocator(params);
+    const resolvedPaths = params.paths?.length ? await resolveDropPaths(tab, params.paths) : undefined;
+    const payload = {
+      ...(resolvedPaths?.length && { files: resolvedPaths.length === 1 ? resolvedPaths[0] : resolvedPaths }),
+      ...(params.data && Object.keys(params.data).length && { data: params.data }),
+    };
+
+    response.addCode(`await page.${await generateLocator(locator)}.drop(${javascript.formatObject(payload)});`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.drop(payload);
+    });
+  },
+});
+
+async function resolveDropPaths(tab: Tab, filePaths: string[]): Promise<string[]> {
+  const configuredRoots = [
+    tab.context.options.clientInfo.rootPath,
+    tab.context.config.outputDir,
+  ].filter((root): root is string => !!root);
+  if (!configuredRoots.length)
+    throw new Error('File drops require a client filesystem root or configured output directory.');
+
+  const allowedRoots = await Promise.all(configuredRoots.map(async root => {
+    const absoluteRoot = path.resolve(root);
+    return await fs.promises.realpath(absoluteRoot).catch(() => absoluteRoot);
+  }));
+
+  return await Promise.all(filePaths.map(async filePath => {
+    if (!path.isAbsolute(filePath))
+      throw new Error(`Drop file path must be absolute: ${filePath}`);
+
+    let resolvedPath: string;
+    try {
+      resolvedPath = await fs.promises.realpath(filePath);
+    } catch {
+      throw new Error(`Drop file does not exist: ${filePath}`);
+    }
+    if (!allowedRoots.some(root => isPathInside(root, resolvedPath)))
+      throw new Error(`Drop file is outside the client filesystem root and output directory: ${filePath}`);
+    if (!(await fs.promises.stat(resolvedPath)).isFile())
+      throw new Error(`Drop path is not a file: ${filePath}`);
+    return resolvedPath;
+  }));
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
 
 const uploadFile = defineTabTool({
   capability: 'core',
@@ -49,4 +135,5 @@ const uploadFile = defineTabTool({
 
 export default [
   uploadFile,
+  drop,
 ];

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
+import mime from 'mime';
+import RE2 from 're2';
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
 import { truncateDataUrls } from '../utils/dataUrl.js';
 
+import type { Response as ToolResponse } from '../response.js';
+import type { Tab } from '../tab.js';
 import type * as playwright from 'playwright';
 
 const requests = defineTabTool({
@@ -26,25 +32,388 @@ const requests = defineTabTool({
   schema: {
     name: 'browser_network_requests',
     title: 'List network requests',
-    description: 'Returns all network requests since loading the page',
-    inputSchema: z.object({}),
+    description: 'Returns a numbered list of network requests since loading the page. Use browser_network_request with the number to get full details.',
+    inputSchema: z.object({
+      static: z.boolean().default(false).describe('Whether to include successful static resources like images, fonts, scripts, etc. Defaults to false.'),
+      filter: z.string().optional().refine(value => !value || isValidRegex(value), { message: 'Invalid regular expression' }).describe('Only return requests whose URL matches this regular expression (e.g. "/api/.*user").'),
+      filename: z.string().optional().describe('Filename to save the network requests to. If not provided, requests are returned as text.'),
+    }),
     type: 'readOnly',
   },
 
   handle: async (tab, params, response) => {
-    const requests = tab.requests();
-    [...requests.entries()].forEach(([req, res]) => response.addResult(renderRequest(req, res)));
+    const entries = [...tab.requests().entries()];
+    if (!entries.length) {
+      response.addResult('No network requests recorded yet.');
+      return;
+    }
+
+    const filter = params.filter ? new RE2(params.filter) : undefined;
+    const lines: string[] = [];
+    let hiddenStaticCount = 0;
+    for (let i = 0; i < entries.length; i++) {
+      const [request, httpResponse] = entries[i];
+      if (!params.static && !isFetch(request) && isSuccessfulResponse(request, httpResponse)) {
+        hiddenStaticCount++;
+        continue;
+      }
+      if (filter && !filter.test(request.url()))
+        continue;
+      lines.push(`${i + 1}. ${renderRequestLine(request, httpResponse)}`);
+    }
+
+    if (hiddenStaticCount > 0)
+      lines.push(`\nNote: ${hiddenStaticCount} static request${hiddenStaticCount === 1 ? '' : 's'} not shown, run with "static" option to see ${hiddenStaticCount === 1 ? 'it' : 'them'}.`);
+
+    const result = lines.join('\n') || 'No network requests matched the filter.';
+    await addTextResult(tab, response, 'Network requests', result, params.filename, 'text/plain');
   },
 });
 
-function renderRequest(request: playwright.Request, response: playwright.Response | null) {
-  const result: string[] = [];
-  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
+const REQUEST_PARTS = ['request-headers', 'request-body', 'response-headers', 'response-body'] as const;
+type RequestPart = typeof REQUEST_PARTS[number];
+const SENSITIVE_HEADER_PATTERN = /(?:^|[-_])(authorization|cookie|api[-_]?key|auth[-_]?token|access[-_]?token|token|secret)(?:$|[-_])/i;
+const MAX_INLINE_RESPONSE_BODY_BYTES = 1024 * 1024;
+const MAX_RESPONSE_BODY_BYTES = 25 * 1024 * 1024;
+
+const request = defineTabTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_network_request',
+    title: 'Show network request details',
+    description: 'Returns metadata and headers for one network request, or a single part if `part` is set. Use the number from browser_network_requests.',
+    inputSchema: z.object({
+      index: z.number().int().min(1).describe('1-based index of the request, as printed by browser_network_requests.'),
+      part: z.enum(REQUEST_PARTS).optional().describe('Return only this part of the request. Omit to return metadata and headers.'),
+      filename: z.string().optional().describe('Filename to save the result to. If not provided, text output is returned inline.'),
+      includeSensitiveHeaders: z.boolean().default(false).describe('Whether to include sensitive header values such as authorization, cookies, API keys, and tokens. Defaults to false.'),
+      allowCompressedBody: z.boolean().default(false).describe('Whether to read compressed response bodies despite their decoded size being unbounded. Defaults to false.'),
+    }),
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    const entries = [...tab.requests().entries()];
+    const entry = entries[params.index - 1];
+    if (!entry) {
+      response.addError(`Request #${params.index} not found. Use browser_network_requests to see available indexes.`);
+      return;
+    }
+
+    const [networkRequest, httpResponse] = entry;
+    if (params.part) {
+      await renderRequestPart(
+          tab,
+          networkRequest,
+          httpResponse,
+          params.index,
+          params.part,
+          !!params.includeSensitiveHeaders,
+          !!params.allowCompressedBody,
+          response,
+          params.filename
+      );
+      return;
+    }
+
+    await addTextResult(
+        tab,
+        response,
+        'Network request',
+        renderRequestDetails(params.index, networkRequest, httpResponse, !!params.includeSensitiveHeaders),
+        params.filename,
+        'text/plain'
+    );
+  },
+});
+
+function isValidRegex(source: string): boolean {
+  try {
+    new RE2(source);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isFetch(request: playwright.Request): boolean {
+  return ['fetch', 'xhr'].includes(request.resourceType());
+}
+
+function isSuccessfulResponse(request: playwright.Request, response: playwright.Response | null): boolean {
+  return !request.failure() && !!response && response.status() < 400;
+}
+
+function renderRequestLine(request: playwright.Request, response: playwright.Response | null): string {
+  let line = `[${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`;
   if (response)
-    result.push(`=> [${response.status()}] ${response.statusText()}`);
-  return result.join(' ');
+    line += ` => [${response.status()}] ${response.statusText()}`;
+  else if (request.failure())
+    line += ` => [FAILED] ${request.failure()?.errorText ?? 'Unknown error'}`;
+  return line;
+}
+
+function renderRequestDetails(index: number, request: playwright.Request, response: playwright.Response | null, includeSensitiveHeaders: boolean): string {
+  const responseHeaders = response?.headers();
+  const lines: string[] = [];
+  lines.push(`#${index} [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
+
+  lines.push('');
+  lines.push('  General');
+  if (response)
+    lines.push(`    status:    [${response.status()}] ${response.statusText()}`);
+  else if (request.failure())
+    lines.push(`    status:    [FAILED] ${request.failure()?.errorText ?? 'Unknown error'}`);
+  const duration = computeDurationMs(request);
+  if (duration !== undefined)
+    lines.push(`    duration:  ${duration}ms`);
+  lines.push(`    type:      ${request.resourceType()}`);
+  const contentType = responseHeaders?.['content-type'];
+  if (contentType)
+    lines.push(`    mimeType:  ${baseMimeType(contentType)}`);
+
+  appendHeaderSection(lines, 'Request headers', request.headers(), includeSensitiveHeaders);
+  if (responseHeaders)
+    appendHeaderSection(lines, 'Response headers', responseHeaders, includeSensitiveHeaders);
+
+  const hints: string[] = [];
+  if (request.postDataBuffer() !== null)
+    hints.push(partHint('request-body', index));
+  if (canHaveResponseBody(request, response))
+    hints.push(partHint('response-body', index));
+  if (hints.length)
+    lines.push('', ...hints);
+
+  return lines.join('\n');
+}
+
+function computeDurationMs(request: playwright.Request): number | undefined {
+  const timing = request.timing();
+  if (!timing || timing.responseEnd < 0)
+    return undefined;
+  return Math.round(timing.responseEnd);
+}
+
+function partHint(part: 'request-body' | 'response-body', index: number): string {
+  const subject = part === 'request-body' ? 'request body' : 'response body';
+  return `Call browser_network_request with index=${index} and part="${part}" to read the ${subject}.`;
+}
+
+function canHaveResponseBody(request: playwright.Request, response: playwright.Response | null): response is playwright.Response {
+  if (request.method().toUpperCase() === 'HEAD' || !response)
+    return false;
+  const status = response.status();
+  return status !== 204 && status !== 304 && !(status >= 100 && status < 200);
+}
+
+function appendHeaderSection(lines: string[], title: string, headers: Record<string, string>, includeSensitiveHeaders: boolean): void {
+  const entries = Object.entries(headers);
+  if (!entries.length)
+    return;
+  lines.push('');
+  lines.push(`  ${title}`);
+  for (const [key, value] of entries)
+    lines.push(`    ${key}: ${renderHeaderValue(key, value, includeSensitiveHeaders)}`);
+}
+
+async function renderRequestPart(
+  tab: Tab,
+  request: playwright.Request,
+  response: playwright.Response | null,
+  index: number,
+  part: RequestPart,
+  includeSensitiveHeaders: boolean,
+  allowCompressedBody: boolean,
+  toolResponse: ToolResponse,
+  filename?: string
+): Promise<void> {
+  if (part === 'request-headers') {
+    await addTextResult(tab, toolResponse, 'Request headers', renderHeaders(request.headers(), includeSensitiveHeaders), filename, 'text/plain');
+    return;
+  }
+  if (part === 'request-body') {
+    const body = request.postDataBuffer();
+    if (body === null) {
+      toolResponse.addResult('No request body.');
+      return;
+    }
+    if (body.length > MAX_RESPONSE_BODY_BYTES) {
+      toolResponse.addError(`Request body is too large to read (${body.length} bytes; maximum ${MAX_RESPONSE_BODY_BYTES} bytes).`);
+      return;
+    }
+    const contentType = baseMimeType(request.headers()['content-type']) || 'application/octet-stream';
+    if (isTextualMimeType(contentType)) {
+      if (!filename && body.length > MAX_INLINE_RESPONSE_BODY_BYTES) {
+        toolResponse.addError(`Request body is too large to return inline (${body.length} bytes; maximum ${MAX_INLINE_RESPONSE_BODY_BYTES} bytes). Provide filename to save it instead.`);
+        return;
+      }
+      await addTextResult(tab, toolResponse, 'Request body', truncateDataUrls(body.toString('utf8')), filename, contentType);
+      return;
+    }
+    await saveBinaryBody(tab, toolResponse, body, contentType, filename, `request-${index}`, 'Request body');
+    return;
+  }
+  if (!response) {
+    toolResponse.addResult('No response was received for this request.');
+    return;
+  }
+  if (part === 'response-headers') {
+    await addTextResult(tab, toolResponse, 'Response headers', renderHeaders(response.headers(), includeSensitiveHeaders), filename, 'text/plain');
+    return;
+  }
+  if (!canHaveResponseBody(request, response)) {
+    toolResponse.addResult('This response cannot have a body.');
+    return;
+  }
+
+  const responseHeaders = response.headers();
+  const contentType = baseMimeType(responseHeaders['content-type']);
+  const contentEncoding = responseHeaders['content-encoding']?.trim().toLowerCase();
+  if (contentEncoding && contentEncoding !== 'identity' && !allowCompressedBody) {
+    toolResponse.addError(`Response body uses ${contentEncoding} encoding, whose decoded size cannot be bounded safely. Set allowCompressedBody to true to read it explicitly.`);
+    return;
+  }
+  const responseBodySize = await safeResponseBodySize(request);
+  if (responseBodySize === undefined) {
+    toolResponse.addError('Unable to determine the response body size safely.');
+    return;
+  }
+  if (responseBodySize > MAX_RESPONSE_BODY_BYTES) {
+    toolResponse.addError(`Response body is too large to read (${responseBodySize} bytes; maximum ${MAX_RESPONSE_BODY_BYTES} bytes).`);
+    return;
+  }
+  if (!filename && isTextualMimeType(contentType) && responseBodySize > MAX_INLINE_RESPONSE_BODY_BYTES) {
+    toolResponse.addError(`Response body is too large to return inline (${responseBodySize} bytes; maximum ${MAX_INLINE_RESPONSE_BODY_BYTES} bytes). Provide filename to save it instead.`);
+    return;
+  }
+  if (isTextualMimeType(contentType)) {
+    let text: string;
+    try {
+      text = await response.text();
+    } catch {
+      toolResponse.addError('Failed to read the response body.');
+      return;
+    }
+    const textSize = Buffer.byteLength(text);
+    if (textSize > MAX_RESPONSE_BODY_BYTES) {
+      toolResponse.addError(`Response body is too large to read (${textSize} bytes; maximum ${MAX_RESPONSE_BODY_BYTES} bytes).`);
+      return;
+    }
+    if (!filename && textSize > MAX_INLINE_RESPONSE_BODY_BYTES) {
+      toolResponse.addError(`Response body is too large to return inline (${textSize} bytes; maximum ${MAX_INLINE_RESPONSE_BODY_BYTES} bytes). Provide filename to save it instead.`);
+      return;
+    }
+    await addTextResult(tab, toolResponse, 'Response body', truncateDataUrls(text), filename, contentType || 'text/plain');
+    return;
+  }
+
+  let body: Buffer;
+  try {
+    body = await response.body();
+  } catch {
+    toolResponse.addError('Failed to read the response body.');
+    return;
+  }
+  if (!body.length) {
+    toolResponse.addResult('Response body is empty.');
+    return;
+  }
+  if (body.length > MAX_RESPONSE_BODY_BYTES) {
+    toolResponse.addError(`Response body is too large to save (${body.length} bytes; maximum ${MAX_RESPONSE_BODY_BYTES} bytes).`);
+    return;
+  }
+
+  await saveBinaryBody(tab, toolResponse, body, contentType, filename, `response-${index}`, 'Response body');
+}
+
+function renderHeaders(headers: Record<string, string>, includeSensitiveHeaders: boolean): string {
+  const entries = Object.entries(headers);
+  if (!entries.length)
+    return 'No headers.';
+  return entries.map(([key, value]) => `${key}: ${renderHeaderValue(key, value, includeSensitiveHeaders)}`).join('\n');
+}
+
+function renderHeaderValue(name: string, value: string, includeSensitiveHeaders: boolean): string {
+  return !includeSensitiveHeaders && SENSITIVE_HEADER_PATTERN.test(name) ? '<redacted>' : value;
+}
+
+async function safeResponseBodySize(request: playwright.Request): Promise<number | undefined> {
+  try {
+    const size = (await request.sizes()).responseBodySize;
+    return Number.isFinite(size) && size >= 0 ? size : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function saveBinaryBody(
+  tab: Tab,
+  response: ToolResponse,
+  body: Buffer,
+  contentType: string,
+  filename: string | undefined,
+  defaultPrefix: string,
+  title: string
+): Promise<void> {
+  const extension = mime.getExtension(contentType) ?? 'bin';
+  const defaultFilename = `${defaultPrefix}-${new Date().toISOString()}.${extension}`;
+  const outputPath = await tab.context.outputFile(filename ?? defaultFilename);
+  await fs.promises.writeFile(outputPath, body);
+  response.addResult(`Saved ${title.toLowerCase()} to ${outputPath}`);
+  response.addFileResourceLink(outputPath, {
+    name: path.basename(outputPath),
+    title,
+    mimeType: contentType || 'application/octet-stream',
+  });
+}
+
+function baseMimeType(contentType: string | undefined): string {
+  return contentType?.split(';')[0].trim().toLowerCase() ?? '';
+}
+
+function isTextualMimeType(contentType: string): boolean {
+  if (!contentType)
+    return false;
+  if (contentType.startsWith('text/'))
+    return true;
+  if (contentType.endsWith('+json') || contentType.endsWith('+xml'))
+    return true;
+  return [
+    'application/json',
+    'application/xml',
+    'application/xhtml+xml',
+    'application/javascript',
+    'application/ecmascript',
+    'application/x-www-form-urlencoded',
+    'image/svg+xml',
+  ].includes(contentType);
+}
+
+async function addTextResult(
+  tab: Tab,
+  response: ToolResponse,
+  title: string,
+  content: string,
+  filename: string | undefined,
+  mimeType: string
+): Promise<void> {
+  if (!filename) {
+    response.addResult(content);
+    return;
+  }
+
+  const outputPath = await tab.context.outputFile(filename);
+  await fs.promises.writeFile(outputPath, content, 'utf8');
+  response.addResult(`Saved ${title.toLowerCase()} to ${outputPath}`);
+  response.addFileResourceLink(outputPath, {
+    name: path.basename(outputPath),
+    title,
+    mimeType,
+  });
 }
 
 export default [
   requests,
+  request,
 ];

--- a/src/utils/codegen.ts
+++ b/src/utils/codegen.ts
@@ -45,8 +45,10 @@ export function formatObject(value: any, indent = '  '): string {
     if (!keys.length)
       return '{}';
     const tokens: string[] = [];
-    for (const key of keys)
-      tokens.push(`${key}: ${formatObject(value[key])}`);
+    for (const key of keys) {
+      const keyToken = /^[A-Za-z_$][\w$]*$/.test(key) ? key : quote(key);
+      tokens.push(`${keyToken}: ${formatObject(value[key])}`);
+    }
     return `{\n${indent}${tokens.join(`,\n${indent}`)}\n}`;
   }
   return String(value);

--- a/tests/e2e-tools-smoke.test.ts
+++ b/tests/e2e-tools-smoke.test.ts
@@ -53,7 +53,17 @@ const homeHtml = `<!doctype html>
     <main id="main">
       <input aria-label="Search" />
       <button type="button">Open menu</button>
+      <div id="dropzone" role="region" aria-label="Drop target">Drop target</div>
     </main>
+    <script>
+      const dropzone = document.querySelector('#dropzone');
+      dropzone.addEventListener('dragover', event => event.preventDefault());
+      dropzone.addEventListener('drop', async event => {
+        event.preventDefault();
+        const file = event.dataTransfer.files[0];
+        dropzone.dataset.dropped = file ? await file.text() : event.dataTransfer.getData('text/plain');
+      });
+    </script>
   </body>
 </html>`;
 
@@ -85,6 +95,15 @@ async function installFixtureRoutes(browserContext: BrowserContext): Promise<voi
         status: 200,
         contentType: 'text/html; charset=utf-8',
         body: aboutHtml,
+      });
+      return;
+    }
+    if (requestUrl.pathname === '/api/data') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json; charset=utf-8',
+        headers: { 'x-fixture-response': 'network-detail' },
+        body: JSON.stringify({ name: 'Ada' }),
       });
       return;
     }
@@ -141,6 +160,8 @@ describe.skipIf(!canRunE2E)('E2E smoke: accessibility tools', () => {
 
   it('runs tool flow end-to-end against a real browser and local pages', async () => {
     const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-a11y-e2e-'));
+    const dropFilePath = path.join(outputDir, 'drop.txt');
+    await fs.promises.writeFile(dropFilePath, 'dropped file contents');
     launchResources.push(async () => {
       await fs.promises.rm(outputDir, { recursive: true, force: true });
     });
@@ -202,15 +223,67 @@ describe.skipIf(!canRunE2E)('E2E smoke: accessibility tools', () => {
     expect(toolNames).toContain('audit_keyboard');
     expect(toolNames).toContain('audit_site');
     expect(toolNames).toContain('scan_page_matrix');
+    expect(toolNames).toContain('browser_network_request');
+    expect(toolNames).toContain('browser_drop');
 
     const navigateResult = await backend.callTool('browser_navigate', { url: `${fixtureOrigin}/` });
     expect(navigateResult.isError).not.toBe(true);
 
-    // Regression guard for #84: browser_evaluate must run against a real page
-    // without the removed playwright-core `_evaluateFunction` private helper.
-    const evaluateResult = await backend.callTool('browser_evaluate', { function: '() => 2 + 2' });
+    // Regression guards for #84 and #116: browser_evaluate must use the public
+    // evaluate API and accept a plain expression against a real page.
+    const evaluateResult = await backend.callTool('browser_evaluate', { function: 'document.title' });
     expect(evaluateResult.isError).not.toBe(true);
-    expect((evaluateResult.content[0] as any).text).toContain('4');
+    expect((evaluateResult.content[0] as any).text).toContain('"Home"');
+
+    const fetchResult = await backend.callTool('browser_evaluate', {
+      function: `fetch('/api/data').then(response => response.json())`,
+    });
+    expect(fetchResult.isError).not.toBe(true);
+    expect((fetchResult.content[0] as any).text).toContain('"name": "Ada"');
+
+    const networkList = await backend.callTool('browser_network_requests', {});
+    expect(networkList.isError).not.toBe(true);
+    const networkListText = (networkList.content[0] as any).text as string;
+    const networkIndex = networkListText.match(/^(\d+)\. \[GET\] .*\/api\/data => \[200\]/m)?.[1];
+    expect(networkIndex).toBeDefined();
+
+    const networkBody = await backend.callTool('browser_network_request', {
+      index: Number(networkIndex),
+      part: 'response-body',
+    });
+    expect(networkBody.isError).not.toBe(true);
+    expect((networkBody.content[0] as any).text).toContain('{"name":"Ada"}');
+
+    const pageSnapshot = await backend.callTool('browser_snapshot', {});
+    const pageSnapshotText = (pageSnapshot.content[0] as any).text as string;
+    const dropRef = pageSnapshotText.match(/region "Drop target" \[ref=(e\d+)\]/)?.[1];
+    expect(dropRef).toBeDefined();
+
+    const dropResult = await backend.callTool('browser_drop', {
+      element: 'Drop target',
+      ref: dropRef,
+      data: { 'text/plain': 'dropped from MCP' },
+    });
+    expect(dropResult.isError).not.toBe(true);
+
+    const droppedValue = await backend.callTool('browser_evaluate', {
+      function: `document.querySelector('#dropzone').dataset.dropped`,
+    });
+    expect(droppedValue.isError).not.toBe(true);
+    expect((droppedValue.content[0] as any).text).toContain('"dropped from MCP"');
+
+    const fileDropResult = await backend.callTool('browser_drop', {
+      element: 'Drop target',
+      ref: dropRef,
+      paths: [dropFilePath],
+    });
+    expect(fileDropResult.isError).not.toBe(true);
+
+    const droppedFileValue = await backend.callTool('browser_evaluate', {
+      function: `document.querySelector('#dropzone').dataset.dropped`,
+    });
+    expect(droppedFileValue.isError).not.toBe(true);
+    expect((droppedFileValue.content[0] as any).text).toContain('"dropped file contents"');
 
     const keyboardResult1 = await backend.callTool('audit_keyboard', {
       maxTabs: 12,

--- a/tests/tools-evaluate.test.ts
+++ b/tests/tools-evaluate.test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import evaluateTools from '../src/tools/evaluate.js';
 import { Response } from '../src/response.js';
+
 import type { Context } from '../src/context.js';
 import type { Tab } from '../src/tab.js';
 
@@ -29,11 +30,7 @@ describe('browser_evaluate tool', () => {
   let response: Response;
 
   beforeEach(() => {
-    pageEvaluate = vi.fn(async (func: any) => {
-      // Mirror Playwright: it serializes the argument via toString(). Returning
-      // the serialized source lets the test assert the user code was forwarded.
-      return func.toString();
-    });
+    pageEvaluate = vi.fn(async (callback: (source: string) => unknown, source: string) => callback(source));
 
     mockTab = {
       modalStates: vi.fn().mockReturnValue([]),
@@ -56,49 +53,113 @@ describe('browser_evaluate tool', () => {
     expect(evaluateTool).toBeDefined();
     expect(evaluateTool.schema.name).toBe('browser_evaluate');
     expect(evaluateTool.capability).toBe('core');
+    expect(evaluateTool.schema.inputSchema.parse({ function: '1 + 1' })).toEqual({ function: '1 + 1' });
   });
 
   it('evaluates a page-scoped function and returns its value', async () => {
-    pageEvaluate.mockResolvedValueOnce(4);
-
     await evaluateTool.handle(mockContext, { function: '() => 2 + 2' }, response);
 
     expect(pageEvaluate).toHaveBeenCalledTimes(1);
-    expect(response.result()).toContain('4');
+    expect(pageEvaluate.mock.calls[0][1]).toBe('() => 2 + 2');
+    expect(response.result()).toBe('4');
+    expect(response.code()).toContain(`await page.evaluate(() => 2 + 2);`);
     expect(response.isError()).toBeFalsy();
   });
 
-  it('forwards the user source to evaluate via Function.toString (no _evaluateFunction)', async () => {
-    // Regression guard for #84: playwright-core 1.59 removed _evaluateFunction,
-    // so the tool must call the public evaluate() with a toString-overridden
-    // function instead of the (now missing) private receiver method.
+  it('evaluates a plain expression and emits runnable code', async () => {
+    await evaluateTool.handle(mockContext, { function: '(1 + 1)' }, response);
+
+    expect(pageEvaluate.mock.calls[0][1]).toBe('(1 + 1)');
+    expect(response.result()).toBe('2');
+    expect(response.code()).toContain(`await page.evaluate(() => ((1 + 1)));`);
+    expect(response.isError()).toBeFalsy();
+  });
+
+  it('does not misclassify an expression containing an arrow callback', async () => {
+    await evaluateTool.handle(mockContext, { function: '[1, 2, 3].map(value => value * 2)' }, response);
+
+    expect(response.result()).toBe('[\n  2,\n  4,\n  6\n]');
+    expect(response.code()).toContain(`await page.evaluate(() => ([1, 2, 3].map(value => value * 2)));`);
+  });
+
+  it('awaits promise expressions', async () => {
+    await evaluateTool.handle(mockContext, { function: 'Promise.resolve(42)' }, response);
+
+    expect(response.result()).toBe('42');
+    expect(response.code()).toContain(`() => (Promise.resolve(42))`);
+  });
+
+  it('uses the public evaluate API instead of the removed _evaluateFunction helper', async () => {
     mockTab.page._evaluateFunction = vi.fn();
 
-    await evaluateTool.handle(mockContext, { function: '() => window.location.href' }, response);
+    await evaluateTool.handle(mockContext, { function: '() => "ok"' }, response);
 
     expect(mockTab.page._evaluateFunction).not.toHaveBeenCalled();
-    const passedFunction = pageEvaluate.mock.calls[0][0];
-    expect(typeof passedFunction).toBe('function');
-    expect(passedFunction.toString()).toBe('() => window.location.href');
+    expect(typeof pageEvaluate.mock.calls[0][0]).toBe('function');
+    expect(pageEvaluate.mock.calls[0][1]).toBe('() => "ok"');
   });
 
   it('evaluates against an element locator when ref and element are provided', async () => {
-    const locatorEvaluate = vi.fn().mockResolvedValue('hello');
+    const locatorEvaluate = vi.fn(async (
+      callback: (element: { textContent: string }, source: string) => unknown,
+      source: string
+    ) => callback({ textContent: 'hello' }, source));
     mockTab.refLocator.mockResolvedValue({
       evaluate: locatorEvaluate,
-      _resolveSelector: async () => ({ resolvedSelector: 'internal:role=button' }),
+      normalize: async () => ({ toString: () => `locator('#button')` }),
     });
 
     await evaluateTool.handle(
         mockContext,
-        { function: '(el) => el.textContent', element: 'the button', ref: 'e1' },
+        { function: '(element) => element.textContent', element: 'the button', ref: 'e1' },
         response
     );
 
     expect(mockTab.refLocator).toHaveBeenCalledWith({ ref: 'e1', element: 'the button' });
     expect(locatorEvaluate).toHaveBeenCalledTimes(1);
+    expect(locatorEvaluate.mock.calls[0][1]).toBe('(element) => element.textContent');
     expect(pageEvaluate).not.toHaveBeenCalled();
-    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(el) => el.textContent');
-    expect(response.result()).toContain('hello');
+    expect(response.result()).toBe('"hello"');
+    expect(response.code()).toContain(`await page.locator('#button').evaluate((element) => element.textContent);`);
+  });
+
+  it('emits an element parameter for locator-scoped plain expressions', async () => {
+    const locatorEvaluate = vi.fn(async (
+      callback: (element: { textContent: string }, source: string) => unknown,
+      source: string
+    ) => callback({ textContent: 'hello' }, source));
+    mockTab.refLocator.mockResolvedValue({
+      evaluate: locatorEvaluate,
+      normalize: async () => ({ toString: () => `locator('#button')` }),
+    });
+
+    await evaluateTool.handle(
+        mockContext,
+        { function: 'element.textContent', element: 'the button', ref: 'e1' },
+        response
+    );
+
+    expect(response.result()).toBe('"hello"');
+    expect(response.code()).toContain(`await page.locator('#button').evaluate((element) => (element.textContent));`);
+  });
+
+  it('reports invalid expressions as tool errors', async () => {
+    await evaluateTool.handle(mockContext, { function: 'not valid javascript {' }, response);
+
+    expect(response.isError()).toBe(true);
+    expect(response.result()).toContain('Unexpected');
+  });
+
+  it('falls back cleanly when the result cannot be JSON-stringified', async () => {
+    pageEvaluate.mockResolvedValueOnce((() => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      return { result: circular, isFunction: false };
+    })());
+
+    await evaluateTool.handle(mockContext, { function: 'globalThis' }, response);
+
+    expect(response.isError()).toBeFalsy();
+    expect(response.result()).toBe('[object Object]');
   });
 });

--- a/tests/tools-files.test.ts
+++ b/tests/tools-files.test.ts
@@ -101,6 +101,8 @@ describe('browser_drop tool', () => {
       data: { 'text/plain': 'hello', 'text/uri-list': 'https://example.com' },
     });
     expect(response.code()).toContain(`await page.locator('#dropzone').drop(`);
+    expect(response.code()).toContain(`'text/plain': 'hello'`);
+    expect(response.code()).toContain(`'text/uri-list': 'https://example.com'`);
   });
 
   it('should pass one file path as a string', async () => {

--- a/tests/tools-files.test.ts
+++ b/tests/tools-files.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fileTools from '../src/tools/files.js';
+import { Response } from '../src/response.js';
+
+const dropTool = fileTools.find(tool => tool.schema.name === 'browser_drop')!;
+
+describe('browser_drop tool', () => {
+  let context: any;
+  let locator: any;
+  let response: Response;
+  let rootDir: string;
+  let tab: any;
+
+  beforeEach(async () => {
+    rootDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-drop-'));
+    rootDir = await fs.promises.realpath(rootDir);
+    await Promise.all([
+      fs.promises.writeFile(path.join(rootDir, 'a.txt'), 'a'),
+      fs.promises.writeFile(path.join(rootDir, 'b.txt'), 'b'),
+    ]);
+    locator = {
+      drop: vi.fn().mockResolvedValue(undefined),
+      normalize: vi.fn().mockResolvedValue({ toString: () => `locator('#dropzone')` }),
+    };
+    tab = {
+      modalStates: vi.fn().mockReturnValue([]),
+      refLocator: vi.fn().mockResolvedValue(locator),
+      waitForCompletion: vi.fn(async (callback: () => Promise<void>) => callback()),
+    };
+    context = {
+      currentTabOrDie: vi.fn().mockReturnValue(tab),
+      config: {},
+      options: { clientInfo: { rootPath: rootDir } },
+    };
+    tab.context = context;
+    response = new Response(context, 'browser_drop', {});
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('should expose a destructive core tool with paths and data inputs', () => {
+    expect(dropTool).toBeDefined();
+    expect(dropTool.capability).toBe('core');
+    expect(dropTool.schema.type).toBe('destructive');
+    expect(dropTool.schema.inputSchema.parse({
+      element: 'Drop target',
+      ref: 'e1',
+      data: { 'text/plain': 'hello' },
+    })).toEqual({
+      element: 'Drop target',
+      ref: 'e1',
+      data: { 'text/plain': 'hello' },
+    });
+    expect(() => dropTool.schema.inputSchema.parse({ element: 'Drop target', ref: 'e1' })).toThrow();
+    expect(() => dropTool.schema.inputSchema.parse({ element: 'Drop target', ref: 'e1', paths: [], data: {} })).toThrow();
+  });
+
+  it('should reject an empty payload when called directly', async () => {
+    await dropTool.handle(context, { element: 'Drop target', ref: 'e1' } as any, response);
+
+    expect(response.isError()).toBe(true);
+    expect(response.result()).toContain('At least one of "paths" or "data" must be provided');
+    expect(tab.refLocator).not.toHaveBeenCalled();
+    expect(locator.drop).not.toHaveBeenCalled();
+  });
+
+  it('should drop MIME-typed data onto the target', async () => {
+    await dropTool.handle(context, {
+      element: 'Drop target',
+      ref: 'e1',
+      data: { 'text/plain': 'hello', 'text/uri-list': 'https://example.com' },
+    }, response);
+
+    expect(tab.refLocator).toHaveBeenCalledWith({
+      element: 'Drop target',
+      ref: 'e1',
+      data: { 'text/plain': 'hello', 'text/uri-list': 'https://example.com' },
+    });
+    expect(locator.drop).toHaveBeenCalledWith({
+      data: { 'text/plain': 'hello', 'text/uri-list': 'https://example.com' },
+    });
+    expect(response.code()).toContain(`await page.locator('#dropzone').drop(`);
+  });
+
+  it('should pass one file path as a string', async () => {
+    await dropTool.handle(context, {
+      element: 'Drop target',
+      ref: 'e1',
+      paths: [path.join(rootDir, 'a.txt')],
+    }, response);
+
+    expect(locator.drop).toHaveBeenCalledWith({ files: path.join(rootDir, 'a.txt') });
+    expect(response.code()).toContain(`files: '${path.join(rootDir, 'a.txt')}'`);
+  });
+
+  it('should pass multiple file paths as an array', async () => {
+    await dropTool.handle(context, {
+      element: 'Drop target',
+      ref: 'e1',
+      paths: [path.join(rootDir, 'a.txt'), path.join(rootDir, 'b.txt')],
+    }, response);
+
+    expect(locator.drop).toHaveBeenCalledWith({ files: [path.join(rootDir, 'a.txt'), path.join(rootDir, 'b.txt')] });
+  });
+
+  it('should reject file paths outside the client root', async () => {
+    const outsideDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-drop-outside-'));
+    const outsideFile = path.join(outsideDir, 'secret.txt');
+    await fs.promises.writeFile(outsideFile, 'secret');
+
+    try {
+      await expect(dropTool.handle(context, {
+        element: 'Drop target',
+        ref: 'e1',
+        paths: [outsideFile],
+      }, response)).rejects.toThrow('outside the client filesystem root');
+      expect(locator.drop).not.toHaveBeenCalled();
+    } finally {
+      await fs.promises.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should include a post-action snapshot', async () => {
+    const setIncludeSnapshot = vi.spyOn(response, 'setIncludeSnapshot');
+
+    await dropTool.handle(context, {
+      element: 'Drop target',
+      ref: 'e1',
+      data: { 'text/plain': 'hello' },
+    }, response);
+
+    expect(setIncludeSnapshot).toHaveBeenCalledTimes(1);
+    expect(tab.waitForCompletion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -14,11 +14,68 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import networkTools from '../src/tools/network.js';
 import { Response } from '../src/response.js';
+
 import type { Context } from '../src/context.js';
 import type { Tab } from '../src/tab.js';
+
+type RequestOptions = {
+  url: string;
+  method?: string;
+  resourceType?: string;
+  headers?: Record<string, string>;
+  postData?: string | null;
+  postDataBuffer?: Buffer | null;
+  failure?: { errorText: string } | null;
+  responseEnd?: number;
+  responseBodySize?: number;
+  sizesError?: boolean;
+};
+
+type ResponseOptions = {
+  status?: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  text?: string;
+  body?: Buffer;
+};
+
+function createRequest(options: RequestOptions) {
+  return {
+    url: () => options.url,
+    method: () => options.method ?? 'GET',
+    resourceType: () => options.resourceType ?? 'fetch',
+    headers: () => options.headers ?? {},
+    postData: () => options.postData ?? options.postDataBuffer?.toString('utf8') ?? null,
+    postDataBuffer: () => options.postDataBuffer ?? (options.postData !== undefined && options.postData !== null ? Buffer.from(options.postData) : null),
+    failure: () => options.failure ?? null,
+    timing: () => ({ responseEnd: options.responseEnd ?? 12 }),
+    sizes: options.sizesError
+      ? vi.fn().mockRejectedValue(new Error('sizes unavailable'))
+      : vi.fn().mockResolvedValue({
+        requestBodySize: 0,
+        requestHeadersSize: 0,
+        responseBodySize: options.responseBodySize ?? 0,
+        responseHeadersSize: 0,
+      }),
+  };
+}
+
+function createResponse(options: ResponseOptions = {}) {
+  return {
+    status: () => options.status ?? 200,
+    statusText: () => options.statusText ?? 'OK',
+    headers: () => options.headers ?? {},
+    text: vi.fn().mockResolvedValue(options.text ?? ''),
+    body: vi.fn().mockResolvedValue(options.body ?? Buffer.alloc(0)),
+  };
+}
 
 describe('Network Tools', () => {
   let mockContext: Context;
@@ -27,16 +84,22 @@ describe('Network Tools', () => {
 
   beforeEach(() => {
     const mockRequests = new Map();
-    const req1 = { url: () => 'https://api.example.com/data', method: () => 'GET' };
-    const res1 = { status: () => 200, statusText: () => 'OK' };
-    mockRequests.set(req1, res1);
-
-    const req2 = { url: () => 'https://api.example.com/user', method: () => 'POST' };
-    const res2 = { status: () => 201, statusText: () => 'Created' };
-    mockRequests.set(req2, res2);
-
-    const req3 = { url: () => 'https://api.example.com/missing', method: () => 'GET' };
-    mockRequests.set(req3, null);
+    mockRequests.set(
+        createRequest({ url: 'https://api.example.com/data', resourceType: 'fetch' }),
+        createResponse({ status: 200, statusText: 'OK' })
+    );
+    mockRequests.set(
+        createRequest({ url: 'https://api.example.com/user', method: 'POST', resourceType: 'xhr' }),
+        createResponse({ status: 201, statusText: 'Created' })
+    );
+    mockRequests.set(
+        createRequest({
+          url: 'https://api.example.com/missing',
+          resourceType: 'image',
+          failure: { errorText: 'net::ERR_FAILED' },
+        }),
+        null
+    );
 
     mockTab = {
       requests: vi.fn().mockReturnValue(mockRequests),
@@ -54,60 +117,99 @@ describe('Network Tools', () => {
   describe('browser_network_requests tool', () => {
     const networkTool = networkTools.find(t => t.schema.name === 'browser_network_requests')!;
 
-    it('should exist', () => {
+    it('should expose the current list schema', () => {
       expect(networkTool).toBeDefined();
-      expect(networkTool.schema.name).toBe('browser_network_requests');
-    });
-
-    it('should have correct schema', () => {
       expect(networkTool.schema.title).toBe('List network requests');
       expect(networkTool.schema.type).toBe('readOnly');
+      expect(networkTool.schema.inputSchema.parse({})).toEqual({ static: false });
+      expect(networkTool.schema.inputSchema.parse({ static: true, filter: '/api/', filename: 'network.log' })).toEqual({
+        static: true,
+        filter: '/api/',
+        filename: 'network.log',
+      });
+      expect(() => networkTool.schema.inputSchema.parse({ filter: '[invalid(' })).toThrow();
     });
 
-    it('should retrieve all network requests', async () => {
+    it('should return numbered request summaries including failures', async () => {
       await networkTool.handle(mockContext, {}, response);
 
       expect(mockTab.requests).toHaveBeenCalled();
-      expect(response.result()).toContain('https://api.example.com/data');
-      expect(response.result()).toContain('https://api.example.com/user');
+      expect(response.result()).toContain('1. [GET] https://api.example.com/data => [200] OK');
+      expect(response.result()).toContain('2. [POST] https://api.example.com/user => [201] Created');
+      expect(response.result()).toContain('3. [GET] https://api.example.com/missing => [FAILED] net::ERR_FAILED');
     });
 
-    it('should show request methods', async () => {
+    it('should hide successful static requests by default while preserving raw indexes', async () => {
+      const requests = new Map();
+      requests.set(
+          createRequest({ url: 'https://example.com/', resourceType: 'document' }),
+          createResponse()
+      );
+      requests.set(
+          createRequest({ url: 'https://example.com/api/users', resourceType: 'fetch' }),
+          createResponse()
+      );
+      mockTab.requests = vi.fn().mockReturnValue(requests);
+
       await networkTool.handle(mockContext, {}, response);
 
-      const result = response.result();
-      expect(result).toContain('GET');
-      expect(result).toContain('POST');
+      expect(response.result()).not.toContain('1. [GET] https://example.com/');
+      expect(response.result()).toContain('2. [GET] https://example.com/api/users');
+      expect(response.result()).toContain('Note: 1 static request not shown');
     });
 
-    it('should show response status', async () => {
-      await networkTool.handle(mockContext, {}, response);
+    it('should include successful static requests when requested', async () => {
+      const requests = new Map();
+      requests.set(
+          createRequest({ url: 'https://example.com/app.js', resourceType: 'script' }),
+          createResponse()
+      );
+      mockTab.requests = vi.fn().mockReturnValue(requests);
 
-      const result = response.result();
-      expect(result).toContain('200');
-      expect(result).toContain('201');
+      await networkTool.handle(mockContext, { static: true }, response);
+
+      expect(response.result()).toContain('1. [GET] https://example.com/app.js => [200] OK');
+      expect(response.result()).not.toContain('not shown');
     });
 
-    it('should handle requests without responses', async () => {
-      await networkTool.handle(mockContext, {}, response);
+    it('should filter URLs without renumbering requests', async () => {
+      await networkTool.handle(mockContext, { filter: '/user' }, response);
 
-      const result = response.result();
-      // Request without response just shows the request line
-      expect(result).toContain('https://api.example.com/missing');
+      expect(response.result()).toContain('2. [POST] https://api.example.com/user');
+      expect(response.result()).not.toContain('1. [GET] https://api.example.com/data');
+      expect(response.result()).not.toContain('3. [GET] https://api.example.com/missing');
     });
 
-    it('should handle empty requests', async () => {
+    it('should return a useful message when no requests were recorded', async () => {
       mockTab.requests = vi.fn().mockReturnValue(new Map());
 
       await networkTool.handle(mockContext, {}, response);
 
-      expect(response.result()).toBe('');
+      expect(response.result()).toBe('No network requests recorded yet.');
+    });
+
+    it('should save the list when filename is provided', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-network-list-'));
+      const outputPath = path.join(outputDir, 'requests.log');
+      (mockTab as any).context = { outputFile: vi.fn().mockResolvedValue(outputPath) };
+
+      try {
+        await networkTool.handle(mockContext, { filename: 'requests.log' }, response);
+
+        expect(await fs.promises.readFile(outputPath, 'utf8')).toContain('https://api.example.com/data');
+        expect(response.result()).toContain(outputPath);
+        expect(response.resourceLinks()).toEqual([
+          expect.objectContaining({ uri: pathToFileURL(outputPath).toString(), mimeType: 'text/plain' }),
+        ]);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
     });
 
     it('should truncate data URL payloads', async () => {
       const payload = Buffer.from('<p>hello</p>').toString('base64');
       const mockRequests = new Map();
-      mockRequests.set({ url: () => `data:text/html;base64,${payload}`, method: () => 'GET' }, null);
+      mockRequests.set(createRequest({ url: `data:text/html;base64,${payload}` }), null);
       mockTab.requests = vi.fn().mockReturnValue(mockRequests);
 
       await networkTool.handle(mockContext, {}, response);
@@ -116,34 +218,13 @@ describe('Network Tools', () => {
       expect(response.result()).not.toContain(payload);
     });
 
-    it('should truncate embedded data URL payloads in request URLs', async () => {
-      const payload = Buffer.from('<p>hello</p>').toString('base64');
-      const mockRequests = new Map();
-      mockRequests.set({ url: () => `https://api.example/upload?src=data:text/html;base64,${payload}&id=123`, method: () => 'POST' }, null);
-      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
-
-      await networkTool.handle(mockContext, {}, response);
-
-      expect(response.result()).toContain('https://api.example/upload?src=data:text/html;base64,...&id=123');
-      expect(response.result()).not.toContain(payload);
-    });
-
-    it('should truncate data URLs with literal prefixes and encoded commas in request URLs', async () => {
-      const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
-      const mockRequests = new Map();
-      mockRequests.set({ url: () => `https://api.example/upload?src=data:text/html;base64%2C${payload}&id=123`, method: () => 'POST' }, null);
-      mockTab.requests = vi.fn().mockReturnValue(mockRequests);
-
-      await networkTool.handle(mockContext, {}, response);
-
-      expect(response.result()).toContain('https://api.example/upload?src=data:text/html;base64%2C...&id=123');
-      expect(response.result()).not.toContain(payload);
-    });
-
-    it('should preserve query params after raw embedded data URL payloads', async () => {
+    it('should truncate embedded data URL payloads and preserve following query params', async () => {
       const payload = '<svg><text>Hello</text></svg>';
       const mockRequests = new Map();
-      mockRequests.set({ url: () => `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`, method: () => 'POST' }, null);
+      mockRequests.set(createRequest({
+        url: `https://api.example/upload?src=data:image/svg+xml,${payload}&id=123`,
+        method: 'POST',
+      }), null);
       mockTab.requests = vi.fn().mockReturnValue(mockRequests);
 
       await networkTool.handle(mockContext, {}, response);
@@ -152,24 +233,424 @@ describe('Network Tools', () => {
       expect(response.result()).not.toContain(payload);
     });
 
-    it('should truncate percent-encoded data URL payloads in request URLs', async () => {
+    it('should truncate percent-encoded data URL payloads', async () => {
       const payload = encodeURIComponent(Buffer.from('<p>hello</p>').toString('base64'));
       const mockRequests = new Map();
-      mockRequests.set({ url: () => `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`, method: () => 'POST' }, null);
+      mockRequests.set(createRequest({
+        url: `https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C${payload}&id=123`,
+        method: 'POST',
+      }), null);
       mockTab.requests = vi.fn().mockReturnValue(mockRequests);
 
       await networkTool.handle(mockContext, {}, response);
 
-      expect(response.result()).toContain('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
+      expect(response.result()).toContain('data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
       expect(response.result()).not.toContain(payload);
+    });
+  });
+
+  describe('browser_network_request tool', () => {
+    const detailTool = networkTools.find(t => t.schema.name === 'browser_network_request')!;
+
+    function setup(entries: [ReturnType<typeof createRequest>, ReturnType<typeof createResponse> | null][]) {
+      const map = new Map(entries);
+      const tab = {
+        requests: vi.fn().mockReturnValue(map),
+        modalStates: vi.fn().mockReturnValue([]),
+      } as any;
+      const context = { currentTabOrDie: () => tab, config: {} } as any;
+      return { tab, context, response: new Response(context, 'browser_network_request', {}) };
+    }
+
+    it('should expose the current detail schema', () => {
+      expect(detailTool).toBeDefined();
+      expect(detailTool.schema.type).toBe('readOnly');
+      expect(detailTool.capability).toBe('core');
+      expect(detailTool.schema.inputSchema.parse({ index: 1 })).toEqual({
+        index: 1,
+        includeSensitiveHeaders: false,
+        allowCompressedBody: false,
+      });
+      expect(detailTool.schema.inputSchema.parse({ index: 2, part: 'response-body', filename: 'body.json' })).toEqual({
+        index: 2,
+        part: 'response-body',
+        filename: 'body.json',
+        includeSensitiveHeaders: false,
+        allowCompressedBody: false,
+      });
+      expect(() => detailTool.schema.inputSchema.parse({ index: 0 })).toThrow();
+    });
+
+    it('should report an error for an out-of-range index', async () => {
+      const { context, response: detailResponse } = setup([]);
+
+      await detailTool.handle(context, { index: 1 }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('Request #1 not found');
+    });
+
+    it('should render metadata and headers without eagerly reading bodies', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/data',
+        method: 'POST',
+        resourceType: 'fetch',
+        headers: { accept: 'application/json', authorization: 'Bearer request-secret' },
+        postData: '{"query":"hello"}',
+        responseEnd: 18.6,
+      });
+      const httpResponse = createResponse({
+        status: 201,
+        statusText: 'Created',
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'x-request-id': 'abc123',
+          'set-cookie': 'session=response-secret',
+        },
+        text: '{"ok":true}',
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1 }, detailResponse);
+
+      const result = detailResponse.result();
+      expect(result).toContain('#1 [POST] https://api.example.com/data');
+      expect(result).toContain('status:    [201] Created');
+      expect(result).toContain('duration:  19ms');
+      expect(result).toContain('type:      fetch');
+      expect(result).toContain('mimeType:  application/json');
+      expect(result).toContain('Request headers');
+      expect(result).toContain('accept: application/json');
+      expect(result).toContain('authorization: <redacted>');
+      expect(result).toContain('Response headers');
+      expect(result).toContain('x-request-id: abc123');
+      expect(result).toContain('set-cookie: <redacted>');
+      expect(result).not.toContain('request-secret');
+      expect(result).not.toContain('response-secret');
+      expect(result).toContain('part="request-body"');
+      expect(result).toContain('part="response-body"');
+      expect(result).not.toContain('{"query":"hello"}');
+      expect(result).not.toContain('{"ok":true}');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+      expect(httpResponse.body).not.toHaveBeenCalled();
+    });
+
+    it('should return each request and response part independently', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/data',
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-request-header': 'request-value' },
+        postData: '{"a":1}',
+      });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'application/json', 'x-response': 'ok' },
+        text: '{"name":"Ada"}',
+      });
+
+      for (const [part, expected] of [
+        ['request-headers', 'x-request-header: request-value'],
+        ['request-body', '{"a":1}'],
+        ['response-headers', 'x-response: ok'],
+        ['response-body', '{"name":"Ada"}'],
+      ] as const) {
+        const { context, response: detailResponse } = setup([[request, httpResponse]]);
+        await detailTool.handle(context, { index: 1, part }, detailResponse);
+        expect(detailResponse.result()).toContain(expected);
+      }
+    });
+
+    it('should include sensitive headers only when explicitly requested', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/data',
+        headers: { authorization: 'Bearer request-secret' },
+      });
+      const httpResponse = createResponse({ headers: { 'content-type': 'application/json' } });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, {
+        index: 1,
+        part: 'request-headers',
+        includeSensitiveHeaders: true,
+      }, detailResponse);
+
+      expect(detailResponse.result()).toContain('authorization: Bearer request-secret');
+    });
+
+    it('should save binary request bodies byte-for-byte', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-network-request-binary-'));
+      const binary = Buffer.from([0x00, 0xff, 0x01, 0xfe]);
+      const request = createRequest({
+        url: 'https://api.example.com/upload',
+        method: 'POST',
+        headers: { 'content-type': 'application/octet-stream' },
+        postDataBuffer: binary,
+      });
+      const httpResponse = createResponse();
+      const { tab, context, response: detailResponse } = setup([[request, httpResponse]]);
+      tab.context = {
+        outputFile: vi.fn(async (name: string) => path.join(outputDir, name)),
+      };
+
+      try {
+        await detailTool.handle(context, { index: 1, part: 'request-body' }, detailResponse);
+
+        const outputName = (tab.context.outputFile as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+        expect(outputName).toMatch(/\.bin$/);
+        expect(await fs.promises.readFile(path.join(outputDir, outputName))).toEqual(binary);
+        expect(detailResponse.resourceLinks()).toEqual([
+          expect.objectContaining({ mimeType: 'application/octet-stream' }),
+        ]);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should preserve request bodies without Content-Type as binary', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-network-request-unknown-'));
+      const binary = Buffer.from([0xff, 0xfe, 0xfd]);
+      const request = createRequest({
+        url: 'https://api.example.com/upload',
+        method: 'POST',
+        postDataBuffer: binary,
+      });
+      const { tab, context, response: detailResponse } = setup([[request, createResponse()]]);
+      tab.context = {
+        outputFile: vi.fn(async (name: string) => path.join(outputDir, name)),
+      };
+
+      try {
+        await detailTool.handle(context, { index: 1, part: 'request-body' }, detailResponse);
+
+        const outputName = (tab.context.outputFile as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+        expect(await fs.promises.readFile(path.join(outputDir, outputName))).toEqual(binary);
+        expect(detailResponse.resourceLinks()).toEqual([
+          expect.objectContaining({ mimeType: 'application/octet-stream' }),
+        ]);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should require filename for request bodies larger than the inline limit', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/large-upload',
+        method: 'POST',
+        headers: { 'content-type': 'text/plain' },
+        postDataBuffer: Buffer.alloc(1024 * 1024 + 1, 0x61),
+      });
+      const { context, response: detailResponse } = setup([[request, createResponse()]]);
+
+      await detailTool.handle(context, { index: 1, part: 'request-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('Request body is too large to return inline');
+      expect(detailResponse.result()).toContain('Provide filename');
+    });
+
+    it('should truncate data URLs in textual bodies', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      const request = createRequest({ url: 'https://api.example.com/data' });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'application/json' },
+        text: `{"image":"data:text/html;base64,${payload}"}`,
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.result()).toContain('data:text/html;base64,...');
+      expect(detailResponse.result()).not.toContain(payload);
+    });
+
+    it('should require filename for text bodies larger than the inline limit', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/large',
+        responseBodySize: 1024 * 1024 + 1,
+      });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'text/plain' },
+        text: 'should not be read',
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('too large to return inline');
+      expect(detailResponse.result()).toContain('Provide filename');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+    });
+
+    it('should reject response bodies larger than the read limit', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/huge',
+        responseBodySize: 25 * 1024 * 1024 + 1,
+      });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'application/octet-stream' },
+        body: Buffer.from('should not be read'),
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('too large to read');
+      expect(httpResponse.body).not.toHaveBeenCalled();
+    });
+
+    it('should fail closed when response size is unavailable', async () => {
+      const request = createRequest({
+        url: 'https://api.example.com/unknown-size',
+        sizesError: true,
+      });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'text/plain' },
+        text: 'should not be read',
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('Unable to determine the response body size safely');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+    });
+
+    it('should require explicit opt-in for compressed response bodies', async () => {
+      const request = createRequest({ url: 'https://api.example.com/compressed', responseBodySize: 20 });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'application/json', 'content-encoding': 'gzip' },
+        text: '{"ok":true}',
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('decoded size cannot be bounded safely');
+      expect(detailResponse.result()).toContain('allowCompressedBody');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+    });
+
+    it('should read compressed response bodies after explicit opt-in', async () => {
+      const request = createRequest({ url: 'https://api.example.com/compressed', responseBodySize: 20 });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'application/json', 'content-encoding': 'gzip' },
+        text: '{"ok":true}',
+      });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, {
+        index: 1,
+        part: 'response-body',
+        allowCompressedBody: true,
+      }, detailResponse);
+
+      expect(detailResponse.isError()).toBeFalsy();
+      expect(detailResponse.result()).toBe('{"ok":true}');
+      expect(httpResponse.text).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([101, 204, 304])('should not read a body for status %s', async status => {
+      const request = createRequest({ url: 'https://api.example.com/no-body' });
+      const httpResponse = createResponse({ status, headers: { 'content-type': 'text/plain' }, text: 'unexpected' });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.result()).toContain('cannot have a body');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+      expect(httpResponse.body).not.toHaveBeenCalled();
+    });
+
+    it('should not read a body for HEAD requests', async () => {
+      const request = createRequest({ url: 'https://api.example.com/headers', method: 'HEAD' });
+      const httpResponse = createResponse({ status: 200, headers: { 'content-type': 'text/plain' }, text: 'unexpected' });
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.result()).toContain('cannot have a body');
+      expect(httpResponse.text).not.toHaveBeenCalled();
+      expect(httpResponse.body).not.toHaveBeenCalled();
+    });
+
+    it('should explain when a request has no response', async () => {
+      const request = createRequest({ url: 'https://api.example.com/pending' });
+      const { context, response: detailResponse } = setup([[request, null]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.result()).toBe('No response was received for this request.');
+    });
+
+    it('should save text bodies when filename is provided', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-network-text-'));
+      const outputPath = path.join(outputDir, 'body.json');
+      const request = createRequest({ url: 'https://api.example.com/data' });
+      const httpResponse = createResponse({ headers: { 'content-type': 'application/json' }, text: '{"ok":true}' });
+      const { tab, context, response: detailResponse } = setup([[request, httpResponse]]);
+      tab.context = { outputFile: vi.fn().mockResolvedValue(outputPath) };
+
+      try {
+        await detailTool.handle(context, { index: 1, part: 'response-body', filename: 'body.json' }, detailResponse);
+
+        expect(await fs.promises.readFile(outputPath, 'utf8')).toBe('{"ok":true}');
+        expect(detailResponse.result()).toContain(outputPath);
+        expect(detailResponse.resourceLinks()).toEqual([
+          expect.objectContaining({ uri: pathToFileURL(outputPath).toString(), mimeType: 'application/json' }),
+        ]);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should save binary bodies byte-for-byte with a MIME-derived extension', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-network-binary-'));
+      const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const request = createRequest({ url: 'https://api.example.com/image' });
+      const httpResponse = createResponse({
+        headers: { 'content-type': 'image/png' },
+        body: binary,
+      });
+      const { tab, context, response: detailResponse } = setup([[request, httpResponse]]);
+      tab.context = {
+        outputFile: vi.fn(async (name: string) => path.join(outputDir, name)),
+      };
+
+      try {
+        await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+        const outputPath = (tab.context.outputFile as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+        expect(outputPath).toMatch(/\.png$/);
+        expect(await fs.promises.readFile(path.join(outputDir, outputPath))).toEqual(binary);
+        expect(httpResponse.body).toHaveBeenCalledTimes(1);
+        expect(httpResponse.text).not.toHaveBeenCalled();
+        expect(detailResponse.resourceLinks()).toEqual([
+          expect.objectContaining({ mimeType: 'image/png' }),
+        ]);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should surface response body read failures', async () => {
+      const request = createRequest({ url: 'https://api.example.com/data' });
+      const httpResponse = createResponse({ headers: { 'content-type': 'text/plain' } });
+      httpResponse.text.mockRejectedValueOnce(new Error('body unavailable'));
+      const { context, response: detailResponse } = setup([[request, httpResponse]]);
+
+      await detailTool.handle(context, { index: 1, part: 'response-body' }, detailResponse);
+
+      expect(detailResponse.isError()).toBe(true);
+      expect(detailResponse.result()).toContain('Failed to read the response body');
     });
   });
 
   describe('Tool capabilities', () => {
     it('should all have core capability', () => {
-      networkTools.forEach(tool => {
-        expect(tool.capability).toBe('core');
-      });
+      networkTools.forEach(tool => expect(tool.capability).toBe('core'));
     });
   });
 });


### PR DESCRIPTION
## Summary

Syncs the browser toolset with upstream playwright-mcp (issue #116):

- **`browser_drop`** — drop files or MIME-typed data onto an element, as if dragged from outside the page. File paths are sandboxed to the client filesystem root / configured output dir.
- **`browser_evaluate`** — now accepts a plain expression as well as a function, awaits returned promises, and reports errors instead of throwing raw.
- **`browser_network_requests`** — numbered list with stable indexes; hides successful static resources by default; adds `static`, `filter`, and `filename` params.
- **`browser_network_request`** (new) — inspect headers or a single body part for one indexed request. Redacts sensitive headers by default, caps inline/total body sizes, saves binary bodies byte-for-byte, and fails closed on compressed/unbounded bodies.

Docs (README, SKILL.md) updated for the new/changed tools.

## Testing

- `npm run typecheck` — clean
- `npm run test` — 394 passed
- `npm run test:mcp` — 29 passed, 1 skipped (`browser_install`); added harness coverage for `browser_drop` and `browser_network_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new drag-and-drop tool for placing text or files onto page elements.
  * Added detailed network inspection, including numbered request listings and per-request headers/body views.
  * Expanded page evaluation support to handle both JavaScript functions and plain expressions.

* **Bug Fixes**
  * Improved handling of dropped data and file paths, including validation and safer file resolution.
  * Refined network request output to better handle filtering, sensitive data redaction, and large or compressed responses.

* **Documentation**
  * Updated tool documentation to reflect the new and enhanced browser interaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->