### PR TITLE
feat: add webp screenshot format from upstream Playwright MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Evaluate a JavaScript expression on the page, or on a specific element when a `r
 
 #### `browser_take_screenshot`
 Take a screenshot of the current page.
-- Parameters: `filename` (optional), `type` (`png` or `jpeg`), `scale` (`css` or `device`, default `css`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
+- Parameters: `filename` (optional), `type` (`png`, `jpeg` or `webp`; inferred from the filename extension when omitted, otherwise `png`), `scale` (`css` or `device`, default `css`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
 - `scale: device` captures a high-resolution screenshot using device pixels (accounts for the device pixel ratio); `scale: css` keeps the image sized in CSS pixels.
 
 #### `browser_pdf_save`

--- a/SKILL.md
+++ b/SKILL.md
@@ -195,7 +195,7 @@ These tools are always available and work in the interactive REPL.
 | `browser_close` | Close the page |
 | `browser_resize` | Resize window: `{"width": 1280, "height": 720}` |
 | `browser_snapshot` | Capture accessibility snapshot |
-| `browser_take_screenshot` | Take screenshot (png/jpeg, fullPage option) |
+| `browser_take_screenshot` | Take screenshot (png/jpeg/webp, fullPage option) |
 | `browser_wait_for` | Wait for text/time: `{"text": "loaded"}` or `{"time": 5}` |
 
 ### Interaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
 				"debug": "^4.4.3",
 				"dotenv": "^17.4.2",
 				"mime": "^4.1.0",
-				"playwright": "1.61.1",
-				"playwright-core": "1.61.1",
+				"playwright": "1.62.0",
+				"playwright-core": "1.62.0",
 				"re2": "^1.24.1",
 				"ws": "^8.21.1",
 				"zod": "^4.4.3"
@@ -4032,12 +4032,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+			"integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.61.1"
+				"playwright-core": "1.62.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4050,15 +4050,15 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+			"integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
 		"debug": "^4.4.3",
 		"dotenv": "^17.4.2",
 		"mime": "^4.1.0",
-		"playwright": "1.61.1",
-		"playwright-core": "1.61.1",
+		"playwright": "1.62.0",
+		"playwright-core": "1.62.0",
 		"re2": "^1.24.1",
 		"ws": "^8.21.1",
 		"zod": "^4.4.3"

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -54,7 +54,7 @@ const screenshot = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const extension = path.extname(params.filename ?? '').toLowerCase();
+    const extension = (path.extname(params.filename ?? '') || path.basename(params.filename ?? '')).toLowerCase();
     const fileType = params.type ?? ({ '.jpg': 'jpeg', '.jpeg': 'jpeg', '.webp': 'webp' } as const)[extension as '.jpg' | '.jpeg' | '.webp'] ?? 'png';
     const fileName = await tab.context.outputFile(params.filename ?? `page-${new Date().toISOString()}.${fileType}`);
     const options: playwright.PageScreenshotOptions = {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import path from 'node:path';
+
 import { z } from 'zod';
 
 import { defineTabTool } from './tool.js';
@@ -23,9 +25,9 @@ import { generateLocator } from './utils.js';
 import type * as playwright from 'playwright';
 
 const screenshotSchema = z.object({
-  type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
+  type: z.enum(['png', 'jpeg', 'webp']).optional().describe('Image format. If unset, inferred from the filename extension, otherwise png.'),
   scale: z.enum(['css', 'device']).default('css').describe(`Image resolution scale. 'css' produces a screenshot sized in CSS pixels (smaller, consistent across devices). 'device' produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.`),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg|webp}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
@@ -52,11 +54,12 @@ const screenshot = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const fileType = params.type || 'png';
+    const extension = path.extname(params.filename ?? '').toLowerCase();
+    const fileType = params.type ?? ({ '.jpg': 'jpeg', '.jpeg': 'jpeg', '.webp': 'webp' } as const)[extension as '.jpg' | '.jpeg' | '.webp'] ?? 'png';
     const fileName = await tab.context.outputFile(params.filename ?? `page-${new Date().toISOString()}.${fileType}`);
     const options: playwright.PageScreenshotOptions = {
       type: fileType,
-      quality: fileType === 'png' ? undefined : 90,
+      quality: fileType === 'jpeg' ? 90 : undefined,
       scale: params.scale,
       path: fileName,
       ...(params.fullPage !== undefined && { fullPage: params.fullPage })
@@ -81,7 +84,7 @@ const screenshot = defineTabTool({
     // Never return large images to LLM, saving them to the file system is enough.
     if (!params.fullPage) {
       response.addImage({
-        contentType: fileType === 'png' ? 'image/png' : 'image/jpeg',
+        contentType: `image/${fileType}`,
         data: buffer
       });
     }

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -74,4 +74,32 @@ describe('Screenshot Tools', () => {
 
     expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ scale: 'device' }));
   });
+
+  it('should accept the webp type and pass it through without quality', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ type: 'webp' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type: 'webp', quality: undefined }));
+  });
+
+  it('should infer the type from the filename', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ filename: 'page.WEBP' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type: 'webp' }));
+  });
+
+  it('should only set quality for jpeg screenshots', async () => {
+    for (const [type, quality] of [['png', undefined], ['jpeg', 90], ['webp', undefined]] as const) {
+      mockPage.screenshot.mockClear();
+      const params = screenshotTool.schema.inputSchema.parse({ type });
+      await screenshotTool.handle(mockContext, params, new Response(mockContext, 'browser_take_screenshot', {}));
+
+      expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type, quality }));
+    }
+  });
+
+  it('should reject an invalid type value', () => {
+    expect(() => screenshotTool.schema.inputSchema.parse({ type: 'gif' })).toThrow();
+  });
 });

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -83,10 +83,13 @@ describe('Screenshot Tools', () => {
   });
 
   it('should infer the type from the filename', async () => {
-    const params = screenshotTool.schema.inputSchema.parse({ filename: 'page.WEBP' });
-    await screenshotTool.handle(mockContext, params, response);
+    for (const [filename, type] of [['page.WEBP', 'webp'], ['.webp', 'webp'], ['.jpeg', 'jpeg'], ['.jpg', 'jpeg']] as const) {
+      mockPage.screenshot.mockClear();
+      const params = screenshotTool.schema.inputSchema.parse({ filename });
+      await screenshotTool.handle(mockContext, params, new Response(mockContext, 'browser_take_screenshot', {}));
 
-    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type: 'webp' }));
+      expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type }));
+    }
   });
 
   it('should only set quality for jpeg screenshots', async () => {


### PR DESCRIPTION
## Summary

Closes #123 by mirroring [microsoft/playwright#41152](https://github.com/microsoft/playwright/pull/41152) / [commit `f3114b3`](https://github.com/microsoft/playwright/commit/f3114b3e9f1aea9f0c123551ebf67ded08dddca2), now shipped in [Playwright 1.62.0](https://github.com/microsoft/playwright/releases/tag/v1.62.0).

Upstream added WebP screenshot support and made screenshot type optional so it can be inferred from the filename extension.

## Changes

- Upgrade `playwright` and `playwright-core` from 1.61.1 to stable 1.62.0.
- Add `webp` to `browser_take_screenshot`.
- Infer `png`, `jpeg`, or `webp` from the filename when `type` is omitted.
- Return the matching image content type and keep format-specific quality handling.
- Update README and focused screenshot tests.

## Why it matters

The downstream tool schema rejected WebP even though stable Playwright supports it. Clients also could not rely on the upstream filename-inference behavior.

## Validation

- `npm test -- tests/tools-screenshot.test.ts` — 9 passed.
- `npm run lint`.
- `npm run build`.
- `npm test` — 37 files, 501 tests passed.
- Real local Chrome screenshot produced valid RIFF/WEBP bytes with Playwright 1.62.0.
- `npm pack --dry-run --json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebP support to the screenshot tool.
  * Screenshot responses now return the correct image content type for PNG, JPEG, and WebP files.
  * JPEG quality settings are applied only to JPEG screenshots.
* **Documentation**
  * Updated screenshot tool docs to include WebP, including how the output format is inferred from the filename when `type` isn’t provided.
* **Tests**
  * Expanded coverage for WebP handling, filename-based format inference, and validation of unsupported `type` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Blocked by upstream ARIA regression

Do not merge this dependency bump yet. A real-browser comparison found that Playwright 1.61.1 preserves the accessible name for the nested-span/aria-hidden-SVG case, while stable 1.62.0 emits an unnamed button.

Upstream fixed the regression in [microsoft/playwright#41988](https://github.com/microsoft/playwright/pull/41988) / [commit `59120d0`](https://github.com/microsoft/playwright/commit/59120d0639ddfe834c387232b22b06fec31e8f59), after 1.62.0 was published.

Next action: wait for a stable Playwright release containing that fix, update the pin, rerun the focused runtime comparison and full validation, then mark this PR ready.