### PR TITLE
fix: remove shebang from index.d.ts type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Copyright (c) Microsoft Corporation.
  *


### PR DESCRIPTION
## Upstream change

Mirrors [microsoft/playwright-mcp#1668](https://github.com/microsoft/playwright-mcp/pull/1668) — "fix: readme typo, update devcontainer playwright version, remove shebang from .d.ts" (merged Jul 15, 2026).

Among that PR's fixes, the relevant one for this repo is the removal of the `#!/usr/bin/env node` shebang from the `index.d.ts` type declaration file. Upstream's rationale: **type declaration files are never executed, so the shebang doesn't belong there.**

## Why it matters here

This repository vendors Playwright MCP's programmatic entry point and ships a hand-maintained `index.d.ts` (exposed via the package `exports` → `types` field). It carried the identical superfluous shebang as upstream's `index.d.ts`:

```
#!/usr/bin/env node
/**
 * Copyright (c) Microsoft Corporation.
 ...
```

The `.d.ts` is only ever consumed by the type system, never run as a script, so the shebang is inert clutter that upstream has now dropped.

## Change

- Remove the leading `#!/usr/bin/env node` line from `index.d.ts` so it now begins with the copyright header (matching upstream and the repo's `eslint-plugin-notice` header expectation).

Scope is kept minimal — the other parts of upstream #1668 do not apply here:
- **README typo**: upstream-specific (their `amp mcp add` section).
- **Devcontainer Playwright bump**: this repo has no `.devcontainer`, and it already pins `playwright@1.61.0`.

The executable entry (`cli.js` / `index.js`) is unaffected; no runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgFp9eNyaCQz1vbLG7Qagt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up package metadata by removing an unnecessary command-line marker from the type declaration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->