### PR TITLE
feat: support extension protocol v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Each line is `<tool-name> <json-arguments>`. Omit the JSON to pass `{}`.
 Global browser connection flags still apply here, for example `npx mcp-accessibility-scanner --headless interactive`.
 Use `--mobile` or `PLAYWRIGHT_MCP_MOBILE=1` to emulate a generic mobile device (`Pixel 10` for Chromium, `iPhone 17` for WebKit). It cannot be combined with `--device`, CDP attach/launch modes, remote browser endpoints, or `--extension`.
 
+### Browser extension mode
+
+Use `--extension` to connect through the current [Playwright Extension](https://github.com/microsoft/playwright/blob/main/packages/extension/README.md), which must support extension protocol v2.
+
+```bash
+npx mcp-accessibility-scanner --extension
+```
+
 ### Discovering available tools (`list-tools` subcommand)
 
 To print every tool name and its description:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Use `--extension` to connect through the current [Playwright Extension](https://
 npx mcp-accessibility-scanner --extension
 ```
 
+Set `PLAYWRIGHT_MCP_EXTENSION_TOKEN` to the token shown by the extension to bypass the connection approval dialog.
+
 ### Discovering available tools (`list-tools` subcommand)
 
 To print every tool name and its description:

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -136,11 +136,7 @@ export class BrowserModel {
     const tabSession = this._tabSessions.values().next().value;
     if (!tabSession)
       throw new Error(`No attached tab to forward browser-level command: ${method}`);
-    return await this._sendToExtension('chrome.debugger.sendCommand', [
-      { tabId: tabSession.tabId },
-      method,
-      params,
-    ]);
+    return await this._sendDebuggerCommand({ tabId: tabSession.tabId }, method, params);
   }
 
   async sendCommand(sessionId: string, method: string, params: any): Promise<any> {
@@ -152,11 +148,14 @@ export class BrowserModel {
     }
     if (!tabSession)
       throw new Error(`No tab found for sessionId: ${sessionId}`);
-    return await this._sendToExtension('chrome.debugger.sendCommand', [
-      { tabId: tabSession.tabId, sessionId: cdpSessionId },
-      method,
-      params,
-    ]);
+    return await this._sendDebuggerCommand({ tabId: tabSession.tabId, sessionId: cdpSessionId }, method, params);
+  }
+
+  private async _sendDebuggerCommand(target: DebuggerSession, method: string, params: any): Promise<any> {
+    const command: [DebuggerSession, string, object?] = [target, method];
+    if (params !== undefined)
+      command.push(params);
+    return await this._sendToExtension('chrome.debugger.sendCommand', command);
   }
 
   private _attachTab(tabId: number): Promise<TabSession> {

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -42,6 +42,8 @@ export class BrowserModel {
   private _sendToCDPClient: SendToCDPClient | null = null;
   private _knownTabs = new Map<number, Tab>();
   private _tabSessions = new Map<number, TabSession>();
+  private _tabAttachmentPromises = new Map<number, Promise<TabSession>>();
+  private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _nextSessionId = 1;
 
@@ -89,9 +91,22 @@ export class BrowserModel {
       this._detachTab(source.tabId);
   }
 
-  async enableAutoAttach(): Promise<void> {
-    this._autoAttach = true;
-    await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId).catch(logUnhandledError)));
+  enableAutoAttach(): Promise<void> {
+    return this._runAutoAttachOperation(async () => {
+      this._autoAttach = true;
+      await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId)));
+    });
+  }
+
+  disableAutoAttach(): Promise<void> {
+    return this._runAutoAttachOperation(async () => {
+      this._autoAttach = false;
+      await Promise.allSettled(this._tabAttachmentPromises.values());
+      await Promise.all([...this._tabSessions.keys()].map(async tabId => {
+        await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
+        this._detachTab(tabId);
+      }));
+    });
   }
 
   async createTarget(url: string | undefined): Promise<{ targetId: string | undefined }> {
@@ -144,10 +159,28 @@ export class BrowserModel {
     ]);
   }
 
-  private async _attachTab(tabId: number): Promise<TabSession> {
+  private _attachTab(tabId: number): Promise<TabSession> {
     const existing = this._tabSessions.get(tabId);
     if (existing)
-      return existing;
+      return Promise.resolve(existing);
+    const inFlight = this._tabAttachmentPromises.get(tabId);
+    if (inFlight)
+      return inFlight;
+    const promise = Promise.resolve().then(() => this._attachTabImpl(tabId));
+    this._tabAttachmentPromises.set(tabId, promise);
+    return promise.finally(() => {
+      if (this._tabAttachmentPromises.get(tabId) === promise)
+        this._tabAttachmentPromises.delete(tabId);
+    });
+  }
+
+  private _runAutoAttachOperation(operation: () => Promise<void>): Promise<void> {
+    const result = this._autoAttachOperation.then(operation);
+    this._autoAttachOperation = result.catch(() => {});
+    return result;
+  }
+
+  private async _attachTabImpl(tabId: number): Promise<TabSession> {
     await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logUnhandledError } from '../utils/log.js';
+
+import type { DebuggerSession, Debuggee, Tab } from './protocol.js';
+
+export type CDPMessage = {
+  id?: number;
+  sessionId?: string;
+  method?: string;
+  params?: any;
+  result?: any;
+  error?: { code?: number; message: string };
+};
+
+export type SendCommand = (method: string, params: any) => Promise<any>;
+export type SendToCDPClient = (message: CDPMessage) => void;
+
+type TabSession = {
+  tabId: number;
+  sessionId: string;
+  targetInfo: any;
+  childSessions: Set<string>;
+};
+
+export class BrowserModel {
+  private _sendToExtension: SendCommand;
+  private _sendToCDPClient: SendToCDPClient | null = null;
+  private _knownTabs = new Map<number, Tab>();
+  private _tabSessions = new Map<number, TabSession>();
+  private _autoAttach = false;
+  private _nextSessionId = 1;
+
+  constructor(sendToExtension: SendCommand) {
+    this._sendToExtension = sendToExtension;
+  }
+
+  connectOverCDP(sendToCDPClient: SendToCDPClient): void {
+    this._sendToCDPClient = sendToCDPClient;
+  }
+
+  private _emit(message: CDPMessage): void {
+    this._sendToCDPClient?.(message);
+  }
+
+  onTabCreated(tab: Tab): void {
+    if (tab.id === undefined)
+      return;
+    this._knownTabs.set(tab.id, tab);
+    if (this._autoAttach)
+      void this._attachTab(tab.id).catch(logUnhandledError);
+  }
+
+  onTabRemoved(tabId: number): void {
+    this._knownTabs.delete(tabId);
+    this._detachTab(tabId);
+  }
+
+  onDebuggerEvent(source: DebuggerSession, method: string, params: any): void {
+    if (source.tabId === undefined)
+      return;
+    const tabSession = this._tabSessions.get(source.tabId);
+    if (!tabSession)
+      return;
+    const childSessionId = (params as { sessionId?: string } | undefined)?.sessionId;
+    if (method === 'Target.attachedToTarget' && childSessionId)
+      tabSession.childSessions.add(childSessionId);
+    else if (method === 'Target.detachedFromTarget' && childSessionId)
+      tabSession.childSessions.delete(childSessionId);
+    this._emit({ sessionId: source.sessionId || tabSession.sessionId, method, params });
+  }
+
+  onDebuggerDetach(source: Debuggee): void {
+    if (source.tabId !== undefined)
+      this._detachTab(source.tabId);
+  }
+
+  async enableAutoAttach(): Promise<void> {
+    this._autoAttach = true;
+    await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId).catch(logUnhandledError)));
+  }
+
+  async createTarget(url: string | undefined): Promise<{ targetId: string | undefined }> {
+    const tab = await this._sendToExtension('chrome.tabs.create', [{ url }]);
+    if (tab?.id === undefined)
+      throw new Error('Failed to create tab');
+    this._knownTabs.set(tab.id, tab);
+    const tabSession = await this._attachTab(tab.id);
+    return { targetId: tabSession.targetInfo?.targetId };
+  }
+
+  async closeTarget(targetId: string | undefined): Promise<{ success: boolean }> {
+    const tabSession = targetId ? this._findTabSession(session => session.targetInfo?.targetId === targetId) : undefined;
+    if (!tabSession)
+      return { success: false };
+    await this._sendToExtension('chrome.tabs.remove', [tabSession.tabId]);
+    return { success: true };
+  }
+
+  getTargetInfo(sessionId: string | undefined): any {
+    if (!sessionId)
+      return undefined;
+    return this._findTabSession(session => session.sessionId === sessionId)?.targetInfo;
+  }
+
+  async sendBrowserCommand(method: string, params: any): Promise<any> {
+    const tabSession = this._tabSessions.values().next().value;
+    if (!tabSession)
+      throw new Error(`No attached tab to forward browser-level command: ${method}`);
+    return await this._sendToExtension('chrome.debugger.sendCommand', [
+      { tabId: tabSession.tabId },
+      method,
+      params,
+    ]);
+  }
+
+  async sendCommand(sessionId: string, method: string, params: any): Promise<any> {
+    let tabSession = this._findTabSession(session => session.sessionId === sessionId);
+    let cdpSessionId: string | undefined;
+    if (!tabSession) {
+      tabSession = this._findTabSession(session => session.childSessions.has(sessionId));
+      cdpSessionId = sessionId;
+    }
+    if (!tabSession)
+      throw new Error(`No tab found for sessionId: ${sessionId}`);
+    return await this._sendToExtension('chrome.debugger.sendCommand', [
+      { tabId: tabSession.tabId, sessionId: cdpSessionId },
+      method,
+      params,
+    ]);
+  }
+
+  private async _attachTab(tabId: number): Promise<TabSession> {
+    const existing = this._tabSessions.get(tabId);
+    if (existing)
+      return existing;
+    await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
+    const result = await this._sendToExtension('chrome.debugger.sendCommand', [
+      { tabId },
+      'Target.getTargetInfo',
+    ]);
+    const targetInfo = result?.targetInfo;
+    const sessionId = `pw-tab-${this._nextSessionId++}`;
+    const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };
+    this._tabSessions.set(tabId, tabSession);
+    this._emit({
+      method: 'Target.attachedToTarget',
+      params: {
+        sessionId,
+        targetInfo: { ...targetInfo, attached: true },
+        waitingForDebugger: false,
+      },
+    });
+    return tabSession;
+  }
+
+  private _detachTab(tabId: number): void {
+    const tabSession = this._tabSessions.get(tabId);
+    if (!tabSession)
+      return;
+    this._tabSessions.delete(tabId);
+    this._emit({
+      method: 'Target.detachedFromTarget',
+      params: {
+        sessionId: tabSession.sessionId,
+        targetId: tabSession.targetInfo?.targetId,
+      },
+    });
+  }
+
+  private _findTabSession(predicate: (session: TabSession) => boolean): TabSession | undefined {
+    for (const session of this._tabSessions.values()) {
+      if (predicate(session))
+        return session;
+    }
+    return undefined;
+  }
+}

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -62,8 +62,8 @@ export class CDPRelayServer {
   private _wss: WebSocketServer;
   private _playwrightConnection: WebSocket | null = null;
   private _extensionConnection: ExtensionConnection | null = null;
-  private _handler: ExtensionProtocolV2;
-  private _extensionConnectionPromise = new ManualPromise<void>();
+  private _handler!: ExtensionProtocolV2;
+  private _extensionConnectionPromise!: ManualPromise<void>;
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
     this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
@@ -71,18 +71,11 @@ export class CDPRelayServer {
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;
 
-    const sendCommand = (method: string, params: any): Promise<any> => {
-      if (!this._extensionConnection)
-        throw new Error('Extension not connected');
-      return this._extensionConnection.send(method as keyof ExtensionCommandV2, params);
-    };
-    this._handler = new ExtensionProtocolV2(sendCommand);
-
     const uuid = crypto.randomUUID();
     this._cdpPath = `/cdp/${uuid}`;
     this._extensionPath = `/extension/${uuid}`;
 
-    void this._extensionConnectionPromise.catch(logUnhandledError);
+    this._resetExtensionConnection();
     this._wss = new WebSocketServer({ server });
     this._wss.on('connection', this._onConnection.bind(this));
   }
@@ -97,14 +90,13 @@ export class CDPRelayServer {
 
   async ensureExtensionConnectionForMCPContext(clientInfo: ClientInfo, abortSignal: AbortSignal, _toolName: string | undefined) {
     debugLogger('Ensuring extension connection for MCP context');
+    if (abortSignal.aborted)
+      throw abortSignal.reason;
     if (!this._extensionConnection)
       this._connectBrowser(clientInfo);
     debugLogger('Waiting for incoming extension connection');
     await Promise.race([
       Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
-      new Promise((_, reject) => setTimeout(() => {
-        reject(new Error(`Extension connection timeout. Make sure the "Playwright Extension" is installed. See https://github.com/microsoft/playwright/blob/main/packages/extension/README.md for installation instructions.`));
-      }, process.env.PWMCP_TEST_CONNECTION_TIMEOUT ? parseInt(process.env.PWMCP_TEST_CONNECTION_TIMEOUT, 10) : 5_000)),
       new Promise((_, reject) => abortSignal.addEventListener('abort', reject))
     ]);
     debugLogger('Extension connection established');
@@ -121,6 +113,9 @@ export class CDPRelayServer {
     };
     url.searchParams.set('client', JSON.stringify(client));
     url.searchParams.set('protocolVersion', process.env.PWMCP_TEST_PROTOCOL_VERSION ?? protocol.VERSION.toString());
+    const token = process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN;
+    if (token)
+      url.searchParams.set('token', token);
     const href = url.toString();
 
     let executablePath = this._executablePath;
@@ -207,6 +202,19 @@ export class CDPRelayServer {
     this._extensionConnection?.close(reason);
     if (!this._extensionConnectionPromise.isDone())
       this._extensionConnectionPromise.reject(new Error(reason));
+    this._handler.onExtensionDisconnect(reason);
+    this._resetExtensionConnection();
+  }
+
+  private _resetExtensionConnection() {
+    this._extensionConnection = null;
+    this._extensionConnectionPromise = new ManualPromise<void>();
+    void this._extensionConnectionPromise.catch(logUnhandledError);
+    this._handler = new ExtensionProtocolV2((method, params) => {
+      if (!this._extensionConnection)
+        throw new Error('Extension not connected');
+      return this._extensionConnection.send(method as keyof ExtensionCommandV2, params);
+    });
   }
 
   private _closePlaywrightConnection(reason: string) {
@@ -220,13 +228,18 @@ export class CDPRelayServer {
       ws.close(1000, 'Another extension connection already established');
       return;
     }
-    this._extensionConnection = new ExtensionConnection(ws);
-    this._extensionConnection.onclose = reason => {
+    const connection = new ExtensionConnection(ws);
+    const handler = this._handler;
+    this._extensionConnection = connection;
+    connection.onclose = reason => {
+      if (this._extensionConnection !== connection)
+        return;
       debugLogger('Extension WebSocket closed:', reason);
-      this._handler.onExtensionDisconnect(reason);
+      handler.onExtensionDisconnect(reason);
       this._closePlaywrightConnection(`Extension disconnected: ${reason}`);
+      this._resetExtensionConnection();
     };
-    this._extensionConnection.onmessage = (method, params) => this._handler.handleExtensionEvent(method, params);
+    connection.onmessage = (method, params) => handler.handleExtensionEvent(method, params);
     this._extensionConnectionPromise.resolve();
   }
 

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -92,9 +92,11 @@ export class CDPRelayServer {
     debugLogger('Ensuring extension connection for MCP context');
     if (abortSignal.aborted)
       throw abortSignal.reason;
+    // Protocol v2 requires explicit tab selection; the legacy newTab hint hides its only approval controls.
     if (!this._extensionConnection)
       this._connectBrowser(clientInfo);
     debugLogger('Waiting for incoming extension connection');
+    // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
     await Promise.race([
       Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
       new Promise((_, reject) => abortSignal.addEventListener('abort', reject))

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -29,11 +29,13 @@ import { WebSocket, WebSocketServer } from 'ws';
 import { httpAddressToString } from '../mcp/http.js';
 import { logUnhandledError } from '../utils/log.js';
 import { ManualPromise } from '../mcp/manualPromise.js';
+import { ExtensionProtocolV2 } from './cdpRelayV2.js';
 import * as protocol from './protocol.js';
 
 import type websocket from 'ws';
 import type { ClientInfo } from '../browserContextFactory.js';
-import type { ExtensionCommand, ExtensionEvents } from './protocol.js';
+import type { CDPMessage } from './browserModel.js';
+import type { ExtensionCommandV2, ExtensionEventsV2 } from './protocol.js';
 
 // @ts-ignore -- internal bundle entry point exposed via package exports
 const coreBundle = (await import('playwright-core/lib/coreBundle')).default;
@@ -48,14 +50,7 @@ type CDPCommand = {
   params?: any;
 };
 
-type CDPResponse = {
-  id?: number;
-  sessionId?: string;
-  method?: string;
-  params?: any;
-  result?: any;
-  error?: { code?: number; message: string };
-};
+type CDPResponse = CDPMessage;
 
 export class CDPRelayServer {
   private _wsHost: string;
@@ -67,13 +62,8 @@ export class CDPRelayServer {
   private _wss: WebSocketServer;
   private _playwrightConnection: WebSocket | null = null;
   private _extensionConnection: ExtensionConnection | null = null;
-  private _connectedTabInfo: {
-    targetInfo: any;
-    // Page sessionId that should be used by this connection.
-    sessionId: string;
-  } | undefined;
-  private _nextSessionId: number = 1;
-  private _extensionConnectionPromise!: ManualPromise<void>;
+  private _handler: ExtensionProtocolV2;
+  private _extensionConnectionPromise = new ManualPromise<void>();
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
     this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
@@ -81,11 +71,18 @@ export class CDPRelayServer {
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;
 
+    const sendCommand = (method: string, params: any): Promise<any> => {
+      if (!this._extensionConnection)
+        throw new Error('Extension not connected');
+      return this._extensionConnection.send(method as keyof ExtensionCommandV2, params);
+    };
+    this._handler = new ExtensionProtocolV2(sendCommand);
+
     const uuid = crypto.randomUUID();
     this._cdpPath = `/cdp/${uuid}`;
     this._extensionPath = `/extension/${uuid}`;
 
-    this._resetExtensionConnection();
+    void this._extensionConnectionPromise.catch(logUnhandledError);
     this._wss = new WebSocketServer({ server });
     this._wss.on('connection', this._onConnection.bind(this));
   }
@@ -98,26 +95,25 @@ export class CDPRelayServer {
     return `${this._wsHost}${this._extensionPath}`;
   }
 
-  async ensureExtensionConnectionForMCPContext(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined) {
+  async ensureExtensionConnectionForMCPContext(clientInfo: ClientInfo, abortSignal: AbortSignal, _toolName: string | undefined) {
     debugLogger('Ensuring extension connection for MCP context');
-    if (this._extensionConnection)
-      return;
-    this._connectBrowser(clientInfo, toolName);
+    if (!this._extensionConnection)
+      this._connectBrowser(clientInfo);
     debugLogger('Waiting for incoming extension connection');
     await Promise.race([
-      this._extensionConnectionPromise,
+      Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
       new Promise((_, reject) => setTimeout(() => {
-        reject(new Error(`Extension connection timeout. Make sure the "Playwright MCP Bridge" extension is installed. See https://github.com/microsoft/playwright-mcp/blob/main/extension/README.md for installation instructions.`));
+        reject(new Error(`Extension connection timeout. Make sure the "Playwright Extension" is installed. See https://github.com/microsoft/playwright/blob/main/packages/extension/README.md for installation instructions.`));
       }, process.env.PWMCP_TEST_CONNECTION_TIMEOUT ? parseInt(process.env.PWMCP_TEST_CONNECTION_TIMEOUT, 10) : 5_000)),
       new Promise((_, reject) => abortSignal.addEventListener('abort', reject))
     ]);
     debugLogger('Extension connection established');
   }
 
-  private _connectBrowser(clientInfo: ClientInfo, toolName: string | undefined) {
+  private _connectBrowser(clientInfo: ClientInfo) {
     const mcpRelayEndpoint = `${this._wsHost}${this._extensionPath}`;
     // Need to specify "key" in the manifest.json to make the id stable when loading from file.
-    const url = new URL('chrome-extension://jakfalbnbhgkpmoaakfflhflbfpkailf/connect.html');
+    const url = new URL(`chrome-extension://${protocol.EXTENSION_ID}/connect.html`);
     url.searchParams.set('mcpRelayUrl', mcpRelayEndpoint);
     const client = {
       name: clientInfo.name,
@@ -125,8 +121,6 @@ export class CDPRelayServer {
     };
     url.searchParams.set('client', JSON.stringify(client));
     url.searchParams.set('protocolVersion', process.env.PWMCP_TEST_PROTOCOL_VERSION ?? protocol.VERSION.toString());
-    if (toolName)
-      url.searchParams.set('newTab', String(toolName === 'browser_navigate'));
     const href = url.toString();
 
     let executablePath = this._executablePath;
@@ -176,12 +170,18 @@ export class CDPRelayServer {
   }
 
   private _handlePlaywrightConnection(ws: WebSocket): void {
+    if (!this._extensionConnection) {
+      debugLogger('Rejecting Playwright connection: extension not connected');
+      ws.close(1000, 'Extension not connected');
+      return;
+    }
     if (this._playwrightConnection) {
       debugLogger('Rejecting second Playwright connection');
       ws.close(1000, 'Another CDP client already connected');
       return;
     }
     this._playwrightConnection = ws;
+    this._handler.connectOverCDP(message => this._sendToPlaywright(message));
     ws.on('message', async data => {
       try {
         const message = JSON.parse(data.toString());
@@ -205,15 +205,8 @@ export class CDPRelayServer {
 
   private _closeExtensionConnection(reason: string) {
     this._extensionConnection?.close(reason);
-    this._extensionConnectionPromise.reject(new Error(reason));
-    this._resetExtensionConnection();
-  }
-
-  private _resetExtensionConnection() {
-    this._connectedTabInfo = undefined;
-    this._extensionConnection = null;
-    this._extensionConnectionPromise = new ManualPromise();
-    void this._extensionConnectionPromise.catch(logUnhandledError);
+    if (!this._extensionConnectionPromise.isDone())
+      this._extensionConnectionPromise.reject(new Error(reason));
   }
 
   private _closePlaywrightConnection(reason: string) {
@@ -228,28 +221,13 @@ export class CDPRelayServer {
       return;
     }
     this._extensionConnection = new ExtensionConnection(ws);
-    this._extensionConnection.onclose = (c, reason) => {
-      debugLogger('Extension WebSocket closed:', reason, c === this._extensionConnection);
-      if (this._extensionConnection !== c)
-        return;
-      this._resetExtensionConnection();
+    this._extensionConnection.onclose = reason => {
+      debugLogger('Extension WebSocket closed:', reason);
+      this._handler.onExtensionDisconnect(reason);
       this._closePlaywrightConnection(`Extension disconnected: ${reason}`);
     };
-    this._extensionConnection.onmessage = this._handleExtensionMessage.bind(this);
+    this._extensionConnection.onmessage = (method, params) => this._handler.handleExtensionEvent(method, params);
     this._extensionConnectionPromise.resolve();
-  }
-
-  private _handleExtensionMessage<M extends keyof ExtensionEvents>(method: M, params: ExtensionEvents[M]['params']) {
-    switch (method) {
-      case 'forwardCDPEvent':
-        const sessionId = params.sessionId || this._connectedTabInfo?.sessionId;
-        this._sendToPlaywright({
-          sessionId,
-          method: params.method,
-          params: params.params
-        });
-        break;
-    }
   }
 
   private async _handlePlaywrightMessage(message: CDPCommand): Promise<void> {
@@ -280,44 +258,11 @@ export class CDPRelayServer {
       case 'Browser.setDownloadBehavior': {
         return { };
       }
-      case 'Target.setAutoAttach': {
-        // Forward child session handling.
-        if (sessionId)
-          break;
-        // Simulate auto-attach behavior with real target info
-        const { targetInfo } = await this._extensionConnection!.send('attachToTab', { });
-        this._connectedTabInfo = {
-          targetInfo,
-          sessionId: `pw-tab-${this._nextSessionId++}`,
-        };
-        debugLogger('Simulating auto-attach');
-        this._sendToPlaywright({
-          method: 'Target.attachedToTarget',
-          params: {
-            sessionId: this._connectedTabInfo.sessionId,
-            targetInfo: {
-              ...this._connectedTabInfo.targetInfo,
-              attached: true,
-            },
-            waitingForDebugger: false
-          }
-        });
-        return { };
-      }
-      case 'Target.getTargetInfo': {
-        return this._connectedTabInfo?.targetInfo;
-      }
     }
-    return await this._forwardToExtension(method, params, sessionId);
-  }
-
-  private async _forwardToExtension(method: string, params: any, sessionId: string | undefined): Promise<any> {
-    if (!this._extensionConnection)
-      throw new Error('Extension not connected');
-    // Top level sessionId is only passed between the relay and the client.
-    if (this._connectedTabInfo?.sessionId === sessionId)
-      sessionId = undefined;
-    return await this._extensionConnection.send('forwardCDPCommand', { sessionId, method, params });
+    const handled = await this._handler.handleCDPCommand(method, params, sessionId);
+    if (handled)
+      return handled.result;
+    return await this._handler.forwardToExtension(method, params, sessionId);
   }
 
   private _sendToPlaywright(message: CDPResponse): void {
@@ -339,8 +284,8 @@ class ExtensionConnection {
   private readonly _callbacks = new Map<number, { resolve: (o: any) => void, reject: (e: Error) => void, error: Error }>();
   private _lastId = 0;
 
-  onmessage?: <M extends keyof ExtensionEvents>(method: M, params: ExtensionEvents[M]['params']) => void;
-  onclose?: (self: ExtensionConnection, reason: string) => void;
+  onmessage?: <M extends keyof ExtensionEventsV2>(method: M, params: ExtensionEventsV2[M]['params']) => void;
+  onclose?: (reason: string) => void;
 
   constructor(ws: WebSocket) {
     this._ws = ws;
@@ -349,7 +294,7 @@ class ExtensionConnection {
     this._ws.on('error', this._onError.bind(this));
   }
 
-  async send<M extends keyof ExtensionCommand>(method: M, params: ExtensionCommand[M]['params']): Promise<any> {
+  async send<M extends keyof ExtensionCommandV2>(method: M, params: ExtensionCommandV2[M]['params']): Promise<any> {
     if (this._ws.readyState !== WebSocket.OPEN)
       throw new Error(`Unexpected WebSocket state: ${this._ws.readyState}`);
     const id = ++this._lastId;
@@ -398,14 +343,14 @@ class ExtensionConnection {
     } else if (object.id) {
       debugLogger('← Extension: unexpected response', object);
     } else {
-      this.onmessage?.(object.method! as keyof ExtensionEvents, object.params);
+      this.onmessage?.(object.method! as keyof ExtensionEventsV2, object.params);
     }
   }
 
   private _onClose(event: websocket.CloseEvent) {
     debugLogger(`<ws closed> code=${event.code} reason=${event.reason}`);
     this._dispose();
-    this.onclose?.(this, event.reason);
+    this.onclose?.(event.reason);
   }
 
   private _onError(event: websocket.ErrorEvent) {

--- a/src/extension/cdpRelayV2.ts
+++ b/src/extension/cdpRelayV2.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ManualPromise } from '../mcp/manualPromise.js';
+import { logUnhandledError } from '../utils/log.js';
+import { BrowserModel } from './browserModel.js';
+
+import type { SendCommand, SendToCDPClient } from './browserModel.js';
+import type { ExtensionEventsV2 } from './protocol.js';
+
+export class ExtensionProtocolV2 {
+  private _model: BrowserModel;
+  private _ready = new ManualPromise<void>();
+
+  constructor(sendCommand: SendCommand) {
+    this._model = new BrowserModel(sendCommand);
+    void this._ready.catch(logUnhandledError);
+  }
+
+  ready(): Promise<void> {
+    return this._ready;
+  }
+
+  connectOverCDP(sendToCDPClient: SendToCDPClient): void {
+    this._model.connectOverCDP(sendToCDPClient);
+  }
+
+  onExtensionDisconnect(reason: string): void {
+    if (!this._ready.isDone())
+      this._ready.reject(new Error(`Extension disconnected before initialization: ${reason}`));
+  }
+
+  handleExtensionEvent(method: string, params: any): void {
+    switch (method) {
+      case 'chrome.debugger.onEvent': {
+        const [source, cdpMethod, cdpParams] = params as ExtensionEventsV2['chrome.debugger.onEvent']['params'];
+        this._model.onDebuggerEvent(source, cdpMethod, cdpParams);
+        break;
+      }
+      case 'chrome.debugger.onDetach': {
+        const [source] = params as ExtensionEventsV2['chrome.debugger.onDetach']['params'];
+        this._model.onDebuggerDetach(source);
+        break;
+      }
+      case 'chrome.tabs.onCreated': {
+        const [tab] = params as ExtensionEventsV2['chrome.tabs.onCreated']['params'];
+        this._model.onTabCreated(tab);
+        break;
+      }
+      case 'chrome.tabs.onRemoved': {
+        const [tabId] = params as ExtensionEventsV2['chrome.tabs.onRemoved']['params'];
+        this._model.onTabRemoved(tabId);
+        break;
+      }
+      case 'extension.initialized': {
+        this._ready.resolve();
+        break;
+      }
+    }
+  }
+
+  async handleCDPCommand(method: string, params: any, sessionId: string | undefined): Promise<{ result: any } | undefined> {
+    switch (method) {
+      case 'Target.setAutoAttach': {
+        if (sessionId)
+          return undefined;
+        await this._model.enableAutoAttach();
+        return { result: {} };
+      }
+      case 'Target.createTarget':
+        return { result: await this._model.createTarget(params?.url) };
+      case 'Target.closeTarget':
+        return { result: await this._model.closeTarget(params?.targetId) };
+      case 'Target.getTargetInfo':
+        return { result: this._model.getTargetInfo(sessionId) };
+    }
+    return undefined;
+  }
+
+  async forwardToExtension(method: string, params: any, sessionId: string | undefined): Promise<any> {
+    if (!sessionId)
+      return await this._model.sendBrowserCommand(method, params);
+    return await this._model.sendCommand(sessionId, method, params);
+  }
+}

--- a/src/extension/cdpRelayV2.ts
+++ b/src/extension/cdpRelayV2.ts
@@ -77,7 +77,10 @@ export class ExtensionProtocolV2 {
       case 'Target.setAutoAttach': {
         if (sessionId)
           return undefined;
-        await this._model.enableAutoAttach();
+        if (params?.autoAttach)
+          await this._model.enableAutoAttach();
+        else
+          await this._model.disableAutoAttach();
         return { result: {} };
       }
       case 'Target.createTarget':

--- a/src/extension/protocol.ts
+++ b/src/extension/protocol.ts
@@ -14,29 +14,75 @@
  * limitations under the License.
  */
 
-// Whenever the commands/events change, the version must be updated. The latest
-// extension version should be compatible with the old MCP clients.
-export const VERSION = 1;
+// The protocol version defined in this file. Bumped whenever the
+// commands/events change. Sent to the extension, which rejects clients
+// requesting a version it does not support.
+export const VERSION = 2;
+export const EXTENSION_ID = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
-export type ExtensionCommand = {
-  'attachToTab': {
-    params: {};
+// Structural mirrors of @types/chrome shapes used over the wire. The extension
+// imports the real chrome.* types and they are structurally compatible.
+export type Debuggee = { tabId?: number; extensionId?: string; targetId?: string };
+export type DebuggerSession = Debuggee & { sessionId?: string };
+export type TabCreateProperties = {
+  active?: boolean;
+  index?: number;
+  openerTabId?: number;
+  pinned?: boolean;
+  url?: string;
+  windowId?: number;
+};
+export type Tab = {
+  id?: number;
+  index: number;
+  windowId: number;
+  openerTabId?: number;
+  url?: string;
+  title?: string;
+  active: boolean;
+  pinned: boolean;
+};
+export type TabRemoveInfo = { windowId: number; isWindowClosing: boolean };
+
+// Protocol v2 command params/results mirror chrome.* positional arguments.
+export type ExtensionCommandV2 = {
+  'chrome.debugger.attach': {
+    params: [target: Debuggee, requiredVersion: string];
+    result: void;
   };
-  'forwardCDPCommand': {
-    params: {
-      method: string,
-      sessionId?: string
-      params?: any,
-    };
+  'chrome.debugger.detach': {
+    params: [target: Debuggee];
+    result: void;
+  };
+  'chrome.debugger.sendCommand': {
+    params: [target: DebuggerSession, method: string, commandParams?: object];
+    result: any;
+  };
+  'chrome.tabs.create': {
+    params: [createProperties: TabCreateProperties];
+    result: Tab;
+  };
+  'chrome.tabs.remove': {
+    params: [tabIds: number | number[]];
+    result: void;
   };
 };
 
-export type ExtensionEvents = {
-  'forwardCDPEvent': {
-    params: {
-      method: string,
-      sessionId?: string
-      params?: any,
-    };
+// Protocol v2 events mirror chrome.<api>.<event>.addListener callback signatures.
+export type ExtensionEventsV2 = {
+  'chrome.debugger.onEvent': {
+    params: [source: DebuggerSession, method: string, eventParams?: object];
+  };
+  'chrome.debugger.onDetach': {
+    params: [source: Debuggee, reason: string];
+  };
+  'chrome.tabs.onCreated': {
+    params: [tab: Tab];
+  };
+  'chrome.tabs.onRemoved': {
+    params: [tabId: number, removeInfo: TabRemoveInfo];
+  };
+  'extension.initialized': {
+    params: [];
   };
 };

--- a/src/program.ts
+++ b/src/program.ts
@@ -85,7 +85,7 @@ function configureBaseProgram() {
       .option('--config <path>', 'path to the configuration file.')
       .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
       .option('--executable-path <path>', 'path to the browser executable.')
-      .option('--extension', 'Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright MCP Bridge" browser extension to be installed.')
+      .option('--extension', 'Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright Extension" to be installed.')
       .option('--headless', 'run browser in headless mode, headed by default')
       .option('--host <host>', 'host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.')
       .option('--ignore-https-errors', 'ignore https errors')

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -143,6 +143,7 @@ describe('extension protocol v2', () => {
     void enabling.then(() => enabled = true);
     await Promise.resolve();
     expect(enabled).toBe(false);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(1);
 
     resolveDetach();
     await expect(Promise.all([disabling, enabling])).resolves.toEqual([{ result: {} }, { result: {} }]);

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -70,6 +70,12 @@ describe('extension protocol v2', () => {
       { expression: '1 + 1' },
     ]);
 
+    await handler.forwardToExtension('Page.enable', undefined, 'pw-tab-1');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Page.enable',
+    ]);
+
     handler.handleExtensionEvent('chrome.debugger.onEvent', [
       { tabId: 7 },
       'Target.attachedToTarget',

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import http from 'node:http';
+import { WebSocket } from 'ws';
 import { describe, expect, it, vi } from 'vitest';
+import { CDPRelayServer } from '../src/extension/cdpRelay.js';
 import { ExtensionProtocolV2 } from '../src/extension/cdpRelayV2.js';
 import { EXTENSION_ID, VERSION } from '../src/extension/protocol.js';
 
 import type { CDPMessage } from '../src/extension/browserModel.js';
 import type { Tab } from '../src/extension/protocol.js';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 
 describe('extension protocol v2', () => {
   it('tracks tabs and routes top-level, child, and browser CDP commands', async () => {
@@ -30,6 +37,7 @@ describe('extension protocol v2', () => {
       if (method === 'chrome.tabs.create') {
         const tab = { id: 8, index: 1, windowId: 1, url: params[0].url, active: true, pinned: false };
         tabs.set(8, tab);
+        handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
         return tab;
       }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
@@ -46,7 +54,8 @@ describe('extension protocol v2', () => {
     handler.handleExtensionEvent('extension.initialized', []);
     await expect(handler.ready()).resolves.toBeUndefined();
 
-    await expect(handler.handleCDPCommand('Target.setAutoAttach', {}, undefined)).resolves.toEqual({ result: {} });
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined))
+        .resolves.toEqual({ result: {} });
     expect(sendCommand).toHaveBeenNthCalledWith(1, 'chrome.debugger.attach', [{ tabId: 7 }, '1.3']);
     expect(sendCommand).toHaveBeenNthCalledWith(2, 'chrome.debugger.sendCommand', [{ tabId: 7 }, 'Target.getTargetInfo']);
     expect(messages[0]).toMatchObject({
@@ -75,6 +84,7 @@ describe('extension protocol v2', () => {
 
     await expect(handler.handleCDPCommand('Target.createTarget', { url: 'https://example.org' }, undefined))
         .resolves.toEqual({ result: { targetId: 'target-8' } });
+    expect(sendCommand.mock.calls.filter(([method, params]) => method === 'chrome.debugger.attach' && params[0].tabId === 8)).toHaveLength(1);
     await expect(handler.handleCDPCommand('Target.closeTarget', { targetId: 'target-8' }, undefined))
         .resolves.toEqual({ result: { success: true } });
     expect(sendCommand).toHaveBeenLastCalledWith('chrome.tabs.remove', [8]);
@@ -85,5 +95,138 @@ describe('extension protocol v2', () => {
       'Storage.getCookies',
       {},
     ]);
+
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined))
+        .resolves.toEqual({ result: {} });
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toEqual([
+      ['chrome.debugger.detach', [{ tabId: 7 }]],
+      ['chrome.debugger.detach', [{ tabId: 8 }]],
+    ]);
+    expect(messages.filter(message => message.method === 'Target.detachedFromTarget')).toHaveLength(2);
+  });
+
+  it('rejects initial auto-attach when an existing tab cannot be attached', async () => {
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'chrome.debugger.attach')
+        throw new Error('attach failed');
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined))
+        .rejects.toThrow('attach failed');
+  });
+
+  it('serializes concurrent auto-attach state changes', async () => {
+    let resolveDetach!: () => void;
+    const detach = new Promise<void>(resolve => resolveDetach = resolve);
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'chrome.debugger.sendCommand')
+        return { targetInfo: { targetId: 'target-7', type: 'page' } };
+      if (method === 'chrome.debugger.detach')
+        await detach;
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+    await vi.waitFor(() => expect(sendCommand.mock.calls.some(([method]) => method === 'chrome.debugger.detach')).toBe(true));
+    const enabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    let enabled = false;
+    void enabling.then(() => enabled = true);
+    await Promise.resolve();
+    expect(enabled).toBe(false);
+
+    resolveDetach();
+    await expect(Promise.all([disabling, enabling])).resolves.toEqual([{ result: {} }, { result: {} }]);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
+  });
+
+  it('accepts a replacement extension connection after disconnect', async () => {
+    vi.mocked(spawn).mockClear();
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
+    const clientInfo = { name: 'test-client', version: '1.0.0' };
+    let second: WebSocket | undefined;
+    try {
+      const first = new WebSocket(relay.extensionEndpoint());
+      await once(first, 'open');
+      first.send(JSON.stringify({ method: 'extension.initialized', params: [] }));
+      await relay.ensureExtensionConnectionForMCPContext(clientInfo, new AbortController().signal, undefined);
+
+      first.close();
+      await once(first, 'close');
+      await vi.waitFor(() => expect((relay as any)._extensionConnection).toBeNull());
+
+      const reconnecting = relay.ensureExtensionConnectionForMCPContext(clientInfo, new AbortController().signal, undefined);
+      let reconnected = false;
+      void reconnecting.then(() => reconnected = true);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      second = new WebSocket(relay.extensionEndpoint());
+      await once(second, 'open');
+      await Promise.resolve();
+      expect(reconnected).toBe(false);
+      second.send(JSON.stringify({ method: 'extension.initialized', params: [] }));
+      await expect(reconnecting).resolves.toBeUndefined();
+      expect(second.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      second?.close();
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  it('waits for extension approval and forwards the configured token', async () => {
+    vi.mocked(spawn).mockClear();
+    vi.stubEnv('PLAYWRIGHT_MCP_EXTENSION_TOKEN', 'test-token');
+    vi.stubEnv('PWMCP_TEST_CONNECTION_TIMEOUT', '1');
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
+    let extension: WebSocket | undefined;
+    try {
+      const aborted = new AbortController();
+      aborted.abort(new Error('cancelled'));
+      await expect(relay.ensureExtensionConnectionForMCPContext(
+          { name: 'test-client', version: '1.0.0' }, aborted.signal, undefined)).rejects.toThrow('cancelled');
+      expect(spawn).not.toHaveBeenCalled();
+
+      const connecting = relay.ensureExtensionConnectionForMCPContext(
+          { name: 'test-client', version: '1.0.0' },
+          new AbortController().signal,
+          undefined,
+      );
+      let settled = false;
+      void connecting.then(() => settled = true, () => settled = true);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(settled).toBe(false);
+
+      const args = vi.mocked(spawn).mock.calls[0][1] as string[];
+      expect(new URL(args.at(-1)!).searchParams.get('token')).toBe('test-token');
+
+      extension = new WebSocket(relay.extensionEndpoint());
+      await once(extension, 'open');
+      extension.send(JSON.stringify({ method: 'extension.initialized', params: [] }));
+      await expect(connecting).resolves.toBeUndefined();
+    } finally {
+      extension?.close();
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { ExtensionProtocolV2 } from '../src/extension/cdpRelayV2.js';
+import { EXTENSION_ID, VERSION } from '../src/extension/protocol.js';
+
+import type { CDPMessage } from '../src/extension/browserModel.js';
+import type { Tab } from '../src/extension/protocol.js';
+
+describe('extension protocol v2', () => {
+  it('tracks tabs and routes top-level, child, and browser CDP commands', async () => {
+    const tabs = new Map<number, Tab>([
+      [7, { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false }],
+    ]);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create') {
+        const tab = { id: 8, index: 1, windowId: 1, url: params[0].url, active: true, pinned: false };
+        tabs.set(8, tab);
+        return tab;
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page', url: tabs.get(params[0].tabId)?.url } };
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+
+    expect(VERSION).toBe(2);
+    expect(EXTENSION_ID).toBe('mmlmfjhmonkocbjadbfplnigmagldckm');
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tabs.get(7)]);
+    handler.handleExtensionEvent('extension.initialized', []);
+    await expect(handler.ready()).resolves.toBeUndefined();
+
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', {}, undefined)).resolves.toEqual({ result: {} });
+    expect(sendCommand).toHaveBeenNthCalledWith(1, 'chrome.debugger.attach', [{ tabId: 7 }, '1.3']);
+    expect(sendCommand).toHaveBeenNthCalledWith(2, 'chrome.debugger.sendCommand', [{ tabId: 7 }, 'Target.getTargetInfo']);
+    expect(messages[0]).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+
+    await handler.forwardToExtension('Runtime.evaluate', { expression: '1 + 1' }, 'pw-tab-1');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Runtime.evaluate',
+      { expression: '1 + 1' },
+    ]);
+
+    handler.handleExtensionEvent('chrome.debugger.onEvent', [
+      { tabId: 7 },
+      'Target.attachedToTarget',
+      { sessionId: 'child-1' },
+    ]);
+    await handler.forwardToExtension('Runtime.enable', {}, 'child-1');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: 'child-1' },
+      'Runtime.enable',
+      {},
+    ]);
+
+    await expect(handler.handleCDPCommand('Target.createTarget', { url: 'https://example.org' }, undefined))
+        .resolves.toEqual({ result: { targetId: 'target-8' } });
+    await expect(handler.handleCDPCommand('Target.closeTarget', { targetId: 'target-8' }, undefined))
+        .resolves.toEqual({ result: { success: true } });
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.tabs.remove', [8]);
+
+    await handler.forwardToExtension('Storage.getCookies', {}, undefined);
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7 },
+      'Storage.getCookies',
+      {},
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the single-tab extension protocol v1 relay with the protocol v2 tab/session model
- target the current Playwright Extension and wait for its initialization handshake
- harden concurrent attachment, auto-attach toggling, disconnect/reconnect, delayed approval, and token-authentication behavior
- document the protocol v2 requirement and token configuration, with focused lifecycle coverage

## Why

Upstream Playwright PR https://github.com/microsoft/playwright/pull/41857 removes extension protocol v1 and makes the extension reject clients advertising versions below 2. This package still advertised v1 and used the legacy extension identity, so extension mode would stop connecting once that upstream extension ships.

The protocol migration follows upstream commit https://github.com/microsoft/playwright/commit/575db11d2156fc7da9015da3dc7dae7478278286. Review fixes also align token pass-through and long-running extension handshakes with upstream commits https://github.com/microsoft/playwright/commit/4968bc611 and https://github.com/microsoft/playwright/commit/32ef2297f36abf92f8bc15843eb051b15e2273e6.

Closes #130.

## Validation

- `npm test -- tests/extension-protocol.test.ts` (5 tests)
- `npm test -- tests/extension-protocol.test.ts tests/program.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (34 files, 367 tests)
- `npm pack --dry-run --json`
- independent sub-agent review: approved with no remaining actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser extension mode via the `--extension` CLI flag.
  * Implemented support for Playwright Extension protocol v2, including debugger/tab session routing and target lifecycle (create/close/attach).
  * Added improved auto-attach behavior that can be enabled and disabled.
* **Documentation**
  * Updated docs and CLI help with extension mode requirements, a usage example, and token-based connection setup to avoid approval prompts.
* **Tests**
  * Expanded coverage for extension protocol v2 and CDP relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->