### PR TITLE
Fix orphaned extension reconnect seed tab

### DIFF
--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -115,9 +115,16 @@ export class BrowserModel {
       throw new Error('Failed to create tab');
     this._knownTabs.set(tab.id, tab);
     const tabSession = await this._attachTab(tab.id);
-    await Promise.allSettled([...this._knownTabs.values()]
-        .filter(knownTab => knownTab.id !== tab.id && this._connectPagePrefix && knownTab.url?.startsWith(this._connectPagePrefix))
-        .map(knownTab => this._sendToExtension('chrome.tabs.remove', [knownTab.id])));
+    if (this._connectPagePrefix) {
+      const connectPagePrefix = this._connectPagePrefix;
+      await Promise.allSettled([...this._knownTabs]
+          .filter(([tabId, knownTab]) => tabId !== tab.id && knownTab.url?.startsWith(connectPagePrefix))
+          .map(async ([tabId]) => {
+            const result = await this._sendDebuggerCommand({ tabId }, 'Target.getTargetInfo', undefined);
+            if (result?.targetInfo?.url?.startsWith(connectPagePrefix))
+              await this._sendToExtension('chrome.tabs.remove', [tabId]);
+          }));
+    }
     return { targetId: tabSession.targetInfo?.targetId };
   }
 

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -15,6 +15,7 @@
  */
 
 import { logUnhandledError } from '../utils/log.js';
+import { EXTENSION_ID } from './protocol.js';
 
 import type { DebuggerSession, Debuggee, Tab } from './protocol.js';
 
@@ -115,6 +116,10 @@ export class BrowserModel {
       throw new Error('Failed to create tab');
     this._knownTabs.set(tab.id, tab);
     const tabSession = await this._attachTab(tab.id);
+    const connectPagePrefix = `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=`;
+    await Promise.all([...this._knownTabs.values()]
+        .filter(knownTab => knownTab.id !== tab.id && knownTab.url?.startsWith(connectPagePrefix))
+        .map(knownTab => this._sendToExtension('chrome.tabs.remove', [knownTab.id])));
     return { targetId: tabSession.targetInfo?.targetId };
   }
 

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -15,7 +15,6 @@
  */
 
 import { logUnhandledError } from '../utils/log.js';
-import { EXTENSION_ID } from './protocol.js';
 
 import type { DebuggerSession, Debuggee, Tab } from './protocol.js';
 
@@ -48,7 +47,7 @@ export class BrowserModel {
   private _autoAttach = false;
   private _nextSessionId = 1;
 
-  constructor(sendToExtension: SendCommand) {
+  constructor(sendToExtension: SendCommand, private _connectPagePrefix?: string) {
     this._sendToExtension = sendToExtension;
   }
 
@@ -116,9 +115,8 @@ export class BrowserModel {
       throw new Error('Failed to create tab');
     this._knownTabs.set(tab.id, tab);
     const tabSession = await this._attachTab(tab.id);
-    const connectPagePrefix = `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=`;
-    await Promise.all([...this._knownTabs.values()]
-        .filter(knownTab => knownTab.id !== tab.id && knownTab.url?.startsWith(connectPagePrefix))
+    await Promise.allSettled([...this._knownTabs.values()]
+        .filter(knownTab => knownTab.id !== tab.id && this._connectPagePrefix && knownTab.url?.startsWith(this._connectPagePrefix))
         .map(knownTab => this._sendToExtension('chrome.tabs.remove', [knownTab.id])));
     return { targetId: tabSession.targetInfo?.targetId };
   }

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -59,6 +59,7 @@ export class CDPRelayServer {
   private _executablePath?: string;
   private _cdpPath: string;
   private _extensionPath: string;
+  private _connectPagePrefix: string;
   private _wss: WebSocketServer;
   private _playwrightConnection: WebSocket | null = null;
   private _extensionConnection: ExtensionConnection | null = null;
@@ -74,6 +75,9 @@ export class CDPRelayServer {
     const uuid = crypto.randomUUID();
     this._cdpPath = `/cdp/${uuid}`;
     this._extensionPath = `/extension/${uuid}`;
+    const connectPageUrl = new URL(`chrome-extension://${protocol.EXTENSION_ID}/connect.html`);
+    connectPageUrl.searchParams.set('mcpRelayUrl', this.extensionEndpoint());
+    this._connectPagePrefix = connectPageUrl.toString();
 
     this._resetExtensionConnection();
     this._wss = new WebSocketServer({ server });
@@ -105,10 +109,8 @@ export class CDPRelayServer {
   }
 
   private _connectBrowser(clientInfo: ClientInfo) {
-    const mcpRelayEndpoint = `${this._wsHost}${this._extensionPath}`;
     // Need to specify "key" in the manifest.json to make the id stable when loading from file.
-    const url = new URL(`chrome-extension://${protocol.EXTENSION_ID}/connect.html`);
-    url.searchParams.set('mcpRelayUrl', mcpRelayEndpoint);
+    const url = new URL(this._connectPagePrefix);
     const client = {
       name: clientInfo.name,
       version: clientInfo.version,
@@ -216,7 +218,7 @@ export class CDPRelayServer {
       if (!this._extensionConnection)
         throw new Error('Extension not connected');
       return this._extensionConnection.send(method as keyof ExtensionCommandV2, params);
-    });
+    }, this._connectPagePrefix);
   }
 
   private _closePlaywrightConnection(reason: string) {

--- a/src/extension/cdpRelayV2.ts
+++ b/src/extension/cdpRelayV2.ts
@@ -25,8 +25,8 @@ export class ExtensionProtocolV2 {
   private _model: BrowserModel;
   private _ready = new ManualPromise<void>();
 
-  constructor(sendCommand: SendCommand) {
-    this._model = new BrowserModel(sendCommand);
+  constructor(sendCommand: SendCommand, connectPagePrefix?: string) {
+    this._model = new BrowserModel(sendCommand, connectPagePrefix);
     void this._ready.catch(logUnhandledError);
   }
 

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -126,15 +126,18 @@ describe('extension protocol v2', () => {
         .rejects.toThrow('attach failed');
   });
 
-  it('best-effort removes only this relay\'s token-bypass connect page', async () => {
+  it('best-effort removes only this relay\'s seed while it is still on the connect page', async () => {
     const connectPage = new URL(`chrome-extension://${EXTENSION_ID}/connect.html`);
     connectPage.searchParams.set('mcpRelayUrl', 'ws://127.0.0.1/current');
     const connectPagePrefix = connectPage.toString();
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.tabs.create')
         return { id: 8, url: params[0].url };
-      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
-        return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        const tabId = params[0].tabId;
+        const url = tabId === 7 ? `${connectPagePrefix}&client=current` : tabId === 10 ? 'https://example.com' : undefined;
+        return { targetInfo: { targetId: `target-${tabId}`, type: 'page', url } };
+      }
       if (method === 'chrome.tabs.remove')
         throw new Error('tab already closed');
       return {};
@@ -143,6 +146,7 @@ describe('extension protocol v2', () => {
     handler.handleExtensionEvent('chrome.tabs.onCreated', [
       { id: 7, url: `${connectPagePrefix}&client=current` },
       { id: 9, url: `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=ws%3A%2F%2F127.0.0.1%2Fother` },
+      { id: 10, url: `${connectPagePrefix}&client=current` },
     ]);
 
     await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
@@ -151,6 +155,7 @@ describe('extension protocol v2', () => {
 
     expect(sendCommand).toHaveBeenCalledWith('chrome.tabs.remove', [7]);
     expect(sendCommand).not.toHaveBeenCalledWith('chrome.tabs.remove', [9]);
+    expect(sendCommand).not.toHaveBeenCalledWith('chrome.tabs.remove', [10]);
   });
 
   it('serializes concurrent auto-attach state changes', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -126,6 +126,26 @@ describe('extension protocol v2', () => {
         .rejects.toThrow('attach failed');
   });
 
+  it('removes the token-bypass connect page after creating a target', async () => {
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create')
+        return { id: 8, url: params[0].url };
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [{
+      id: 7,
+      url: `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=ws%3A%2F%2F127.0.0.1`,
+    }]);
+
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await handler.handleCDPCommand('Target.createTarget', {}, undefined);
+
+    expect(sendCommand).toHaveBeenCalledWith('chrome.tabs.remove', [7]);
+  });
+
   it('serializes concurrent auto-attach state changes', async () => {
     let resolveDetach!: () => void;
     const detach = new Promise<void>(resolve => resolveDetach = resolve);

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -126,24 +126,31 @@ describe('extension protocol v2', () => {
         .rejects.toThrow('attach failed');
   });
 
-  it('removes the token-bypass connect page after creating a target', async () => {
+  it('best-effort removes only this relay\'s token-bypass connect page', async () => {
+    const connectPage = new URL(`chrome-extension://${EXTENSION_ID}/connect.html`);
+    connectPage.searchParams.set('mcpRelayUrl', 'ws://127.0.0.1/current');
+    const connectPagePrefix = connectPage.toString();
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.tabs.create')
         return { id: 8, url: params[0].url };
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
         return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      if (method === 'chrome.tabs.remove')
+        throw new Error('tab already closed');
       return {};
     });
-    const handler = new ExtensionProtocolV2(sendCommand);
-    handler.handleExtensionEvent('chrome.tabs.onCreated', [{
-      id: 7,
-      url: `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=ws%3A%2F%2F127.0.0.1`,
-    }]);
+    const handler = new ExtensionProtocolV2(sendCommand, connectPagePrefix);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, url: `${connectPagePrefix}&client=current` },
+      { id: 9, url: `chrome-extension://${EXTENSION_ID}/connect.html?mcpRelayUrl=ws%3A%2F%2F127.0.0.1%2Fother` },
+    ]);
 
     await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
-    await handler.handleCDPCommand('Target.createTarget', {}, undefined);
+    await expect(handler.handleCDPCommand('Target.createTarget', {}, undefined))
+        .resolves.toEqual({ result: { targetId: 'target-8' } });
 
     expect(sendCommand).toHaveBeenCalledWith('chrome.tabs.remove', [7]);
+    expect(sendCommand).not.toHaveBeenCalledWith('chrome.tabs.remove', [9]);
   });
 
   it('serializes concurrent auto-attach state changes', async () => {


### PR DESCRIPTION
## Summary

- remove the token-bypass `connect.html?mcpRelayUrl=` seed tab after its replacement target is attached
- keep cleanup scoped to the Playwright extension relay so normal browser tabs and other run modes are unchanged
- add focused protocol-v2 regression coverage

## Upstream context

Upstream issue: https://github.com/microsoft/playwright/issues/41864

Playwright reports that after an extension reconnect, making `browser_tabs { action: "new" }` the first tool call creates a second target and leaves the connection seed page orphaned. This repository has the same protocol-v2 flow: token bypass adopts the seed page, then `BrowserModel.createTarget()` attached the requested page without retiring the infrastructure tab.

The fix removes only other known tabs with the exact extension seed URL, and only after the replacement target attaches. This resolves the locally reproducible cause without changing general tab behavior or attempting to patch the separate competing-tab-group race owned by the browser extension.

Closes #132

## Validation

- real protocol-v2 extension + headed Chromium reproduction on current `main`
- `npm test -- tests/extension-protocol.test.ts`
- `npm run lint`
- `npm test` (34 files, 368 tests)
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically closes obsolete extension connect-page tabs when creating a new browser target, based on a computed connect-page prefix.
  * Ensures best-effort cleanup removes only the intended relay’s connect page, without affecting other connect-page tabs.

* **Tests**
  * Added a new protocol v2 test to verify correct tab removal behavior across multiple connect-page tabs, including when the removal targets are already closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->