### PR TITLE
feat: make post-action settle delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ Create a `config.json` file with the following options:
   },
   "timeouts": {
     "navigationTimeout": 60000,
-    "defaultTimeout": 5000
+    "defaultTimeout": 5000,
+    "settle": 500
   },
   "network": {
     "allowedOrigins": ["example.com", "trusted-site.com"],
@@ -217,10 +218,13 @@ Create a `config.json` file with the following options:
 - CDP attach modes preserve the target browser's existing default-context settings instead of applying Playwright's defaults.
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
+- `timeouts.settle`: How long to wait after each action for triggered work to settle before responding (default: `500`)
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
+
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay.
 
 #### HTTP Heartbeat
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -180,5 +180,10 @@ export type Config = {
      * Default timeout for all Playwright operations (clicks, fills, etc). Defaults to 5000ms (5 seconds).
      */
     defaultTimeout?: number;
+
+    /**
+     * How long to wait after each action for triggered work to settle before responding. Defaults to 500ms.
+     */
+    settle?: number;
   };
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export type CLIOptions = {
     viewportSize?: string;
     navigationTimeout?: number;
     defaultTimeout?: number;
+    settleTimeout?: number;
 };
 
 const defaultConfig: FullConfig = {
@@ -83,6 +84,7 @@ const defaultConfig: FullConfig = {
   timeouts: {
     navigationTimeout: 60000,
     defaultTimeout: 5000,
+    settle: 500,
   },
 };
 
@@ -260,6 +262,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
     timeouts: {
       navigationTimeout: cliOptions.navigationTimeout,
       defaultTimeout: cliOptions.defaultTimeout,
+      settle: cliOptions.settleTimeout,
     }
   };
 }
@@ -301,6 +304,7 @@ function cliOptionsFromEnv(): CLIOptions {
   options.viewportSize = envToString(process.env.PLAYWRIGHT_MCP_VIEWPORT_SIZE);
   options.navigationTimeout = envToNumber(process.env.PLAYWRIGHT_MCP_NAVIGATION_TIMEOUT);
   options.defaultTimeout = envToNumber(process.env.PLAYWRIGHT_MCP_DEFAULT_TIMEOUT);
+  options.settleTimeout = envToNumber(process.env.PLAYWRIGHT_MCP_TIMEOUT_SETTLE);
   return options;
 }
 
@@ -366,6 +370,7 @@ function mergeConfig(base: FullConfig, overrides: Config): FullConfig {
     timeouts: {
       navigationTimeout: overrides.timeouts?.navigationTimeout ?? base.timeouts.navigationTimeout,
       defaultTimeout: overrides.timeouts?.defaultTimeout ?? base.timeouts.defaultTimeout,
+      settle: overrides.timeouts?.settle ?? base.timeouts.settle,
     },
   } as FullConfig;
 }

--- a/src/program.ts
+++ b/src/program.ts
@@ -105,6 +105,7 @@ function configureBaseProgram() {
       .option('--viewport-size <size>', 'specify browser viewport size in pixels, for example "1280, 720"')
       .option('--navigation-timeout <ms>', 'maximum time in milliseconds for page navigation. Defaults to 60000ms (60 seconds).', parseInt)
       .option('--default-timeout <ms>', 'default timeout for all Playwright operations (clicks, fills, etc). Defaults to 5000ms (5 seconds).', parseInt)
+      .option('--timeout-settle <ms>', 'how long to wait after each action for triggered work to settle, in milliseconds. Defaults to 500ms.', parseInt)
       .addOption(new Option('--connect-tool', 'Allow to switch between different browser connection methods.').hideHelp())
       .addOption(new Option('--vscode', 'VS Code tools.').hideHelp());
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -22,6 +22,7 @@ import type * as playwright from 'playwright';
 import type { Tab } from '../tab.js';
 
 export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>): Promise<R> {
+  const settleMs = tab.context.config.timeouts.settle ?? 500;
   const requests = new Set<playwright.Request>();
   let frameNavigated = false;
   let waitCallback: () => void = () => {};
@@ -65,7 +66,7 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     if (!requests.size && !frameNavigated)
       waitCallback();
     await waitBarrier;
-    await tab.waitForTimeout(1000);
+    await tab.waitForTimeout(settleMs);
     return result;
   } finally {
     dispose();

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -36,6 +36,7 @@ describe('Config', () => {
       expect(config.browser.browserName).toBe('chromium');
       expect(config.timeouts.navigationTimeout).toBe(60000);
       expect(config.timeouts.defaultTimeout).toBe(5000);
+      expect(config.timeouts.settle).toBe(500);
       expect(config.saveTrace).toBe(false);
     });
 
@@ -60,6 +61,7 @@ describe('Config', () => {
         timeouts: {
           navigationTimeout: 30000,
           defaultTimeout: 10000,
+          settle: 250,
         },
       };
 
@@ -67,6 +69,7 @@ describe('Config', () => {
 
       expect(config.timeouts.navigationTimeout).toBe(30000);
       expect(config.timeouts.defaultTimeout).toBe(10000);
+      expect(config.timeouts.settle).toBe(250);
     });
 
     it('should merge network config', async () => {
@@ -106,6 +109,20 @@ describe('Config', () => {
       expect(config.timeouts.navigationTimeout).toBe(60000);
       expect(config.saveTrace).toBe(false);
     });
+  });
+
+  it('reads the settle timeout from the environment and lets CLI override it', async () => {
+    const previous = process.env.PLAYWRIGHT_MCP_TIMEOUT_SETTLE;
+    process.env.PLAYWRIGHT_MCP_TIMEOUT_SETTLE = '250';
+    try {
+      expect((await resolveCLIConfig({})).timeouts.settle).toBe(250);
+      expect((await resolveCLIConfig({ settleTimeout: 100 })).timeouts.settle).toBe(100);
+    } finally {
+      if (previous === undefined)
+        delete process.env.PLAYWRIGHT_MCP_TIMEOUT_SETTLE;
+      else
+        process.env.PLAYWRIGHT_MCP_TIMEOUT_SETTLE = previous;
+    }
   });
 
   describe('parseCdpHeaders', () => {

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -66,6 +66,7 @@ describe('CLI command dispatch contract', () => {
       expect(help).toContain('--config');
       expect(help).toContain('--headless');
       expect(help).toContain('--mobile');
+      expect(help).toContain('--timeout-settle');
     });
   });
 

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -62,6 +62,7 @@ describe('Tool Utils', () => {
     mockPage._wrapApiCall = vi.fn().mockImplementation(cb => cb());
 
     mockTab = {
+      context: { config: { timeouts: { settle: 500 } } },
       page: mockPage,
       waitForLoadState: vi.fn().mockResolvedValue(undefined),
       waitForTimeout: vi.fn().mockResolvedValue(undefined),
@@ -125,12 +126,13 @@ describe('Tool Utils', () => {
       vi.useRealTimers();
     });
 
-    it('should wait 1 second after completion', async () => {
+    it('should use the configured settle delay after completion', async () => {
       const callback = vi.fn().mockResolvedValue('result');
+      mockTab.context.config.timeouts.settle = 25;
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(1000);
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
     });
   });
 


### PR DESCRIPTION
## Summary

- Mirrors [microsoft/playwright#41924](https://github.com/microsoft/playwright/pull/41924) and its [merged commit](https://github.com/microsoft/playwright/commit/6d487d67c9cfaa960faa32f60a8e0a03facd3d91).
- Adds the `timeouts.settle` config value, `--timeout-settle` CLI option, and `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` environment variable.
- Uses the configured delay after browser actions, defaulting to the upstream 500 ms behavior instead of the previous hard-coded 1,000 ms delay.
- Documents the new surface and adds focused config, CLI, and action-settling coverage.

## Why this matters

The fixed post-action pause applies to every browser action in this server. Matching the upstream control lets callers reduce avoidable latency when they already handle settling, while retaining the upstream default for existing users.

## Validation

- `npm test -- tests/config.test.ts tests/tools-utils.test.ts tests/program.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable post-action settle delay, defaulting to 500 ms.
  * Added the `--timeout-settle` command-line option.
  * Added support for configuring the delay through the `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` environment variable.
* **Documentation**
  * Updated configuration examples and option reference with the new timeout setting.
* **Bug Fixes**
  * Post-action waits now use the configured settle delay instead of a fixed duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->