### PR TITLE
fix: sync MCP download and extension profile handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ npx mcp-accessibility-scanner --extension
 ```
 
 Set `PLAYWRIGHT_MCP_EXTENSION_TOKEN` to the token shown by the extension to bypass the connection approval dialog.
+When `--user-data-dir` contains multiple Chrome profiles, the profile with the extension installed is selected automatically, preferring Chrome's last-used profile.
 
 ### Discovering available tools (`list-tools` subcommand)
 

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -98,15 +98,24 @@ export class CDPRelayServer {
     debugLogger('Ensuring extension connection for MCP context');
     if (abortSignal.aborted)
       throw abortSignal.reason;
-    // Protocol v2 requires explicit tab selection; the legacy newTab hint hides its only approval controls.
-    if (!this._extensionConnection)
-      await this._connectBrowser(clientInfo, abortSignal);
-    debugLogger('Waiting for incoming extension connection');
-    // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
-    await Promise.race([
-      Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
-      new Promise((_, reject) => abortSignal.addEventListener('abort', reject))
-    ]);
+    let abortListener = () => {};
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortListener = () => reject(abortSignal.reason);
+      abortSignal.addEventListener('abort', abortListener, { once: true });
+    });
+    try {
+      // Protocol v2 requires explicit tab selection; the legacy newTab hint hides its only approval controls.
+      if (!this._extensionConnection)
+        await Promise.race([this._connectBrowser(clientInfo, abortSignal), abortPromise]);
+      debugLogger('Waiting for incoming extension connection');
+      // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
+      await Promise.race([
+        Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
+        abortPromise,
+      ]);
+    } finally {
+      abortSignal.removeEventListener('abort', abortListener);
+    }
     debugLogger('Extension connection established');
   }
 

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -23,7 +23,9 @@
  */
 
 import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
 import http from 'node:http';
+import path from 'node:path';
 import debug from 'debug';
 import { WebSocket, WebSocketServer } from 'ws';
 import { httpAddressToString } from '../mcp/http.js';
@@ -98,7 +100,7 @@ export class CDPRelayServer {
       throw abortSignal.reason;
     // Protocol v2 requires explicit tab selection; the legacy newTab hint hides its only approval controls.
     if (!this._extensionConnection)
-      this._connectBrowser(clientInfo);
+      await this._connectBrowser(clientInfo);
     debugLogger('Waiting for incoming extension connection');
     // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
     await Promise.race([
@@ -108,7 +110,7 @@ export class CDPRelayServer {
     debugLogger('Extension connection established');
   }
 
-  private _connectBrowser(clientInfo: ClientInfo) {
+  private async _connectBrowser(clientInfo: ClientInfo) {
     // Need to specify "key" in the manifest.json to make the id stable when loading from file.
     const url = new URL(this._connectPagePrefix);
     const client = {
@@ -133,8 +135,12 @@ export class CDPRelayServer {
     }
 
     const args: string[] = [];
-    if (this._userDataDir)
+    if (this._userDataDir) {
       args.push(`--user-data-dir=${this._userDataDir}`);
+      const profileDirectory = await findPlaywrightExtensionProfile(this._userDataDir);
+      if (profileDirectory)
+        args.push(`--profile-directory=${profileDirectory}`);
+    }
     args.push(href);
 
     spawn(executablePath, args, {
@@ -285,6 +291,36 @@ export class CDPRelayServer {
   private _sendToPlaywright(message: CDPResponse): void {
     debugLogger('→ Playwright:', `${message.method ?? `response(id=${message.id})`}`);
     this._playwrightConnection?.send(JSON.stringify(message));
+  }
+}
+
+async function findPlaywrightExtensionProfile(userDataDir: string): Promise<string | undefined> {
+  let profiles: string[];
+  try {
+    profiles = (await fs.readdir(userDataDir, { withFileTypes: true }))
+        .filter(entry => entry.isDirectory() && (entry.name === 'Default' || /^Profile \d+$/.test(entry.name)))
+        .map(entry => entry.name)
+        .sort((a, b) => a === 'Default' ? -1 : b === 'Default' ? 1 : parseInt(a.slice(8), 10) - parseInt(b.slice(8), 10));
+  } catch {
+    return;
+  }
+
+  try {
+    const localState = JSON.parse(await fs.readFile(path.join(userDataDir, 'Local State'), 'utf8'));
+    const lastUsed = localState?.profile?.last_used;
+    if (typeof lastUsed === 'string' && profiles.includes(lastUsed))
+      profiles = [lastUsed, ...profiles.filter(profile => profile !== lastUsed)];
+  } catch {
+    // Fall back to the deterministic profile order when Local State is unavailable.
+  }
+
+  for (const profile of profiles) {
+    try {
+      await fs.access(path.join(userDataDir, profile, 'Extensions', protocol.EXTENSION_ID));
+      return profile;
+    } catch {
+      continue;
+    }
   }
 }
 

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -100,7 +100,7 @@ export class CDPRelayServer {
       throw abortSignal.reason;
     // Protocol v2 requires explicit tab selection; the legacy newTab hint hides its only approval controls.
     if (!this._extensionConnection)
-      await this._connectBrowser(clientInfo);
+      await this._connectBrowser(clientInfo, abortSignal);
     debugLogger('Waiting for incoming extension connection');
     // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
     await Promise.race([
@@ -110,7 +110,7 @@ export class CDPRelayServer {
     debugLogger('Extension connection established');
   }
 
-  private async _connectBrowser(clientInfo: ClientInfo) {
+  private async _connectBrowser(clientInfo: ClientInfo, abortSignal: AbortSignal) {
     // Need to specify "key" in the manifest.json to make the id stable when loading from file.
     const url = new URL(this._connectPagePrefix);
     const client = {
@@ -141,6 +141,7 @@ export class CDPRelayServer {
       if (profileDirectory)
         args.push(`--profile-directory=${profileDirectory}`);
     }
+    abortSignal.throwIfAborted();
     args.push(href);
 
     spawn(executablePath, args, {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -180,7 +180,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async navigate(url: string) {
     this._clearCollectedArtifacts();
 
-    const downloadEvent = callOnPageNoTrace(this.page, page => page.waitForEvent('download').catch(logUnhandledError));
+    const downloadEvent = callOnPageNoTrace(this.page, page => page.waitForEvent('download', { timeout: this._pageStateTimeoutMs() }).catch(logUnhandledError));
     try {
       await this.page.goto(url, { waitUntil: 'domcontentloaded' });
     } catch (_e: unknown) {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -185,16 +185,9 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       await this.page.goto(url, { waitUntil: 'domcontentloaded' });
     } catch (_e: unknown) {
       const e = _e as Error;
-      const mightBeDownload =
-        e.message.includes('net::ERR_ABORTED') // chromium
-        || e.message.includes('Download is starting'); // firefox + webkit
-      if (!mightBeDownload)
+      if (!e.message.includes('Download is starting'))
         throw e;
-      // on chromium, the download event is fired *after* page.goto rejects, so we wait a lil bit
-      const download = await Promise.race([
-        downloadEvent,
-        new Promise(resolve => setTimeout(resolve, 3000)),
-      ]);
+      const download = await downloadEvent;
       if (!download)
         throw e;
       // Make sure other "download" listeners are notified first.

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -180,19 +180,25 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async navigate(url: string) {
     this._clearCollectedArtifacts();
 
-    const downloadEvent = callOnPageNoTrace(this.page, page => page.waitForEvent('download', { timeout: this._pageStateTimeoutMs() }).catch(logUnhandledError));
+    const downloadEvent = new ManualPromise<playwright.Download>();
+    const downloadListener = (download: playwright.Download) => downloadEvent.resolve(download);
+    this.page.once('download', downloadListener);
     try {
-      await this.page.goto(url, { waitUntil: 'domcontentloaded' });
-    } catch (_e: unknown) {
-      const e = _e as Error;
-      if (!e.message.includes('Download is starting'))
-        throw e;
-      const download = await downloadEvent;
-      if (!download)
-        throw e;
-      // Make sure other "download" listeners are notified first.
-      await new Promise(resolve => setTimeout(resolve, 500));
-      return;
+      try {
+        await this.page.goto(url, { waitUntil: 'domcontentloaded' });
+      } catch (_e: unknown) {
+        const e = _e as Error;
+        if (!e.message.includes('Download is starting'))
+          throw e;
+        const download = await this._withPageStateTimeout(downloadEvent, 'waiting for download').catch(() => undefined);
+        if (!download)
+          throw e;
+        // Make sure other "download" listeners are notified first.
+        await new Promise(resolve => setTimeout(resolve, 500));
+        return;
+      }
+    } finally {
+      this.page.off('download', downloadListener);
     }
 
     // Cap load event to 5 seconds, the page is operational at this point.

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -275,7 +275,7 @@ describe('extension protocol v2', () => {
   it('launches the profile containing the extension', async () => {
     vi.mocked(spawn).mockClear();
     const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-extension-profile-'));
-    await fs.mkdir(path.join(userDataDir, 'Default'), { recursive: true });
+    await fs.mkdir(path.join(userDataDir, 'Default', 'Extensions', EXTENSION_ID), { recursive: true });
     await fs.mkdir(path.join(userDataDir, 'Profile 1', 'Extensions', EXTENSION_ID), { recursive: true });
     await fs.writeFile(path.join(userDataDir, 'Local State'), JSON.stringify({ profile: { last_used: 'Profile 1' } }));
     const server = http.createServer();
@@ -303,6 +303,40 @@ describe('extension protocol v2', () => {
       relay.stop();
       await new Promise<void>(resolve => server.close(() => resolve()));
       await fs.rm(userDataDir, { recursive: true });
+    }
+  });
+
+  it('does not launch Chrome when cancelled during profile discovery', async () => {
+    vi.mocked(spawn).mockClear();
+    let finishScan!: () => void;
+    const scan = new Promise<void>(resolve => finishScan = resolve);
+    const readdir = vi.spyOn(fs, 'readdir').mockImplementationOnce(async () => {
+      await scan;
+      return [] as any;
+    });
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', '/tmp/profile', '/tmp/chrome');
+    try {
+      const controller = new AbortController();
+      const connecting = relay.ensureExtensionConnectionForMCPContext(
+          { name: 'test-client', version: '1.0.0' },
+          controller.signal,
+          undefined,
+      );
+      await vi.waitFor(() => expect(readdir).toHaveBeenCalled());
+      controller.abort(new Error('cancelled during profile discovery'));
+      finishScan();
+
+      await expect(connecting).rejects.toThrow('cancelled during profile discovery');
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      readdir.mockRestore();
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
     }
   });
 });

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -329,9 +329,11 @@ describe('extension protocol v2', () => {
       );
       await vi.waitFor(() => expect(readdir).toHaveBeenCalled());
       controller.abort(new Error('cancelled during profile discovery'));
-      finishScan();
 
       await expect(connecting).rejects.toThrow('cancelled during profile discovery');
+      expect(spawn).not.toHaveBeenCalled();
+      finishScan();
+      await Promise.resolve();
       expect(spawn).not.toHaveBeenCalled();
     } finally {
       readdir.mockRestore();

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -16,7 +16,10 @@
 
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import fs from 'node:fs/promises';
 import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 import { WebSocket } from 'ws';
 import { describe, expect, it, vi } from 'vitest';
 import { CDPRelayServer } from '../src/extension/cdpRelay.js';
@@ -266,6 +269,40 @@ describe('extension protocol v2', () => {
       relay.stop();
       await new Promise<void>(resolve => server.close(() => resolve()));
       vi.unstubAllEnvs();
+    }
+  });
+
+  it('launches the profile containing the extension', async () => {
+    vi.mocked(spawn).mockClear();
+    const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-extension-profile-'));
+    await fs.mkdir(path.join(userDataDir, 'Default'), { recursive: true });
+    await fs.mkdir(path.join(userDataDir, 'Profile 1', 'Extensions', EXTENSION_ID), { recursive: true });
+    await fs.writeFile(path.join(userDataDir, 'Local State'), JSON.stringify({ profile: { last_used: 'Profile 1' } }));
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', userDataDir, '/tmp/chrome');
+    let extension: WebSocket | undefined;
+    try {
+      const connecting = relay.ensureExtensionConnectionForMCPContext(
+          { name: 'test-client', version: '1.0.0' },
+          new AbortController().signal,
+          undefined,
+      );
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+      expect(vi.mocked(spawn).mock.calls[0][1]).toContain('--profile-directory=Profile 1');
+
+      extension = new WebSocket(relay.extensionEndpoint());
+      await once(extension, 'open');
+      extension.send(JSON.stringify({ method: 'extension.initialized', params: [] }));
+      await expect(connecting).resolves.toBeUndefined();
+    } finally {
+      extension?.close();
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+      await fs.rm(userDataDir, { recursive: true });
     }
   });
 });

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -47,6 +47,7 @@ describe('Tab', () => {
         },
       },
       currentTab: vi.fn(),
+      outputFile: vi.fn().mockResolvedValue('/tmp/download'),
       tools: [],
     } as any;
 
@@ -212,20 +213,30 @@ describe('Tab', () => {
     });
 
     it('waits for an explicitly reported download', async () => {
-      mockPage.goto = vi.fn().mockRejectedValue(new Error('Download is starting'));
-      mockPage.waitForEvent = vi.fn().mockResolvedValue({});
+      const download = {
+        suggestedFilename: vi.fn().mockReturnValue('download.txt'),
+        saveAs: vi.fn().mockResolvedValue(undefined),
+      };
+      mockPage.goto = vi.fn(async () => {
+        mockPage.emit('download', download);
+        throw new Error('Download is starting');
+      });
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
       await expect(tab.navigate('https://example.com/download')).resolves.toBeUndefined();
-      expect(mockPage.waitForEvent).toHaveBeenCalledWith('download', { timeout: 6000 });
+      expect(download.saveAs).toHaveBeenCalledWith('/tmp/download');
+      expect(mockPage.listenerCount('download')).toBe(1);
     });
 
     it('rethrows when an explicitly reported download never arrives', async () => {
+      vi.useFakeTimers();
       mockPage.goto = vi.fn().mockRejectedValue(new Error('Download is starting'));
-      mockPage.waitForEvent = vi.fn().mockRejectedValue(new Error('Timeout 6000ms exceeded'));
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
-      await expect(tab.navigate('https://example.com/download')).rejects.toThrow('Download is starting');
+      const result = expect(tab.navigate('https://example.com/download')).rejects.toThrow('Download is starting');
+      await vi.advanceTimersByTimeAsync(6000);
+      await result;
+      expect(mockPage.listenerCount('download')).toBe(1);
     });
   });
 

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -202,6 +202,24 @@ describe('Tab', () => {
     });
   });
 
+  describe('navigate', () => {
+    it('does not wait for a download after an unrelated aborted navigation', async () => {
+      mockPage.goto = vi.fn().mockRejectedValue(new Error('page.goto: net::ERR_ABORTED'));
+      mockPage.waitForEvent = vi.fn().mockReturnValue(new Promise(() => {}));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      await expect(tab.navigate('chrome://crash')).rejects.toThrow('net::ERR_ABORTED');
+    });
+
+    it('waits for an explicitly reported download', async () => {
+      mockPage.goto = vi.fn().mockRejectedValue(new Error('Download is starting'));
+      mockPage.waitForEvent = vi.fn().mockResolvedValue({});
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      await expect(tab.navigate('https://example.com/download')).resolves.toBeUndefined();
+    });
+  });
+
   describe('captureSnapshot', () => {
     it('should capture page snapshot', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -217,6 +217,15 @@ describe('Tab', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
 
       await expect(tab.navigate('https://example.com/download')).resolves.toBeUndefined();
+      expect(mockPage.waitForEvent).toHaveBeenCalledWith('download', { timeout: 6000 });
+    });
+
+    it('rethrows when an explicitly reported download never arrives', async () => {
+      mockPage.goto = vi.fn().mockRejectedValue(new Error('Download is starting'));
+      mockPage.waitForEvent = vi.fn().mockRejectedValue(new Error('Timeout 6000ms exceeded'));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      await expect(tab.navigate('https://example.com/download')).rejects.toThrow('Download is starting');
     });
   });
 


### PR DESCRIPTION
## Summary

- Mirrors [microsoft/playwright#41933](https://github.com/microsoft/playwright/pull/41933) and its [merged commit](https://github.com/microsoft/playwright/commit/15c4f55879e49159e766fe1aa3dd9f9d87ba5fc1): only an explicit `Download is starting` navigation error is treated as a download, so unrelated Chromium `net::ERR_ABORTED` failures return immediately instead of waiting up to three seconds.
- Mirrors [microsoft/playwright#41939](https://github.com/microsoft/playwright/pull/41939) and its [merged commit](https://github.com/microsoft/playwright/commit/0edafe4baab7fd20122939d3cfe1acabd8ed84a9): extension mode now launches the Chrome profile that contains the Playwright bridge extension when `--user-data-dir` contains multiple profiles, preferring Chrome's last-used profile.
- Documents the profile-selection behavior and adds focused regression coverage.

## Why this matters

The navigation path used a broad Chromium error heuristic that delayed genuine failures and could misclassify aborted navigations. Extension mode passed the user-data directory without a profile, so Chrome could open `Default` even when the extension had been validated or installed in another profile, leaving the connection waiting indefinitely.

## Validation

- `npm test -- tests/tab.test.ts tests/extension-protocol.test.ts` (39 tests)
- `npm run lint`
- `npm run build`
- `npm test` (34 files, 372 tests)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Browser extension mode now automatically selects the Chrome profile containing the extension when multiple profiles are available, prioritizing Chrome’s last-used profile.

- **Bug Fixes**
  - Improved navigation handling for downloads so unrelated aborted navigations correctly report errors instead of being mistaken for downloads.
  - Download navigation now waits for the confirmed download event before continuing.

- **Documentation**
  - Clarified Chrome profile selection behavior when using `--user-data-dir`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->