### PR TITLE
fix: escape user input in generated code

### DIFF
--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -36,7 +36,6 @@ const pressKey = defineTabTool({
 
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
-    response.addCode(`// Press ${params.key}`);
     response.addCode(`await page.keyboard.press(${javascript.quote(params.key)});`);
 
     await tab.waitForCompletion(async () => {

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -37,7 +37,7 @@ const pressKey = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
     response.addCode(`// Press ${params.key}`);
-    response.addCode(`await page.keyboard.press('${params.key}');`);
+    response.addCode(`await page.keyboard.press(${javascript.quote(params.key)});`);
 
     await tab.waitForCompletion(async () => {
       await tab.page.keyboard.press(params.key);

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { defineTool, defineTabTool } from './tool.js';
+import * as javascript from '../utils/codegen.js';
 
 const navigate = defineTool({
   capability: 'core',
@@ -35,7 +36,7 @@ const navigate = defineTool({
     await tab.navigate(params.url);
 
     response.setIncludeSnapshot();
-    response.addCode(`await page.goto('${params.url}');`);
+    response.addCode(`await page.goto(${javascript.quote(params.url)});`);
   },
 });
 

--- a/tests/tools-codegen.test.ts
+++ b/tests/tools-codegen.test.ts
@@ -23,6 +23,7 @@ describe('tool code generation', () => {
   it.each([
     ['browser_navigate', { url: `https://example.com/it's` }],
     ['browser_press_key', { key: `'` }],
+    ['browser_press_key', { key: '\ninvalid javascript }' }],
   ])('escapes user input for %s', async (toolName, args) => {
     const tab = {
       modalStates: () => [],

--- a/tests/tools-codegen.test.ts
+++ b/tests/tools-codegen.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import keyboardTools from '../src/tools/keyboard.js';
+import navigateTools from '../src/tools/navigate.js';
+import { Response } from '../src/response.js';
+
+describe('tool code generation', () => {
+  it.each([
+    ['browser_navigate', { url: `https://example.com/it's` }],
+    ['browser_press_key', { key: `'` }],
+  ])('escapes user input for %s', async (toolName, args) => {
+    const tab = {
+      modalStates: () => [],
+      navigate: vi.fn(),
+      page: { keyboard: { press: vi.fn() } },
+      waitForCompletion: async (callback: () => Promise<void>) => await callback(),
+    };
+    const context = {
+      config: {},
+      currentTabOrDie: () => tab,
+      ensureTab: async () => tab,
+    };
+    const response = new Response(context as any, toolName, args);
+    const tool = [...navigateTools, ...keyboardTools].find(candidate => candidate.schema.name === toolName)!;
+
+    await tool.handle(context as any, args as any, response);
+
+    expect(() => new Function('page', `return async () => {\n${response.code()}\n};`)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Upstream change

- PR: https://github.com/microsoft/playwright/pull/41962
- Commit: https://github.com/microsoft/playwright/commit/e0e867011c1e29682b5dcc1380aa3dd6380b7858

Playwright MCP now escapes user-controlled strings before emitting generated Playwright code. Inputs containing apostrophes previously produced invalid JavaScript.

## Why it matters here

This repository already uses its shared code-generation quoting helper for typed text and locator values, but `browser_navigate` and `browser_press_key` still interpolated URL/key input inside raw single quotes. They had the same invalid-code failure fixed upstream.

## Implemented fix

- Reuse the existing `codegen.quote()` helper for navigation URLs and pressed keys.
- Add focused regression coverage that parses the generated snippets for apostrophe-containing input.

## Validation

- `npm test -- tests/tools-codegen.test.ts tests/tools-navigate.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` — 35 files, 379 tests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated browser navigation and keyboard actions to safely handle special characters in URLs and key values.
  * Prevented code-generation errors caused by apostrophes and similar characters.

* **Tests**
  * Added coverage verifying generated actions remain valid when provided with special-character inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->