### PR TITLE
Rule-level control: withRules / disableRules

### DIFF
--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -575,6 +575,54 @@ const tests = [
     }
   }),
 
+  test('audit_screen_reader', async () => {
+    await navigate([
+      '<title>ScreenReader</title><main>',
+      // Broken markup: one instance per check.
+      '<p><a href="/pricing">Read more</a></p>',
+      '<p><img src="/IMG_2048.jpg" alt="IMG_2048.jpg"></p>',
+      '<p><button aria-label="Submit form">Send</button></p>',
+      '<p><input type="text"></p>',
+      '<p><a href="/a.pdf">Download</a> <a href="/b.pdf">Download</a></p>',
+      '<div style="display:flex;flex-direction:row-reverse">',
+      '<button>Reversed first</button><button>Reversed second</button></div>',
+      // Correct markup: none of these may be flagged.
+      '<p><a href="/pricing-detail">Read more about pricing</a></p>',
+      '<p><img src="/team.jpg" alt="The team at the 2024 offsite"></p>',
+      '<p><button aria-label="Search products">Search</button></p>',
+      '<p><label>Email address <input type="email"></label></p>',
+      '<p><a href="/help">Help centre</a> <a href="/help">Help centre</a></p>',
+      '<div style="display:flex"><button>Ordered first</button><button>Ordered second</button></div>',
+      '<div style="columns:2;width:300px"><p>Column one top</p><p>Column one bottom</p>',
+      '<p>Column two top</p><p>Column two bottom</p></div>',
+      '</main>',
+    ].join(''));
+    const result = await callTool('audit_screen_reader', {
+      checkNames: true,
+      checkReadingOrder: true,
+      maxElements: 200,
+      maxFindingsPerCheck: 10,
+    });
+    const text = resultText(result);
+    const expected = [
+      /missing-accessible-name \| [1-9]/,
+      /uninformative-accessible-name \| [1-9]/,
+      /filename-as-accessible-name \| [1-9]/,
+      /label-in-name-mismatch \| [1-9]/,
+      /duplicate-accessible-name \| [1-9]/,
+      /reading-order-mismatch \| [1-9]/,
+    ];
+    for (const pattern of expected)
+      assertText(text, pattern);
+    assertText(text, /JSON report:/);
+    const clean = ['Read more about pricing', 'The team at the 2024 offsite', 'Search products',
+      'Email address', 'Help centre', 'Ordered first', 'Column one top'];
+    for (const label of clean) {
+      if (text.includes(label))
+        throw new Error(`Correct markup was flagged: ${label}\n${text.slice(0, 4000)}`);
+    }
+  }),
+
   test('browser_install', async () => {
     if (!options.includeInstall)
       throw new SkipError('browser_install skipped by default; rerun with --include-install');

--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -33,6 +33,9 @@ const client = new Client({ name: 'mcp-accessibility-direct-harness', version: '
 const state = {
   toolNames: [],
   fixtureOrigin: '',
+  // Every path the fixture server was asked for, so a test can assert a tool
+  // rejected its arguments without visiting anything.
+  fixtureRequests: [],
 };
 
 class SkipError extends Error {}
@@ -293,6 +296,56 @@ const tests = [
     });
     assertText(leftovers, /"layers":\s*0/);
     assertText(leftovers, /"idInHtml":\s*false/);
+
+    // Rule-level control: two images with no alt (image-alt) plus a form input
+    // with no label (label), so each rule filter has a different rule to move.
+    await navigate([
+      '<title>Rules</title>',
+      '<img src="x"><img src="y">',
+      '<input type="text" name="q">',
+    ].join(''));
+    const ruleArgs = { violationsTag: ['wcag2a', 'wcag2aa'], includeIncomplete: false };
+    const both = await callTool('scan_page', ruleArgs);
+    assertViolationNodeCount(both, 'image-alt', 2);
+    assertViolationNodeCount(both, 'label', 1);
+
+    // withRules overrides violationsTag entirely: axe holds either a rule list
+    // or a tag list, never both.
+    const onlyLabel = await callTool('scan_page', { ...ruleArgs, withRules: ['label'] });
+    assertViolationNodeCount(onlyLabel, 'label', 1);
+    assertViolationNodeCount(onlyLabel, 'image-alt', 0);
+
+    // disableRules subtracts from whatever is selected — tags here...
+    const noImages = await callTool('scan_page', { ...ruleArgs, disableRules: ['image-alt'] });
+    assertViolationNodeCount(noImages, 'image-alt', 0);
+    assertViolationNodeCount(noImages, 'label', 1);
+    // ...and an explicit rule list here. Axe drops the disabled-rule flag once
+    // runOnly holds a rule list, so without the scanner subtracting up front
+    // this would still report image-alt.
+    const listMinusImages = await callTool('scan_page', {
+      ...ruleArgs,
+      withRules: ['image-alt', 'label'],
+      disableRules: ['image-alt'],
+    });
+    assertViolationNodeCount(listMinusImages, 'image-alt', 0);
+    assertViolationNodeCount(listMinusImages, 'label', 1);
+
+    // Emptying the rule list must fail, not fall back to scanning everything.
+    await assertToolError(
+        'scan_page',
+        { ...ruleArgs, withRules: ['image-alt'], disableRules: ['image-alt'] },
+        /disableRules disabled every rule in withRules \(image-alt\)/);
+
+    // A misspelled rule id would otherwise select/disable nothing and return a
+    // clean-looking report, so it must fail by name instead.
+    await assertToolError(
+        'scan_page',
+        { ...ruleArgs, withRules: ['label', 'image-altt'] },
+        /Unknown Axe rule id\(s\) in withRules: image-altt/);
+    await assertToolError(
+        'scan_page',
+        { ...ruleArgs, disableRules: ['colour-contrast'] },
+        /Unknown Axe rule id\(s\) in disableRules: colour-contrast/);
   }),
 
   test('browser_tabs', async () => {
@@ -400,6 +453,27 @@ const tests = [
     });
     if (redirected.structuredContent?.sessionLoss?.url !== `${state.fixtureOrigin}/signed-out`)
       throw new Error(`Expected sessionLoss at /signed-out, got ${JSON.stringify(redirected.structuredContent?.sessionLoss)}`);
+
+    // Rule ids are run-wide input, so a bad one must be rejected before the
+    // crawl starts. Otherwise every supplied URL is visited, errored, and
+    // written up as a completed audit.
+    const requestsBeforeBadRule = state.fixtureRequests.length;
+    await assertToolError(
+        'audit_site',
+        {
+          ...auditSiteDefaults,
+          maxPages: 3,
+          urls: [
+            `${state.fixtureOrigin}/audit-site`,
+            `${state.fixtureOrigin}/secure`,
+            `${state.fixtureOrigin}/secure-2`,
+          ],
+          withRules: ['image-altt'],
+        },
+        /Unknown Axe rule id\(s\) in withRules: image-altt/);
+    const visitedAfterBadRule = state.fixtureRequests.slice(requestsBeforeBadRule);
+    if (visitedAfterBadRule.length)
+      throw new Error(`audit_site visited ${visitedAfterBadRule.length} page(s) before rejecting an invalid rule id: ${visitedAfterBadRule.join(', ')}`);
   }),
 
   test('scan_page_matrix', async () => {
@@ -701,6 +775,7 @@ async function verifyCoverage(testCases, toolNames) {
 
 function startFixtureServer() {
   const server = http.createServer((request, response) => {
+    state.fixtureRequests.push(request.url);
     if (request.url === '/audit-site') {
       response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
       response.end('<!doctype html><html><head><title>AuditSite</title></head><body><img src="x"><h1>Audit Site</h1></body></html>');

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -231,6 +231,8 @@
         "src/tools/auditSite.ts",
         "src/tools/scanPageMatrix.ts",
         "src/tools/auditKeyboard.ts",
+        "src/tools/auditScreenReader.ts",
+        "tests/tools-auditScreenReader.test.ts",
         "tests/tools-auditSite.test.ts",
         "tests/tools-axe.test.ts",
         "tests/tools-scanPageMatrix.test.ts",

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Interactive mode. Type "<tool-name> <json>" to call a tool. Ctrl+D to exit.
 > browser_navigate {"url": "https://example.com"}
 > scan_page {"violationsTag": ["wcag21aa"]}
 > audit_keyboard {"maxTabs": 30}
+> audit_screen_reader {}
 ```
 
 Each line is `<tool-name> <json-arguments>`. Omit the JSON to pass `{}`.
@@ -410,6 +411,37 @@ Audits real keyboard focus behavior by pressing Tab (and optional Shift+Tab) wit
 1. Navigate to the target page and let it fully load
 2. Run audit_keyboard with maxTabs: 50
 3. Review focus findings and open the generated JSON report path
+```
+
+#### `audit_screen_reader`
+Audits what a screen reader actually announces, using the browser's own accessibility tree (`page.ariaSnapshot`) plus element geometry. No screen reader is installed or driven; this is a static reading of the exposed tree.
+
+**Checks (`checkNames`)**
+- `missing-accessible-name`: controls and images exposed with no accessible name (WCAG 4.1.2)
+- `uninformative-accessible-name`: names such as "click here", "read more", "image" that mean nothing out of context (WCAG 2.4.4)
+- `filename-as-accessible-name`: image alt text that is a file name, e.g. `IMG_1234.jpg`, `DSC00123` (WCAG 1.1.1). Only images are checked: a link or button legitimately named after the file it downloads (`logo.png`) is not a defect.
+- `label-in-name-mismatch`: the accessible name does not contain the visible label, which breaks voice control (WCAG 2.5.3). The visible label of `<input type="submit|button|reset">` is read from its `value`.
+- `duplicate-accessible-name`: sibling links with the same name that lead to different URLs (WCAG 2.4.4)
+
+**Check (`checkReadingOrder`)**
+- `reading-order-mismatch`: accessibility tree order (what is read) versus visual position (WCAG 1.3.2), i.e. `order`, `flex-direction: row-reverse`, absolute positioning
+
+**What it deliberately does not detect**
+- Reading order is only compared between siblings that form a single row or a single column. Genuine two-dimensional layouts (grid, CSS multi-column, wrapped flex) have no single correct linear order and are skipped rather than guessed.
+- Elements are excluded from the reading-order comparison when they render no text, are `aria-hidden`, floated, `position: fixed`, off-canvas, or clipped to 1px, because their visual position is decoupled from source order by design. Tolerance: two boxes count as swapped only when they are fully separated along the compared axis (1px), and right-to-left containers are compared right-to-left.
+- Duplicate names are only reported when the destinations differ *and* are observable, which today means link `href`s. Two `Save` submit buttons in one form are never called ambiguous, because nothing in the exposed tree says whether they do different things.
+- Only elements the AI snapshot gives a `ref` are analyzed, and Playwright refs the elements that are visible and receive pointer events. A control that is announced but not interactable (`pointer-events: none`, some off-canvas widgets) is therefore skipped: without a ref it cannot be measured, so neither its `aria-hidden` state nor a selector to fix it can be established, and reporting it would mostly surface decorative `aria-hidden` icons.
+- Heading levels and landmark structure are not checked; axe already reports those (`heading-order`, `region`, `landmark-one-main`), so use `scan_page` for them.
+- Findings for names overlap with axe rules such as `link-name`, `button-name` and `image-alt`; this tool adds the quality checks (generic names, file names, label-in-name, duplicates) that axe cannot make.
+- It reports the page as currently rendered. Content behind a collapsed panel or another viewport is judged in that state.
+
+**Bounds:** `maxElements` (default 400) caps how many *screen-reader-reachable* accessibility tree elements are analyzed. The snapshot also refs `aria-hidden` subtrees, which no check reports, so measuring continues past them until the budget is filled with reachable elements (up to a hard ceiling of twice `maxElements` measured, so a page built mostly of hidden refs stays bounded). `maxFindingsPerCheck` (default 20) caps the findings listed per check. Both truncations are stated in the summary and the JSON report, and the full counts are always reported. Always writes a JSON report (default filename: `audit-screen-reader-{timestamp}.json`).
+
+**Example flow:**
+```text
+1. Navigate to the target page and let it fully load
+2. Run audit_screen_reader (optionally raise maxElements for a large page)
+3. Fix the reported elements by ref, then re-run to confirm
 ```
 
 ### Navigation Tools

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Performs a comprehensive accessibility scan on the current page using Axe-core.
 - `includeIncomplete` (default `true`): also report Axe "incomplete" results
 - `maxNodesPerViolation` (default `10`): cap on nodes reported per rule
 - `includeSelectors` / `excludeSelectors`: CSS selectors that scope the scan
+- `withRules` / `disableRules`: Axe rule ids that narrow which rules run
 - `annotateScreenshot` (default `false`): capture an annotated screenshot of the violations
 
 **Annotated screenshots:**
@@ -334,6 +335,15 @@ Selectors are resolved before the scan runs:
 - An `excludeSelectors` entry that matches nothing is a no-op, not an error -- a crawl legitimately visits pages that lack the excluded widget.
 
 In `audit_site`, selectors apply to every crawled page, so an `includeSelectors` value that is absent from a given page marks *that page* as errored in the report while the crawl continues. Link discovery runs before the scan, so pages reachable only through an errored page are still crawled.
+
+**Rule-level control:**
+`scan_page`, `audit_site`, and `scan_page_matrix` accept `withRules` and `disableRules` to pick individual Axe rules instead of whole tag sets. Use `withRules` to re-check one rule after a fix (`["color-contrast"]`) and `disableRules` to mute a rule you have already triaged (`["region"]`). Rule ids are the ones Axe reports (`image-alt`, `color-contrast`, ...); see the [Deque rule reference](https://dequeuniversity.com/rules/axe/).
+
+- **`withRules` overrides `violationsTag`.** Axe can run either a rule list or a tag list, never both, so when `withRules` is set the tags are ignored entirely -- `withRules: ["image-alt"]` runs exactly that one rule regardless of `violationsTag`. Rule ids are the more specific request, so they win.
+- **`disableRules` subtracts from whatever is selected.** It applies to `violationsTag` and `withRules` alike. (Axe itself ignores disabled rules once you give it an explicit rule list; the scanner subtracts them up front so the two options mean the same thing together as apart.) Disabling every rule in `withRules` is an error rather than an empty scan.
+- **Unknown rule ids fail the scan, naming the id.** Both options are checked against Axe's rule catalogue before the browser is touched, so a typo is reported as `Unknown Axe rule id(s) in withRules: image-altt` rather than surfacing later as an `frame.evaluate` failure from inside the page. Rule ids apply to a whole run, so `audit_site` checks them once before it opens a tab -- a bad id fails the call outright instead of crawling every URL and reporting each page as errored.
+
+`audit_site` and `scan_page_matrix` record both values in their JSON report metadata, so a stored report can be told apart from a full scan.
 
 **Incomplete ("needs review") results:**
 Axe returns `incomplete` for checks it cannot decide on its own -- contrast over a background image or gradient, ambiguous labels, elements it could not fully evaluate. `scan_page`, `audit_site`, and `scan_page_matrix` report these in a section separate from violations so you can resolve them by inspecting the page (screenshot, snapshot, `browser_evaluate`). Set `includeIncomplete: false` to suppress them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@axe-core/playwright": "^4.12.1",
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
+				"axe-core": "4.12.1",
 				"commander": "^15.0.0",
 				"debug": "^4.4.3",
 				"dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@axe-core/playwright": "^4.12.1",
 		"@cfworker/json-schema": "^4.1.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
+		"axe-core": "4.12.1",
 		"commander": "^15.0.0",
 		"debug": "^4.4.3",
 		"dotenv": "^17.4.2",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,6 +34,7 @@ import verify from './tools/verify.js';
 import auditSite from './tools/auditSite.js';
 import scanPageMatrix from './tools/scanPageMatrix.js';
 import auditKeyboard from './tools/auditKeyboard.js';
+import auditScreenReader from './tools/auditScreenReader.js';
 
 import type { Tool } from './tools/tool.js';
 import type { FullConfig } from './config.js';
@@ -59,6 +60,7 @@ export const allTools: Tool<any>[] = [
   ...auditSite,
   ...scanPageMatrix,
   ...auditKeyboard,
+  ...auditScreenReader,
 ];
 
 export function filteredTools(config: FullConfig) {
@@ -68,8 +70,9 @@ export function filteredTools(config: FullConfig) {
 export const serverInstructions = [
   'This server runs automated web accessibility audits (axe-core / WCAG) and drives a real browser via Playwright.',
   'Use `browser_navigate` to load a page first. Then use `audit_site` to crawl and scan multiple pages of a site,',
-  '`scan_page_matrix` to scan the current page across viewports and WCAG tag sets, and `audit_keyboard` to check',
-  'keyboard navigation, focus visibility and skip links. Results are returned as markdown with axe-core rule ids,',
+  '`scan_page_matrix` to scan the current page across viewports and WCAG tag sets, `audit_keyboard` to check',
+  'keyboard navigation, focus visibility and skip links, and `audit_screen_reader` to check accessible name quality',
+  'and reading order. Results are returned as markdown with axe-core rule ids,',
   'impact levels, failure summaries and remediation links. Regular browser interaction tools (click, type, snapshot,',
   'screenshot, tabs) are also available for navigating to the state you want to audit.',
 ].join(' ');

--- a/src/tools/auditScreenReader.ts
+++ b/src/tools/auditScreenReader.ts
@@ -1,0 +1,632 @@
+import fs from 'node:fs';
+import { z } from 'zod';
+import { defineTabTool } from './tool.js';
+import { sanitizeForFilePath } from '../utils/fileUtils.js';
+
+import type * as playwright from 'playwright';
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+export type AriaTreeNode = {
+  role: string;
+  name: string | null;
+  level: number | null;
+  ref: string | null;
+  depth: number;
+  parent: number | null;
+};
+
+export type ElementFacts = {
+  tagName: string | null;
+  selector: string | null;
+  visibleText: string | null;
+  href: string | null;
+  rect: Rect | null;
+  direction: 'ltr' | 'rtl';
+  positionFixed: boolean;
+  floating: boolean;
+  ariaHidden: boolean;
+};
+
+export type ScreenReaderNode = AriaTreeNode & ElementFacts & { childCount: number };
+
+export type ScreenReaderCheck =
+  | 'missing-accessible-name'
+  | 'uninformative-accessible-name'
+  | 'filename-as-accessible-name'
+  | 'label-in-name-mismatch'
+  | 'duplicate-accessible-name'
+  | 'reading-order-mismatch';
+
+export type ScreenReaderFinding = {
+  check: ScreenReaderCheck;
+  wcag: string;
+  ref: string | null;
+  role: string;
+  name: string | null;
+  selector: string | null;
+  problem: string;
+  fix: string;
+};
+
+export type ScreenReaderAuditResult = {
+  findings: ScreenReaderFinding[];
+  countByCheck: Record<ScreenReaderCheck, number>;
+  truncatedChecks: ScreenReaderCheck[];
+};
+
+export type ScreenReaderAuditOptions = {
+  checkNames: boolean;
+  checkReadingOrder: boolean;
+  maxFindingsPerCheck: number;
+};
+
+// Roles that a screen-reader user reaches out of context, so an empty or
+// meaningless accessible name leaves them with nothing to act on.
+const namedRoles = new Set([
+  'link', 'button', 'checkbox', 'radio', 'switch', 'textbox', 'searchbox', 'combobox',
+  'listbox', 'slider', 'spinbutton', 'menuitem', 'menuitemcheckbox', 'menuitemradio',
+  'tab', 'treeitem', 'option', 'img', 'image',
+]);
+
+// Only roles whose accessible name is expected to start with the visible label;
+// containers are excluded because their text is the concatenation of children.
+const labelInNameRoles = new Set([
+  'link', 'button', 'checkbox', 'radio', 'switch', 'menuitem', 'menuitemcheckbox',
+  'menuitemradio', 'tab', 'option', 'treeitem',
+]);
+
+const uninformativeNames = new Set([
+  'click here', 'click', 'here', 'this link', 'link', 'read more', 'more', 'more info',
+  'more information', 'more details', 'details', 'learn more', 'see more', 'view more',
+  'read this', 'full story', 'go', 'untitled', 'image', 'photo', 'picture', 'graphic',
+  'spacer', 'placeholder',
+]);
+
+const filenameNamePattern = /\.(jpe?g|png|gif|webp|svg|avif|bmp|tiff?|ico)$/i;
+const cameraFileNamePattern = /^(img|dsc|dscn|pxl|screenshot|image|photo)[-_ ]?\d{3,}$/i;
+
+// Refs are resolved and measured in chunks of this size.
+const measureChunkSize = 50;
+
+// Bands narrower than this are noise (sr-only clip boxes, 1px spacers).
+const minLayoutSizePx = 2;
+const layoutTolerancePx = 1;
+const bandOverlapRatio = 0.5;
+
+function normalizeText(value: string | null): string {
+  if (!value)
+    return '';
+  return value.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').replace(/\s+/gu, ' ').trim();
+}
+
+export function parseAriaSnapshot(snapshot: string): AriaTreeNode[] {
+  const nodes: AriaTreeNode[] = [];
+  const stack: { depth: number; index: number }[] = [];
+  for (const line of snapshot.split('\n')) {
+    const match = /^(\s*)- ([a-zA-Z]+)(?:\s+"((?:[^"\\]|\\.)*)")?(.*)$/.exec(line);
+    if (!match)
+      continue;
+    const depth = match[1].length;
+    const rest = match[4];
+    while (stack.length && stack[stack.length - 1].depth >= depth)
+      stack.pop();
+    const levelMatch = /\[level=(\d+)\]/.exec(rest);
+    nodes.push({
+      role: match[2],
+      name: match[3] === undefined ? null : match[3].replace(/\\(.)/g, '$1'),
+      level: levelMatch ? Number(levelMatch[1]) : null,
+      ref: /\[ref=([^\]]+)\]/.exec(rest)?.[1] ?? null,
+      depth,
+      parent: stack.length ? stack[stack.length - 1].index : null,
+    });
+    stack.push({ depth, index: nodes.length - 1 });
+  }
+  return nodes;
+}
+
+function describe(node: ScreenReaderNode): string {
+  const label = node.name ? `"${node.name}"` : node.visibleText ? `showing "${node.visibleText.slice(0, 40)}"` : 'no name';
+  return `${node.role} ${label}${node.selector ? ` (${node.selector})` : ''}`;
+}
+
+function overlapRatio(a: Rect, b: Rect, axis: 'x' | 'y'): number {
+  const aStart = axis === 'x' ? a.x : a.y;
+  const bStart = axis === 'x' ? b.x : b.y;
+  const aSize = axis === 'x' ? a.width : a.height;
+  const bSize = axis === 'x' ? b.width : b.height;
+  const overlap = Math.min(aStart + aSize, bStart + bSize) - Math.max(aStart, bStart);
+  const smaller = Math.min(aSize, bSize);
+  return smaller <= 0 ? 0 : overlap / smaller;
+}
+
+function countBands(rects: Rect[], axis: 'x' | 'y'): number {
+  const band = rects.map((_, index) => index);
+  const rootOf = (index: number): number => band[index] === index ? index : rootOf(band[index]);
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      if (overlapRatio(rects[i], rects[j], axis) >= bandOverlapRatio)
+        band[rootOf(j)] = rootOf(i);
+    }
+  }
+  return new Set(rects.map((_, index) => rootOf(index))).size;
+}
+
+function isLayoutRelevant(node: ScreenReaderNode): boolean {
+  // Floated and fixed boxes are placed outside the normal flow on purpose (media
+  // beside a paragraph, sticky bars), so their visual position never claims to
+  // match source order.
+  if (!node.ref || !node.rect || node.positionFixed || node.floating || node.ariaHidden)
+    return false;
+  // Only text-bearing elements can change what is *read* when they move. Icon
+  // affordances next to their label (disclosure arrows, leading glyphs) are the
+  // single largest source of false reading-order alarms.
+  if (!/[\p{L}\p{N}]/u.test(node.visibleText ?? ''))
+    return false;
+  const { x, y, width, height } = node.rect;
+  // Off-canvas and clipped boxes are the standard visually-hidden techniques:
+  // they have no visual order to compare the reading order against.
+  return width >= minLayoutSizePx && height >= minLayoutSizePx && x + width > 0 && y + height > 0;
+}
+
+// An image inside a named link or button is announced through that control, so
+// its own missing name is not a defect (icon buttons are full of these).
+function hasNamedControlAncestor(nodes: ScreenReaderNode[], index: number): boolean {
+  for (let parent = nodes[index].parent; parent !== null; parent = nodes[parent].parent) {
+    if (nodes[parent].name?.trim() && labelInNameRoles.has(nodes[parent].role))
+      return true;
+  }
+  return false;
+}
+
+function checkAccessibleNames(nodes: ScreenReaderNode[], push: (finding: ScreenReaderFinding) => void) {
+  for (const [index, node] of nodes.entries()) {
+    if (!node.ref || node.ariaHidden)
+      continue;
+    const name = node.name?.trim() ?? '';
+    const base = {
+      ref: node.ref,
+      role: node.role,
+      name: node.name,
+      selector: node.selector,
+    };
+
+    const isImage = node.role === 'img' || node.role === 'image';
+    if (!name && namedRoles.has(node.role) && !(isImage && hasNamedControlAncestor(nodes, index))) {
+      push({
+        ...base,
+        check: 'missing-accessible-name',
+        wcag: '4.1.2 Name, Role, Value',
+        problem: `${describe(node)} exposes no accessible name, so a screen reader announces only its role.`,
+        fix: isImage
+          ? 'Describe it with alt text (or a <title> child for inline SVG), or mark it decorative with alt="" and aria-hidden="true".'
+          : 'Give it visible text, an aria-label, or an aria-labelledby pointing at visible text.',
+      });
+      continue;
+    }
+
+    if (!name)
+      continue;
+
+    // Both name-quality checks below judge how a control or image is announced,
+    // so they only apply to roles that carry their own name.
+    const isNamedRole = namedRoles.has(node.role);
+
+    if (isNamedRole && uninformativeNames.has(normalizeText(name))) {
+      push({
+        ...base,
+        check: 'uninformative-accessible-name',
+        wcag: '2.4.4 Link Purpose (In Context) / 2.4.9',
+        problem: `${describe(node)} is announced as "${name}", which says nothing when read out of context in a links or controls list.`,
+        fix: 'Rename it after its destination or action (e.g. "Pricing details"), or extend it with visually hidden text.',
+      });
+    }
+
+    // Only an image is *described* by its name, so only there is a file name a
+    // defect; a link or button legitimately named after the file it downloads
+    // ("logo.png") is doing its job.
+    if (isImage && (filenameNamePattern.test(name) || cameraFileNamePattern.test(name))) {
+      push({
+        ...base,
+        check: 'filename-as-accessible-name',
+        wcag: '1.1.1 Non-text Content',
+        problem: `${describe(node)} uses the file name "${name}" as its accessible name; a screen reader reads the file name aloud.`,
+        fix: 'Replace the alt text with a description of what the image shows.',
+      });
+    }
+
+    const visibleText = node.visibleText?.trim() ?? '';
+    const normalizedVisible = normalizeText(visibleText);
+    const isLeaf = node.childCount === 0;
+    if (labelInNameRoles.has(node.role) && isLeaf && normalizedVisible && visibleText.length <= 60
+        && /[\p{L}\p{N}]/u.test(visibleText) && !normalizeText(name).includes(normalizedVisible)) {
+      push({
+        ...base,
+        check: 'label-in-name-mismatch',
+        wcag: '2.5.3 Label in Name',
+        problem: `${describe(node)} shows "${visibleText}" but is announced as "${name}", so a voice-control user saying "click ${visibleText}" cannot activate it.`,
+        fix: `Make the accessible name start with the visible text, e.g. aria-label="${visibleText} ${name}".`,
+      });
+    }
+  }
+}
+
+function checkDuplicateNames(nodes: ScreenReaderNode[], push: (finding: ScreenReaderFinding) => void) {
+  const byParent = new Map<string, ScreenReaderNode[]>();
+  for (const node of nodes) {
+    const normalized = normalizeText(node.name);
+    if (!node.ref || node.ariaHidden || !normalized || !labelInNameRoles.has(node.role))
+      continue;
+    const key = `${node.parent ?? -1}|${node.role}|${normalized}`;
+    const group = byParent.get(key);
+    if (group)
+      group.push(node);
+    else
+      byParent.set(key, [node]);
+  }
+
+  for (const group of byParent.values()) {
+    // Same name pointing at the same destination is allowed (WCAG 2.4.4); only
+    // siblings that do different things are ambiguous. A destination is only
+    // observable for links, so controls whose action we cannot see (two "Save"
+    // submit buttons in one form) are never claimed to differ.
+    const targets = new Set(group.map(node => node.href));
+    if (group.length < 2 || targets.has(null) || targets.size < 2)
+      continue;
+    push({
+      check: 'duplicate-accessible-name',
+      wcag: '2.4.4 Link Purpose (In Context)',
+      ref: group[0].ref,
+      role: group[0].role,
+      name: group[0].name,
+      selector: group[0].selector,
+      problem: `${group.length} sibling ${group[0].role}s share the accessible name "${group[0].name}" but lead to different targets (${[...targets].slice(0, 4).join(', ')}).`,
+      fix: 'Give each one a distinct accessible name, or append visually hidden text that names its target.',
+    });
+  }
+}
+
+function checkReadingOrder(nodes: ScreenReaderNode[], push: (finding: ScreenReaderFinding) => void) {
+  const childrenByParent = new Map<number, ScreenReaderNode[]>();
+  for (const node of nodes) {
+    if (node.parent === null || !isLayoutRelevant(node))
+      continue;
+    const siblings = childrenByParent.get(node.parent);
+    if (siblings)
+      siblings.push(node);
+    else
+      childrenByParent.set(node.parent, [node]);
+  }
+
+  for (const [parentIndex, siblings] of childrenByParent) {
+    if (siblings.length < 2)
+      continue;
+    const rects = siblings.map(node => node.rect!);
+    const rows = countBands(rects, 'y');
+    const columns = countBands(rects, 'x');
+    // A true 2-D layout (grid, CSS columns, wrapped flex) has no single correct
+    // linear visual order, so comparing against DOM order there only cries wolf.
+    const horizontal = rows === 1 && columns > 1;
+    const vertical = columns === 1 && rows > 1;
+    if (!horizontal && !vertical)
+      continue;
+
+    // The container's own direction decides the order of its children, but an
+    // unmeasured parent has no measured direction (it defaults to ltr), and an
+    // iframe element's direction belongs to the embedding page rather than to
+    // the document inside it. Fall back to the children's inherited direction.
+    const parent = nodes[parentIndex];
+    const parentDirection = parent?.rect && parent.tagName !== 'iframe' ? parent.direction : siblings[0].direction;
+    const rtl = parentDirection === 'rtl';
+    const isInverted = (a: Rect, b: Rect) => horizontal
+      ? (rtl ? a.x + a.width <= b.x + layoutTolerancePx : a.x >= b.x + b.width - layoutTolerancePx)
+      : a.y >= b.y + b.height - layoutTolerancePx;
+
+    let inversions = 0;
+    for (let i = 0; i < siblings.length; i++) {
+      for (let j = i + 1; j < siblings.length; j++) {
+        if (isInverted(rects[i], rects[j]))
+          inversions++;
+      }
+    }
+    if (!inversions)
+      continue;
+
+    const sortKey = (rect: Rect) => horizontal ? (rtl ? -(rect.x + rect.width) : rect.x) : rect.y;
+    const visualOrder = [...siblings].sort((a, b) => sortKey(a.rect!) - sortKey(b.rect!));
+    const label = (list: ScreenReaderNode[]) => list.slice(0, 6).map(node => describe(node)).join(' -> ')
+        + (list.length > 6 ? ` -> ... (+${list.length - 6})` : '');
+    push({
+      check: 'reading-order-mismatch',
+      wcag: '1.3.2 Meaningful Sequence',
+      ref: parent?.ref ?? siblings[0].ref,
+      role: parent?.role ?? 'generic',
+      name: parent?.name ?? null,
+      selector: parent?.selector ?? null,
+      problem: `Inside ${parent ? describe(parent) : 'the page'}, screen readers and keyboard users follow DOM order [${label(siblings)}] but the ${rtl ? 'right-to-left ' : ''}visual order is [${label(visualOrder)}].`,
+      fix: 'Reorder the source so DOM order matches the visual order; CSS order, flex-direction: row-reverse and absolute positioning move pixels but not the reading order.',
+    });
+  }
+}
+
+export function analyzeScreenReader(
+  nodes: ScreenReaderNode[],
+  options: ScreenReaderAuditOptions
+): ScreenReaderAuditResult {
+  const findings: ScreenReaderFinding[] = [];
+  const countByCheck = {
+    'missing-accessible-name': 0,
+    'uninformative-accessible-name': 0,
+    'filename-as-accessible-name': 0,
+    'label-in-name-mismatch': 0,
+    'duplicate-accessible-name': 0,
+    'reading-order-mismatch': 0,
+  } satisfies Record<ScreenReaderCheck, number>;
+
+  const push = (finding: ScreenReaderFinding) => {
+    countByCheck[finding.check]++;
+    if (countByCheck[finding.check] <= options.maxFindingsPerCheck)
+      findings.push(finding);
+  };
+
+  if (options.checkNames) {
+    checkAccessibleNames(nodes, push);
+    checkDuplicateNames(nodes, push);
+  }
+  if (options.checkReadingOrder)
+    checkReadingOrder(nodes, push);
+
+  const truncatedChecks = (Object.keys(countByCheck) as ScreenReaderCheck[])
+      .filter(check => countByCheck[check] > options.maxFindingsPerCheck);
+  return { findings, countByCheck, truncatedChecks };
+}
+
+// Runs inside the page: no imports, no closures over module scope.
+export function collectElementFacts(elements: (SVGElement | HTMLElement)[]): ElementFacts[] {
+  // innerText counts visually hidden (clipped) labels as visible, which makes
+  // icon-only controls look like text. Walk the subtree instead and skip the
+  // usual visually-hidden techniques; the cache keeps nested elements linear.
+  const textCache = new Map<Element, string>();
+  const hiddenFromSight = (element: Element) => {
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')
+      return true;
+    if (style.clip === 'rect(0px, 0px, 0px, 0px)' || style.clipPath.startsWith('inset(50%'))
+      return true;
+    const rect = element.getBoundingClientRect();
+    return rect.width <= 1 || rect.height <= 1;
+  };
+  const sightedText = (element: Element): string => {
+    const cached = textCache.get(element);
+    if (cached !== undefined)
+      return cached;
+    let text = '';
+    for (const child of element.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE)
+        text += child.nodeValue ?? '';
+      else if (child.nodeType === Node.ELEMENT_NODE && !hiddenFromSight(child as Element))
+        text += ` ${sightedText(child as Element)}`;
+    }
+    const value = text.replace(/\s+/g, ' ').trim();
+    textCache.set(element, value);
+    return value;
+  };
+
+  // Button-like inputs render their label from `value` and have no child nodes,
+  // so without this they look like icon-only controls to every text check.
+  const buttonInputTypes = ['submit', 'button', 'reset'];
+
+  return elements.map(element => {
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    const text = element instanceof HTMLInputElement && buttonInputTypes.includes(element.type)
+      ? element.value.trim()
+      : sightedText(element);
+    return {
+      tagName: element.tagName.toLowerCase(),
+      selector: `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ''}${element.classList[0] ? `.${element.classList[0]}` : ''}`,
+      visibleText: text ? text.slice(0, 200) : null,
+      href: element instanceof HTMLAnchorElement ? element.getAttribute('href') : null,
+      rect: {
+        x: rect.x + window.scrollX,
+        y: rect.y + window.scrollY,
+        width: rect.width,
+        height: rect.height,
+      },
+      direction: style.direction === 'rtl' ? 'rtl' : 'ltr',
+      positionFixed: style.position === 'fixed',
+      floating: style.float !== 'none',
+      // Playwright's snapshot still lists aria-hidden elements, but a screen
+      // reader never reaches them, so nothing about them is a defect.
+      ariaHidden: element.closest('[aria-hidden="true"]') !== null,
+    };
+  });
+}
+
+const auditScreenReaderSchema = z.object({
+  checkNames: z.boolean().default(true).describe('Check accessible name quality (missing, generic, filename, label-in-name, duplicate sibling names).'),
+  checkReadingOrder: z.boolean().default(true).describe('Compare accessibility tree order against visual position to find reading-order mismatches.'),
+  maxElements: z.number().int().min(1).max(2000).default(400).describe('Maximum accessibility tree elements to analyze; extra elements are reported as truncated.'),
+  maxFindingsPerCheck: z.number().int().min(1).max(200).default(20).describe('Maximum findings kept per check; the full count is still reported.'),
+  reportFile: z.string().optional().describe('Output JSON report file name.'),
+});
+
+function safeIsoTimestampForFileName() {
+  return sanitizeForFilePath(new Date().toISOString());
+}
+
+const auditScreenReader = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'audit_screen_reader',
+    title: 'Audit screen reader experience',
+    description: 'Audit accessible name quality and reading order using the browser accessibility tree and element geometry.',
+    inputSchema: auditScreenReaderSchema,
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    const ariaNodes = parseAriaSnapshot(await tab.page.ariaSnapshot({ mode: 'ai' }));
+    const refIndexes = ariaNodes.map((node, index) => node.ref ? index : -1).filter(index => index >= 0);
+    const childCounts = new Map<number, number>();
+    for (const node of ariaNodes) {
+      if (node.parent !== null)
+        childCounts.set(node.parent, (childCounts.get(node.parent) ?? 0) + 1);
+    }
+
+    // Snapshot elements can live in child frames, and a handle can only be
+    // evaluated by its own frame, so measure one batch per owning frame.
+    type Measured = { index: number; handle: playwright.ElementHandle<SVGElement | HTMLElement> };
+    const onlyFrame = tab.page.frames().length === 1 ? tab.page.mainFrame() : null;
+    const factsByIndex = new Map<number, ElementFacts>();
+    const analyzedIndexes: number[] = [];
+    let resolvedCount = 0;
+    let reachable = 0;
+
+    // maxElements budgets the elements a screen reader can actually reach: the
+    // AI snapshot also refs aria-hidden subtrees, and slicing the raw ref list
+    // let those spend the whole budget and leave every visible control below
+    // them unmeasured. The ceiling keeps a page made mostly of hidden refs
+    // bounded. Refs are resolved a chunk at a time because a ref that went
+    // stale costs a full timeout, and one timeout per element serially would
+    // stall a large audit for minutes.
+    const measureCeiling = Math.min(refIndexes.length, params.maxElements * 2);
+    for (let start = 0; start < measureCeiling && reachable < params.maxElements; start += measureChunkSize) {
+      const chunk = refIndexes.slice(start, Math.min(start + measureChunkSize, measureCeiling));
+      const handles = await Promise.all(chunk.map(index =>
+        tab.page.locator(`aria-ref=${ariaNodes[index].ref}`).elementHandle({ timeout: 1000 }).catch(() => null)));
+      const byFrame = new Map<playwright.Frame, Measured[]>();
+      for (const [position, handle] of handles.entries()) {
+        const frame = handle ? onlyFrame ?? await handle.ownerFrame().catch(() => null) : null;
+        if (!handle || !frame)
+          continue;
+        const batch = byFrame.get(frame);
+        if (batch)
+          batch.push({ index: chunk[position], handle });
+        else
+          byFrame.set(frame, [{ index: chunk[position], handle }]);
+      }
+      for (const [frame, batch] of byFrame) {
+        const facts = await frame.evaluate(collectElementFacts, batch.map(entry => entry.handle)).catch(() => null);
+        if (facts) {
+          batch.forEach((entry, position) => factsByIndex.set(entry.index, facts[position]));
+          resolvedCount += batch.length;
+          reachable += facts.filter(fact => !fact.ariaHidden).length;
+        }
+        await Promise.all(batch.map(entry => entry.handle.dispose().catch(() => undefined)));
+      }
+      analyzedIndexes.push(...chunk);
+      await response.reportProgress({
+        progress: analyzedIndexes.length,
+        total: measureCeiling,
+        message: `Measured ${analyzedIndexes.length} accessibility tree elements (${Math.min(reachable, params.maxElements)}/${params.maxElements} screen-reader-reachable)`,
+      });
+    }
+
+    const emptyFacts: ElementFacts = {
+      tagName: null,
+      selector: null,
+      visibleText: null,
+      href: null,
+      rect: null,
+      direction: 'ltr',
+      positionFixed: false,
+      floating: false,
+      ariaHidden: false,
+    };
+
+    const nodes: ScreenReaderNode[] = ariaNodes.map((node, index) => ({
+      ...node,
+      ...(factsByIndex.get(index) ?? emptyFacts),
+      ref: factsByIndex.has(index) ? node.ref : null,
+      childCount: childCounts.get(index) ?? 0,
+    }));
+
+    const result = analyzeScreenReader(nodes, {
+      checkNames: params.checkNames,
+      checkReadingOrder: params.checkReadingOrder,
+      maxFindingsPerCheck: params.maxFindingsPerCheck,
+    });
+
+    const truncatedElements = refIndexes.length - analyzedIndexes.length;
+    const elementCountSuffix = truncatedElements > 0
+      ? ` (truncated: analyzed the first ${analyzedIndexes.length} of ${refIndexes.length}; raise maxElements to see the rest)`
+      : '';
+    const totalFindings = Object.values(result.countByCheck).reduce((sum, count) => sum + count, 0);
+
+    const report = {
+      version: 'v1',
+      metadata: {
+        url: tab.page.url(),
+        options: params,
+        generatedAt: new Date().toISOString(),
+      },
+      elements: {
+        total: refIndexes.length,
+        analyzed: analyzedIndexes.length,
+        unresolved: analyzedIndexes.length - resolvedCount,
+        truncated: truncatedElements > 0,
+      },
+      countByCheck: result.countByCheck,
+      totalFindings,
+      truncatedChecks: result.truncatedChecks,
+      findings: result.findings,
+    };
+
+    const reportFileName = sanitizeForFilePath(params.reportFile ?? `audit-screen-reader-${safeIsoTimestampForFileName()}.json`);
+    const reportPath = await tab.context.outputFile(reportFileName);
+    await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
+    const reportResourceLink = response.addFileResourceLink(reportPath, {
+      name: 'audit-screen-reader-report',
+      title: 'Audit screen reader JSON report',
+      description: 'JSON report for accessible name quality and reading order findings.',
+      mimeType: 'application/json',
+    });
+    response.setStructuredContent({
+      kind: 'audit_screen_reader',
+      report: {
+        path: reportPath,
+        uri: reportResourceLink.uri,
+        name: reportResourceLink.name,
+        title: reportResourceLink.title ?? null,
+        mimeType: reportResourceLink.mimeType ?? null,
+      },
+      page: {
+        url: tab.page.url(),
+      },
+      summary: {
+        elementsTotal: refIndexes.length,
+        elementsAnalyzed: analyzedIndexes.length,
+        elementsTruncated: truncatedElements,
+        totalFindings,
+        countByCheck: result.countByCheck,
+        truncatedChecks: result.truncatedChecks,
+      },
+      findings: result.findings,
+      reportUri: reportResourceLink.uri,
+    });
+
+    const findingLines = result.findings.map(finding => (
+      `- [${finding.check}] WCAG ${finding.wcag} — ${finding.problem}\n  Fix: ${finding.fix}${finding.ref ? `\n  Ref: ${finding.ref}` : ''}`
+    ));
+    response.addCode('// Read the accessibility tree with page.ariaSnapshot() and compared names and geometry against reading order.');
+    response.addResult([
+      `Elements analyzed: ${analyzedIndexes.length}${elementCountSuffix}`,
+      `Findings: ${totalFindings}`,
+      'Check | Findings',
+      '--- | ---',
+      ...(Object.keys(result.countByCheck) as ScreenReaderCheck[]).map(check => `${check} | ${result.countByCheck[check]}`),
+      ...(result.truncatedChecks.length
+        ? ['', `Showing at most ${params.maxFindingsPerCheck} findings per check; truncated: ${result.truncatedChecks.join(', ')}`]
+        : []),
+      '',
+      ...(findingLines.length ? findingLines : ['- No screen-reader-level issues detected.']),
+      '',
+      `JSON report: ${reportPath}`,
+    ].join('\n'));
+  },
+});
+
+export default [
+  auditScreenReader,
+];

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { defineTabTool } from './tool.js';
 import { sanitizeForFilePath } from '../utils/fileUtils.js';
 import {
+  assertRuleOptionsValid,
+  axeRuleSchemaShape,
   axeScopeSchemaShape,
   axeTagValues,
   defaultAxeTags,
@@ -122,6 +124,7 @@ const auditSiteSchema = z.object({
   waitAfterNavigationMs: z.number().int().min(0).max(5000).default(250).describe('Extra wait after navigation before scanning.'),
   reportFile: z.string().optional().describe('Output JSON report file name.'),
   ...axeScopeSchemaShape,
+  ...axeRuleSchemaShape,
 }).superRefine((value, context) => {
   if (value.strategy === 'provided' && (!value.urls || !value.urls.length)) {
     context.addIssue({
@@ -364,6 +367,11 @@ const auditSite = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
+    // Rule ids apply to the whole run, so a bad one must fail before any tab is
+    // opened or any URL visited; leaving it to the per-page scan would crawl the
+    // entire site and write a "completed" report of nothing but errored pages.
+    assertRuleOptionsValid({ rules: params.withRules, disableRules: params.disableRules });
+
     const context = tab.context;
     const originalTab = tab;
     const queue: CrawlItem[] = [];
@@ -511,6 +519,8 @@ const auditSite = defineTabTool({
 
           const axeResult = await runAxeScan(crawlTab.page, {
             tags: params.violationsTag as AxeTag[],
+            rules: params.withRules,
+            disableRules: params.disableRules,
             include: params.includeSelectors,
             exclude: params.excludeSelectors,
           });
@@ -582,6 +592,8 @@ const auditSite = defineTabTool({
           includeIncomplete: params.includeIncomplete,
           includeSelectors: params.includeSelectors ?? null,
           excludeSelectors: params.excludeSelectors ?? null,
+          withRules: params.withRules ?? null,
+          disableRules: params.disableRules ?? null,
           maxNodesPerViolation: params.maxNodesPerViolation,
           waitAfterNavigationMs: params.waitAfterNavigationMs,
         },

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,4 +1,5 @@
 import { AxeBuilder } from '@axe-core/playwright';
+import axe from 'axe-core';
 import type { AxeResults } from 'axe-core';
 import { z } from 'zod';
 
@@ -49,6 +50,8 @@ export type TrimmedAxeViolation = {
 
 export type AxeScanOptions = {
   tags?: readonly AxeTag[];
+  rules?: readonly string[];
+  disableRules?: readonly string[];
   include?: readonly string[];
   exclude?: readonly string[];
 };
@@ -58,6 +61,53 @@ export const axeScopeSchemaShape = {
   includeSelectors: z.array(z.string().min(1)).optional().describe('CSS selectors to restrict the scan to, e.g. ["#checkout-form"]. Omit to scan the whole page. Each selector may match multiple elements.'),
   excludeSelectors: z.array(z.string().min(1)).optional().describe('CSS selectors to exclude from the scan, e.g. ["#cookie-banner", "iframe.chat-widget"]. Applied after includeSelectors, so it can carve regions out of an included subtree.'),
 };
+
+// Shared by every scan tool so rule filtering means the same thing everywhere.
+export const axeRuleSchemaShape = {
+  withRules: z.array(z.string().min(1)).optional().describe('Run only these Axe rule ids, e.g. ["color-contrast", "image-alt"]. Axe can run a rule list or a tag list but never both, so setting withRules ignores violationsTag entirely. Unknown rule ids are rejected rather than silently skipped.'),
+  disableRules: z.array(z.string().min(1)).optional().describe('Axe rule ids to skip, e.g. ["color-contrast"]. Unlike withRules this narrows whatever is already selected, so it applies to violationsTag and withRules alike. Disabling every rule in withRules is an error, not an empty scan. Unknown rule ids are rejected rather than silently skipped.'),
+};
+
+// The rule catalogue comes from the same axe-core build that AxeBuilder injects
+// into the page (it ships `axe.source`), so ids can never drift from what the
+// scan actually supports and no extra injection is needed to check them.
+// package.json pins axe-core to the exact version @axe-core/playwright requires
+// so the two can never resolve to different builds.
+// Axe does reject unknown ids itself, but only from inside the page after
+// injection, surfacing as an opaque `frame.evaluate` failure; checking up front
+// names the bad id and costs nothing.
+let knownRuleIds: Set<string> | undefined;
+function assertRuleIdsExist(ruleIds: readonly string[], label: 'withRules' | 'disableRules') {
+  if (!ruleIds.length)
+    return;
+  knownRuleIds ??= new Set(axe.getRules().map(rule => rule.ruleId));
+  const unknown = ruleIds.filter(ruleId => !knownRuleIds!.has(ruleId));
+  if (unknown.length)
+    throw new Error(`Unknown Axe rule id(s) in ${label}: ${unknown.join(', ')}. See https://dequeuniversity.com/rules/axe/ for valid ids.`);
+}
+
+// Rule options are run-wide input and need no page, so a crawler can validate
+// them once before navigating anything instead of failing every page in turn.
+// Returns the rule list to actually run, empty when the caller passed none.
+// (Scope selectors stay per-page on purpose: a component may legitimately be
+// absent from some pages of a crawl.)
+export function assertRuleOptionsValid(options: Pick<AxeScanOptions, 'rules' | 'disableRules'>): string[] {
+  assertRuleIdsExist(options.rules ?? [], 'withRules');
+  assertRuleIdsExist(options.disableRules ?? [], 'disableRules');
+  if (!options.rules?.length)
+    return [];
+  // axe's ruleShouldRun returns on the runOnly-is-a-rule-list branch before it
+  // ever reads the per-rule `enabled` flag that disableRules sets, so passing
+  // both would silently run a rule the caller asked to disable. Subtract here
+  // so disableRules means the same thing next to withRules as next to tags.
+  const disabled = new Set(options.disableRules ?? []);
+  const rules = options.rules.filter(rule => !disabled.has(rule));
+  // axe rejects an empty runOnly list with a message that names neither
+  // option, and falling back to the tag set would scan far more than asked.
+  if (!rules.length)
+    throw new Error(`disableRules disabled every rule in withRules (${options.rules.join(', ')}), leaving nothing to scan.`);
+  return rules;
+}
 
 // Axe only rejects a scope when the *whole* include set resolves to nothing, so
 // one typo among several include selectors silently shrinks the scan and the
@@ -92,10 +142,21 @@ async function assertScopeSelectorsResolve(
 }
 
 export async function runAxeScan(page: playwright.Page, options: AxeScanOptions = {}): Promise<AxeScanResult> {
+  const rules = assertRuleOptionsValid(options);
   await assertScopeSelectorsResolve(page, options.include ?? [], 'includeSelectors');
   await assertScopeSelectorsResolve(page, options.exclude ?? [], 'excludeSelectors');
 
-  const builder = new AxeBuilder({ page }).withTags([...(options.tags ?? defaultAxeTags)]);
+  const builder = new AxeBuilder({ page });
+  // withRules and withTags both overwrite axe's single `runOnly` slot, so only
+  // one may be called. Explicit rule ids are the more specific request, so they
+  // win over tags.
+  if (rules.length) {
+    builder.withRules(rules);
+  } else {
+    builder.withTags([...(options.tags ?? defaultAxeTags)]);
+    if (options.disableRules?.length)
+      builder.disableRules([...options.disableRules]);
+  }
   // include/exclude are cumulative in AxeBuilder; exclude wins over include for
   // overlapping subtrees, which is what "scan this component minus the widget"
   // needs.

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { defineTabTool } from './tool.js';
 import { sanitizeForFilePath } from '../utils/fileUtils.js';
 import {
+  axeRuleSchemaShape,
   axeScopeSchemaShape,
   axeTagValues,
   defaultAxeTags,
@@ -86,6 +87,7 @@ const scanPageMatrixSchema = z.object({
   reloadBetweenVariants: z.boolean().default(false).describe('Reload page between variants.'),
   reportFile: z.string().optional().describe('Output JSON report file name.'),
   ...axeScopeSchemaShape,
+  ...axeRuleSchemaShape,
 });
 
 function normalizeMedia(variantMedia: z.output<typeof variantSchema>['media'] | undefined) {
@@ -163,6 +165,8 @@ const scanPageMatrix = defineTabTool({
 
         const axeResult = await runAxeScan(tab.page, {
           tags: params.violationsTag as AxeTag[],
+          rules: params.withRules,
+          disableRules: params.disableRules,
           include: params.includeSelectors,
           exclude: params.excludeSelectors,
         });
@@ -222,6 +226,8 @@ const scanPageMatrix = defineTabTool({
           includeIncomplete: params.includeIncomplete,
           includeSelectors: params.includeSelectors ?? null,
           excludeSelectors: params.excludeSelectors ?? null,
+          withRules: params.withRules ?? null,
+          disableRules: params.disableRules ?? null,
           maxNodesPerViolation: params.maxNodesPerViolation,
           waitAfterApplyMs: params.waitAfterApplyMs,
           reloadBetweenVariants: params.reloadBetweenVariants,

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 import { defineTabTool, defineTool } from './tool.js';
 import * as javascript from '../utils/codegen.js';
 import { generateLocator } from './utils.js';
-import { axeScopeSchemaShape, axeTagValues, dedupeAxeNodes, defaultAxeTags, prepareAxeResults, runAxeScan } from './axe.js';
+import { axeRuleSchemaShape, axeScopeSchemaShape, axeTagValues, dedupeAxeNodes, defaultAxeTags, prepareAxeResults, runAxeScan } from './axe.js';
 import { truncateDataUrls } from '../utils/dataUrl.js';
 import { sanitizeForFilePath } from '../utils/fileUtils.js';
 
@@ -53,6 +53,7 @@ const scanPageSchema = z.object({
       .default(false)
       .describe(`Capture a full-page PNG with every violating element outlined and labelled with its rule ids, then remove the markers. Off by default because screenshots are expensive. At most ${maxAnnotatedElements} elements are marked; nodes that are hidden, zero-size, or inside an iframe cannot be marked and are reported as skipped.`),
   ...axeScopeSchemaShape,
+  ...axeRuleSchemaShape,
 });
 
 const snapshotSchema = z.object({
@@ -83,6 +84,8 @@ const scanPage = defineTool({
     const tab = context.currentTabOrDie();
     const results = await runAxeScan(tab.page, {
       tags: params.violationsTag,
+      rules: params.withRules,
+      disableRules: params.disableRules,
       include: params.includeSelectors,
       exclude: params.excludeSelectors,
     });

--- a/tests/tools-auditScreenReader.test.ts
+++ b/tests/tools-auditScreenReader.test.ts
@@ -1,0 +1,474 @@
+import fs from 'fs';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chromium, type Browser } from 'playwright';
+import auditScreenReaderTools, {
+  analyzeScreenReader,
+  collectElementFacts,
+  parseAriaSnapshot,
+  type ElementFacts,
+  type Rect,
+  type ScreenReaderCheck,
+  type ScreenReaderNode,
+} from '../src/tools/auditScreenReader.js';
+import { Response } from '../src/response.js';
+
+function node(overrides: Partial<ScreenReaderNode>): ScreenReaderNode {
+  return {
+    role: 'generic',
+    name: null,
+    level: null,
+    ref: 'e1',
+    depth: 0,
+    parent: null,
+    tagName: 'div',
+    selector: 'div',
+    visibleText: null,
+    href: null,
+    rect: null,
+    direction: 'ltr',
+    positionFixed: false,
+    floating: false,
+    ariaHidden: false,
+    childCount: 0,
+    ...overrides,
+  };
+}
+
+function rect(x: number, y: number, width = 100, height = 20): Rect {
+  return { x, y, width, height };
+}
+
+function analyze(nodes: ScreenReaderNode[], maxFindingsPerCheck = 20) {
+  return analyzeScreenReader(nodes, { checkNames: true, checkReadingOrder: true, maxFindingsPerCheck });
+}
+
+function checks(nodes: ScreenReaderNode[]): ScreenReaderCheck[] {
+  return analyze(nodes).findings.map(finding => finding.check);
+}
+
+describe('parseAriaSnapshot', () => {
+  it('parses roles, names, refs, levels and parent links', () => {
+    const nodes = parseAriaSnapshot([
+      '- generic [active] [ref=e1]:',
+      '  - link "click here" [ref=e2] [cursor=pointer]:',
+      '    - /url: /a',
+      '  - heading "Title" [level=2] [ref=e3]',
+      '  - button "Say \\"hi\\" now" [ref=e4]: Hi',
+      '  - text: loose text',
+    ].join('\n'));
+
+    expect(nodes.map(entry => entry.role)).toEqual(['generic', 'link', 'heading', 'button', 'text']);
+    expect(nodes[1]).toMatchObject({ name: 'click here', ref: 'e2', parent: 0 });
+    expect(nodes[2]).toMatchObject({ level: 2, ref: 'e3', parent: 0 });
+    expect(nodes[3].name).toBe('Say "hi" now');
+    expect(nodes[4].ref).toBeNull();
+  });
+});
+
+describe('analyzeScreenReader accessible names', () => {
+  it('flags controls and images with no accessible name', () => {
+    expect(checks([node({ role: 'textbox', ref: 'e1' })])).toEqual(['missing-accessible-name']);
+    expect(checks([node({ role: 'img', ref: 'e1' })])).toEqual(['missing-accessible-name']);
+  });
+
+  it('ignores aria-hidden elements, which the snapshot still lists', () => {
+    expect(checks([
+      node({ role: 'img', ref: 'e1', ariaHidden: true }),
+      node({ role: 'button', ref: 'e2', ariaHidden: true, visibleText: 'Decorative' }),
+      node({ role: 'link', ref: 'e3', ariaHidden: true, name: 'Read more', href: '/a' }),
+    ])).toEqual([]);
+  });
+
+  it('does not flag containers, text nodes or named controls', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      node({ role: 'paragraph', ref: 'e2', visibleText: 'Some prose' }),
+      node({ role: 'button', ref: 'e3', name: 'Save', visibleText: 'Save' }),
+      node({ role: 'button', ref: null, name: null }),
+    ])).toEqual([]);
+  });
+
+  it('flags names that are useless out of context but keeps specific ones', () => {
+    expect(checks([node({ role: 'link', ref: 'e1', name: 'Read more', visibleText: 'Read more', href: '/a' })]))
+        .toEqual(['uninformative-accessible-name']);
+    expect(checks([node({ role: 'link', ref: 'e1', name: 'Read more about pricing', visibleText: 'Read more about pricing', href: '/a' })]))
+        .toEqual([]);
+    expect(checks([node({ role: 'link', ref: 'e1', name: 'Click here!', visibleText: 'Click here!', href: '/a' })]))
+        .toEqual(['uninformative-accessible-name']);
+  });
+
+  it('flags an exposed option with no name but not a named one', () => {
+    // A closed <select> exposes no refs, so this only fires for a rendered
+    // listbox, where a blank row is an unpickable choice.
+    expect(checks([node({ role: 'option', ref: 'e1' })])).toEqual(['missing-accessible-name']);
+    expect(checks([node({ role: 'option', ref: 'e1', name: 'Apples', visibleText: 'Apples' })])).toEqual([]);
+  });
+
+  it('flags file names used as alt text but not descriptions that mention a photo', () => {
+    expect(checks([node({ role: 'img', ref: 'e1', name: 'IMG_1234.jpg' })]))
+        .toEqual(['filename-as-accessible-name']);
+    expect(checks([node({ role: 'img', ref: 'e1', name: 'DSC00123' })]))
+        .toEqual(['filename-as-accessible-name']);
+    expect(checks([node({ role: 'img', ref: 'e1', name: 'Photo of the 2024 team offsite' })]))
+        .toEqual([]);
+  });
+
+  it('does not read a link or button named after a file as bad alt text', () => {
+    // Only an image is described by its name; a download link named after the
+    // file it fetches has nothing to fix.
+    expect(checks([node({ role: 'link', ref: 'e1', name: 'logo.png', visibleText: 'logo.png', href: '/logo.png' })]))
+        .toEqual([]);
+    expect(checks([node({ role: 'button', ref: 'e1', name: 'IMG_1234.jpg', visibleText: 'IMG_1234.jpg' })]))
+        .toEqual([]);
+  });
+
+  it('flags visible label and accessible name mismatches without punctuation or case noise', () => {
+    expect(checks([node({ role: 'button', ref: 'e1', name: 'Submit form', visibleText: 'Send' })]))
+        .toEqual(['label-in-name-mismatch']);
+    expect(checks([node({ role: 'button', ref: 'e1', name: 'Search products', visibleText: 'Search' })]))
+        .toEqual([]);
+    expect(checks([node({ role: 'button', ref: 'e1', name: 'save changes', visibleText: 'SAVE CHANGES!' })]))
+        .toEqual([]);
+  });
+
+  it('does not treat container text or icon-only controls as a label mismatch', () => {
+    expect(checks([
+      node({ role: 'link', ref: 'e1', name: 'Product card', visibleText: 'Nice hat 19.99 Add to cart', childCount: 3 }),
+      node({ role: 'button', ref: 'e2', name: 'Close dialog', visibleText: '×' }),
+    ])).toEqual([]);
+  });
+
+  it('flags sibling controls that share a name but lead elsewhere', () => {
+    const siblings = [
+      node({ role: 'list', ref: 'e1' }),
+      node({ role: 'link', ref: 'e2', parent: 0, name: 'Download', visibleText: 'Download', href: '/a.pdf' }),
+      node({ role: 'link', ref: 'e3', parent: 0, name: 'Download', visibleText: 'Download', href: '/b.pdf' }),
+    ];
+    expect(checks(siblings)).toEqual(['duplicate-accessible-name']);
+  });
+
+  it('does not flag repeated names with the same target or in different containers', () => {
+    expect(checks([
+      node({ role: 'list', ref: 'e1' }),
+      node({ role: 'link', ref: 'e2', parent: 0, name: 'Home', visibleText: 'Home', href: '/' }),
+      node({ role: 'link', ref: 'e3', parent: 0, name: 'Home', visibleText: 'Home', href: '/' }),
+    ])).toEqual([]);
+
+    expect(checks([
+      node({ role: 'listitem', ref: 'e1' }),
+      node({ role: 'listitem', ref: 'e2' }),
+      node({ role: 'button', ref: 'e3', parent: 0, name: 'Edit', visibleText: 'Edit' }),
+      node({ role: 'button', ref: 'e4', parent: 1, name: 'Edit', visibleText: 'Edit' }),
+    ])).toEqual([]);
+  });
+
+  it('does not claim controls differ when their destination is not observable', () => {
+    // Two "Save" submit buttons in one form, or an ARIA link with no href: the
+    // audit cannot see what either one does, so it cannot call them ambiguous.
+    expect(checks([
+      node({ role: 'form', ref: 'e1' }),
+      node({ role: 'button', ref: 'e2', parent: 0, name: 'Save', visibleText: 'Save' }),
+      node({ role: 'button', ref: 'e3', parent: 0, name: 'Save', visibleText: 'Save' }),
+    ])).toEqual([]);
+
+    expect(checks([
+      node({ role: 'list', ref: 'e1' }),
+      node({ role: 'link', ref: 'e2', parent: 0, name: 'Download', visibleText: 'Download', href: '/a.pdf' }),
+      node({ role: 'link', ref: 'e3', parent: 0, name: 'Download', visibleText: 'Download' }),
+    ])).toEqual([]);
+  });
+});
+
+describe('analyzeScreenReader reading order', () => {
+  // Every reading-order participant needs rendered text; see the icon-only test below.
+  function block(ref: string, text: string, x: number, y: number, overrides: Partial<ScreenReaderNode> = {}) {
+    return node({ role: 'paragraph', ref, parent: 0, name: null, visibleText: text, rect: rect(x, y), ...overrides });
+  }
+
+  it('flags a single row whose visual order is reversed', () => {
+    const result = analyze([
+      node({ role: 'generic', ref: 'e1', selector: 'div.toolbar', visibleText: 'First in DOM Second in DOM' }),
+      block('e2', 'First in DOM', 200, 10, { role: 'button', name: 'First in DOM' }),
+      block('e3', 'Second in DOM', 50, 10, { role: 'button', name: 'Second in DOM' }),
+    ]);
+    expect(result.findings.map(finding => finding.check)).toEqual(['reading-order-mismatch']);
+    expect(result.findings[0].problem).toContain('First in DOM');
+    expect(result.findings[0].fix).toContain('Reorder the source');
+  });
+
+  it('flags a column whose visual order is reversed by absolute positioning', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Lower but first in DOM', 10, 200),
+      block('e3', 'Upper but second in DOM', 10, 10),
+    ])).toEqual(['reading-order-mismatch']);
+  });
+
+  it('accepts a matching row, a matching column and a right-to-left row', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Back', 10, 10, { role: 'button', name: 'Back' }),
+      block('e3', 'Next', 200, 10, { role: 'button', name: 'Next' }),
+    ])).toEqual([]);
+
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Top paragraph', 10, 10),
+      block('e3', 'Bottom paragraph', 10, 200),
+    ])).toEqual([]);
+
+    expect(checks([
+      node({ role: 'generic', ref: 'e1', direction: 'rtl' }),
+      block('e2', 'الأول', 300, 10, { role: 'link', name: 'الأول', href: '/1', direction: 'rtl' }),
+      block('e3', 'الثاني', 150, 10, { role: 'link', name: 'الثاني', href: '/2', direction: 'rtl' }),
+    ])).toEqual([]);
+  });
+
+  it('flags a right-to-left row only when it contradicts right-to-left reading', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1', direction: 'rtl' }),
+      block('e2', 'الأول', 150, 10, { role: 'link', name: 'الأول', href: '/1', direction: 'rtl' }),
+      block('e3', 'الثاني', 300, 10, { role: 'link', name: 'الثاني', href: '/2', direction: 'rtl' }),
+    ])).toEqual(['reading-order-mismatch']);
+  });
+
+  it('ignores two-dimensional layouts such as CSS multi-column and grids', () => {
+    // DOM order goes down column one then column two; row-major comparison would
+    // wrongly call this a mismatch.
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Column one top', 10, 100),
+      block('e3', 'Column one bottom', 10, 140),
+      block('e4', 'Column two top', 200, 100),
+      block('e5', 'Column two bottom', 200, 140),
+    ])).toEqual([]);
+  });
+
+  it('ignores an icon-only control rendered before its label', () => {
+    // Disclosure arrows and leading icons carry no text, so their position is a
+    // rendering detail rather than a change of reading sequence.
+    expect(checks([
+      node({ role: 'listitem', ref: 'e1' }),
+      block('e2', 'Legislation', 60, 200, { role: 'link', name: 'Legislation', href: '#legislation' }),
+      node({ role: 'button', ref: 'e3', parent: 0, name: 'Toggle Legislation subsection', visibleText: '', rect: rect(37, 201, 22, 22) }),
+    ])).toEqual([]);
+  });
+
+  it('ignores floated media placed beside a later paragraph', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Figure caption', 756, 628, { role: 'figure', name: 'Figure caption', floating: true }),
+      block('e3', 'Body paragraph', 264, 347),
+    ])).toEqual([]);
+  });
+
+  it('ignores off-canvas, clipped, fixed and overlapping boxes', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Skip to content', -9999, 10, { role: 'link', name: 'Skip to content' }),
+      block('e3', 'Clipped', 10, 10, { role: 'link', name: 'Clipped', rect: rect(10, 10, 1, 1) }),
+      block('e4', 'Sticky header', 10, 500, { role: 'banner', positionFixed: true }),
+      block('e5', 'First paragraph', 10, 10),
+      block('e6', 'Overlapping paragraph', 15, 15),
+    ])).toEqual([]);
+  });
+
+  it('reads direction from the children when the parent carries none of its own', () => {
+    // An iframe element's direction is the embedding page's, and a parent that
+    // was never measured has no direction at all; both would otherwise be read
+    // as ltr and turn a correct right-to-left row into a false mismatch.
+    const rtlRow = (parent: Partial<ScreenReaderNode>) => [
+      node({ role: 'iframe', ref: 'e1', tagName: 'iframe', direction: 'ltr', ...parent }),
+      block('f1e2', 'rishon', 300, 10, { role: 'link', name: 'rishon', href: '/1', direction: 'rtl' }),
+      block('f1e3', 'sheni', 150, 10, { role: 'link', name: 'sheni', href: '/2', direction: 'rtl' }),
+    ];
+    expect(checks(rtlRow({ rect: rect(0, 0, 300, 80) }))).toEqual([]);
+    expect(checks(rtlRow({ ref: null, rect: null, tagName: null }))).toEqual([]);
+
+    // The same row in the wrong right-to-left order is still reported.
+    expect(checks([
+      node({ role: 'iframe', ref: 'e1', tagName: 'iframe', rect: rect(0, 0, 300, 80) }),
+      block('f1e2', 'rishon', 150, 10, { role: 'link', name: 'rishon', href: '/1', direction: 'rtl' }),
+      block('f1e3', 'sheni', 300, 10, { role: 'link', name: 'sheni', href: '/2', direction: 'rtl' }),
+    ])).toEqual(['reading-order-mismatch']);
+  });
+
+  it('ignores elements that were not measured', () => {
+    expect(checks([
+      node({ role: 'generic', ref: 'e1' }),
+      block('e2', 'Unmeasured', 0, 0, { rect: null }),
+      block('e3', 'Measured', 10, 10),
+    ])).toEqual([]);
+  });
+});
+
+describe('analyzeScreenReader bounds and toggles', () => {
+  it('caps findings per check while still counting and reporting the truncation', () => {
+    const nodes = Array.from({ length: 5 }, (_, index) => node({ role: 'textbox', ref: `e${index + 1}` }));
+    const result = analyze(nodes, 2);
+    expect(result.findings).toHaveLength(2);
+    expect(result.countByCheck['missing-accessible-name']).toBe(5);
+    expect(result.truncatedChecks).toEqual(['missing-accessible-name']);
+  });
+
+  it('honours the check toggles', () => {
+    const nodes = [
+      node({ role: 'textbox', ref: 'e1' }),
+      node({ role: 'generic', ref: 'e2' }),
+      node({ role: 'button', ref: 'e3', parent: 1, name: 'Back', visibleText: 'Back', rect: rect(200, 10) }),
+      node({ role: 'button', ref: 'e4', parent: 1, name: 'Next', visibleText: 'Next', rect: rect(50, 10) }),
+    ];
+    expect(analyzeScreenReader(nodes, { checkNames: false, checkReadingOrder: true, maxFindingsPerCheck: 20 })
+        .findings.map(finding => finding.check)).toEqual(['reading-order-mismatch']);
+    expect(analyzeScreenReader(nodes, { checkNames: true, checkReadingOrder: false, maxFindingsPerCheck: 20 })
+        .findings.map(finding => finding.check)).toEqual(['missing-accessible-name']);
+  });
+});
+
+const baseFacts: ElementFacts = {
+  tagName: 'div',
+  selector: 'div',
+  visibleText: null,
+  href: null,
+  rect: null,
+  direction: 'ltr',
+  positionFixed: false,
+  floating: false,
+  ariaHidden: false,
+};
+
+function snapshotOf(entries: { role: string; ref: string }[]): string {
+  return ['- generic:', ...entries.map(entry => `  - ${entry.role} [ref=${entry.ref}]`)].join('\n');
+}
+
+function createToolHarness(options: {
+  snapshot: string;
+  factsFor?: (ref: string) => Partial<ElementFacts>;
+  staleRefs?: (ref: string) => boolean;
+  staleDelayMs?: number;
+}) {
+  const concurrency = { current: 0, max: 0 };
+  const frame: any = {
+    evaluate: vi.fn(async (_collect: unknown, handles: { ref: string }[]) =>
+      handles.map(handle => ({ ...baseFacts, ...options.factsFor?.(handle.ref) }))),
+  };
+  const page: any = {
+    ariaSnapshot: vi.fn(async () => options.snapshot),
+    frames: vi.fn(() => [frame]),
+    mainFrame: vi.fn(() => frame),
+    url: vi.fn(() => 'https://example.com/'),
+    locator: vi.fn((selector: string) => ({
+      elementHandle: async () => {
+        const ref = selector.replace('aria-ref=', '');
+        const stale = options.staleRefs?.(ref) ?? false;
+        concurrency.current++;
+        concurrency.max = Math.max(concurrency.max, concurrency.current);
+        await new Promise(resolve => setTimeout(resolve, stale ? options.staleDelayMs ?? 0 : 0));
+        concurrency.current--;
+        return stale ? null : { ref, ownerFrame: async () => frame, dispose: async () => undefined };
+      },
+    })),
+  };
+  const tab: any = {
+    modalStates: () => [],
+    page,
+    context: { outputFile: async (name: string) => `/tmp/${name}` },
+  };
+  const context: any = { currentTabOrDie: () => tab, config: {} };
+  return { context, response: new Response(context, 'audit_screen_reader', {}), concurrency };
+}
+
+describe('audit_screen_reader tool measurement', () => {
+  const tool = auditScreenReaderTools.find(entry => entry.schema.name === 'audit_screen_reader')!;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+  });
+
+  async function run(harness: ReturnType<typeof createToolHarness>, maxElements: number) {
+    await tool.handle(harness.context, {
+      checkNames: true,
+      checkReadingOrder: true,
+      maxElements,
+      maxFindingsPerCheck: 20,
+    } as any, harness.response);
+    return harness.response.result();
+  }
+
+  it('spends the element budget on elements a screen reader can reach', async () => {
+    // The AI snapshot also refs aria-hidden subtrees: slicing the raw ref list
+    // let 60 decorative icons eat the whole budget and hide the two real defects.
+    const harness = createToolHarness({
+      snapshot: snapshotOf([
+        ...Array.from({ length: 60 }, (_, index) => ({ role: 'img', ref: `h${index}` })),
+        { role: 'button', ref: 'b1' },
+        { role: 'button', ref: 'b2' },
+      ]),
+      factsFor: ref => ref.startsWith('h') ? { ariaHidden: true } : {},
+    });
+
+    const result = await run(harness, 50);
+    expect(result).toContain('Elements analyzed: 62');
+    expect(result).toContain('missing-accessible-name | 2');
+  });
+
+  it('still stops at the budget when every element is reachable', async () => {
+    const harness = createToolHarness({
+      snapshot: snapshotOf(Array.from({ length: 62 }, (_, index) => ({ role: 'button', ref: `b${index}` }))),
+    });
+
+    const result = await run(harness, 50);
+    expect(result).toContain('Elements analyzed: 50');
+    expect(result).toContain('truncated: analyzed the first 50 of 62');
+    expect(result).toContain('missing-accessible-name | 50');
+  });
+
+  it('resolves refs in parallel batches so a stale snapshot cannot stall the audit', async () => {
+    // Every ref of a rerendered page times out; resolving them one at a time
+    // costs one full timeout per element.
+    const harness = createToolHarness({
+      snapshot: snapshotOf(Array.from({ length: 120 }, (_, index) => ({ role: 'button', ref: `b${index}` }))),
+      staleRefs: () => true,
+      staleDelayMs: 5,
+    });
+
+    const result = await run(harness, 50);
+    expect(harness.concurrency.max).toBe(50);
+    // Unresolvable refs never fill the budget, so measurement stops at the ceiling.
+    expect(result).toContain('Elements analyzed: 100');
+    expect(result).toContain('Findings: 0');
+  });
+});
+
+describe('collectElementFacts in a real page', () => {
+  let browser: Browser | undefined;
+
+  beforeEach(async () => {
+    browser ??= await chromium.launch();
+  });
+
+  it('takes the visible label of button-like inputs from value', async () => {
+    const page = await browser!.newPage();
+    await page.setContent(`
+      <input type="submit" id="send" value="Send" aria-label="Submit form">
+      <input type="reset" id="clear" value="Clear">
+      <input type="submit" id="bare">
+      <input type="text" id="text" value="typed text" aria-label="Query">
+      <button id="save">Save</button>
+      <button id="icon"><svg width="12" height="12"></svg></button>`);
+    const handles = await Promise.all(['#send', '#clear', '#bare', '#text', '#save', '#icon']
+        .map(selector => page.$(selector)));
+
+    const facts = await page.evaluate(collectElementFacts, handles as any);
+
+    // #bare has no value: the UA renders "Submit" but exposes no label to copy,
+    // and #text holds user input rather than a label.
+    expect(facts.map(fact => fact.visibleText)).toEqual(['Send', 'Clear', null, null, 'Save', null]);
+    await page.close();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+});

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -150,7 +150,7 @@ describe('audit_site tool', () => {
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
   });
 
-  it('passes tags and scope selectors through to the axe scan', async () => {
+  it('passes tags, rule filters and scope selectors through to the axe scan', async () => {
     const { context, response } = createHarness({ 'https://example.com/': [] });
     const runAxeScanSpy = vi.spyOn(axe, 'runAxeScan')
         .mockImplementation(async (page: any) => createAxeResult(page.url(), []));
@@ -169,13 +169,23 @@ describe('audit_site tool', () => {
       waitAfterNavigationMs: 0,
       includeSelectors: ['#main'],
       excludeSelectors: ['#chat-widget'],
+      withRules: ['image-alt'],
+      disableRules: ['color-contrast'],
     } as any, response);
 
     expect(runAxeScanSpy.mock.calls[0][1]).toEqual({
       tags: ['wcag2aa'],
+      rules: ['image-alt'],
+      disableRules: ['color-contrast'],
       include: ['#main'],
       exclude: ['#chat-widget'],
     });
+
+    // The report has to say which rule filter produced it, or a stored audit
+    // cannot be told apart from a full scan.
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(report.metadata.options.withRules).toEqual(['image-alt']);
+    expect(report.metadata.options.disableRules).toEqual(['color-contrast']);
   });
 
   it('reports incomplete results per page and aggregated, and drops them when disabled', async () => {
@@ -450,6 +460,83 @@ describe('audit_site tool', () => {
       maxNodesPerViolation: 10,
       waitAfterNavigationMs: 0,
     } as any, response)).rejects.toThrow('excludePathPatterns[0] is too long');
+  });
+
+  it('rejects unknown rule ids before crawling anything, instead of erroring every page', async () => {
+    const { context, response, crawlTab } = createHarness({ 'https://example.com/': [] });
+    const runAxeScanSpy = vi.spyOn(axe, 'runAxeScan');
+
+    await expect(tool.handle(context as any, {
+      strategy: 'provided',
+      urls: ['https://example.com/', 'https://example.com/pricing', 'https://example.com/contact'],
+      maxPages: 5,
+      maxDepth: 2,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+      withRules: ['image-altt'],
+    } as any, response)).rejects.toThrow('Unknown Axe rule id(s) in withRules: image-altt');
+
+    // The point of the up-front check: no tab opened, no page visited, no
+    // report claiming a completed audit.
+    expect(context.newTab).not.toHaveBeenCalled();
+    expect(crawlTab.navigate).not.toHaveBeenCalled();
+    expect(runAxeScanSpy).not.toHaveBeenCalled();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a disableRules set that empties withRules before crawling anything', async () => {
+    const { context, response, crawlTab } = createHarness({ 'https://example.com/': [] });
+
+    await expect(tool.handle(context as any, {
+      strategy: 'provided',
+      urls: ['https://example.com/'],
+      maxPages: 5,
+      maxDepth: 2,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+      withRules: ['image-alt'],
+      disableRules: ['image-alt'],
+    } as any, response)).rejects.toThrow('disableRules disabled every rule in withRules (image-alt)');
+
+    expect(context.newTab).not.toHaveBeenCalled();
+    expect(crawlTab.navigate).not.toHaveBeenCalled();
+  });
+
+  it('still validates scope selectors per page, not up front', async () => {
+    // A component may legitimately be missing from some crawled pages, so an
+    // unmatched selector is a page-level error — unlike a bad rule id.
+    const { context, response, crawlTab } = createHarness({ 'https://example.com/': [] });
+    vi.spyOn(axe, 'runAxeScan').mockRejectedValue(new Error('No elements matched includeSelectors: #missing'));
+
+    await tool.handle(context as any, {
+      strategy: 'provided',
+      urls: ['https://example.com/'],
+      maxPages: 5,
+      maxDepth: 2,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+      includeSelectors: ['#missing'],
+    } as any, response);
+
+    expect(crawlTab.navigate).toHaveBeenCalledTimes(1);
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(report.pages[0].status).toBe('error');
+    expect(report.pages[0].error).toContain('No elements matched includeSelectors');
   });
 
   it('includes subdomains when sameOriginOnly=true and includeSubdomains=true', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const builderCalls: { withTags: string[][]; include: string[]; exclude: string[] } = {
+const builderCalls: { withTags: string[][]; withRules: string[][]; disableRules: string[][]; include: string[]; exclude: string[] } = {
   withTags: [],
+  withRules: [],
+  disableRules: [],
   include: [],
   exclude: [],
 };
@@ -11,6 +13,14 @@ vi.mock('@axe-core/playwright', () => ({
   AxeBuilder: class {
     withTags(tags: string[]) {
       builderCalls.withTags.push(tags);
+      return this;
+    }
+    withRules(rules: string[]) {
+      builderCalls.withRules.push(rules);
+      return this;
+    }
+    disableRules(rules: string[]) {
+      builderCalls.disableRules.push(rules);
       return this;
     }
     include(selector: string) {
@@ -29,10 +39,12 @@ vi.mock('@axe-core/playwright', () => ({
   },
 }));
 
-const { axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } = await import('../src/tools/axe.js');
+const { assertRuleOptionsValid, axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } = await import('../src/tools/axe.js');
 
 function resetBuilderCalls() {
   builderCalls.withTags = [];
+  builderCalls.withRules = [];
+  builderCalls.disableRules = [];
   builderCalls.include = [];
   builderCalls.exclude = [];
   analyzeResult = { violations: [], incomplete: [], passes: [], inapplicable: [] };
@@ -115,8 +127,99 @@ describe('axe helpers', () => {
     resetBuilderCalls();
     await runAxeScan({} as any);
     expect(builderCalls.withTags).toEqual([[...defaultAxeTags]]);
+    expect(builderCalls.withRules).toEqual([]);
+    expect(builderCalls.disableRules).toEqual([]);
     expect(builderCalls.include).toEqual([]);
     expect(builderCalls.exclude).toEqual([]);
+  });
+
+  it('runs explicit rule ids instead of tags, because axe runOnly holds only one of them', async () => {
+    resetBuilderCalls();
+    await runAxeScan({} as any, { tags: ['wcag2aa'], rules: ['image-alt', 'label'] });
+    expect(builderCalls.withRules).toEqual([['image-alt', 'label']]);
+    // withTags would overwrite the rule list in axe's single runOnly slot.
+    expect(builderCalls.withTags).toEqual([]);
+  });
+
+  it('falls back to tags when the rule list is empty', async () => {
+    resetBuilderCalls();
+    await runAxeScan({} as any, { tags: ['wcag2aa'], rules: [] });
+    expect(builderCalls.withTags).toEqual([['wcag2aa']]);
+    expect(builderCalls.withRules).toEqual([]);
+  });
+
+  it('composes disableRules with tags', async () => {
+    resetBuilderCalls();
+    await runAxeScan({} as any, { tags: ['wcag2aa'], disableRules: ['color-contrast'] });
+    expect(builderCalls.withTags).toEqual([['wcag2aa']]);
+    expect(builderCalls.disableRules).toEqual([['color-contrast']]);
+  });
+
+  it('subtracts disableRules from an explicit rule list rather than relying on axe', async () => {
+    resetBuilderCalls();
+    // axe ignores the per-rule enabled flag once runOnly holds a rule list, so
+    // passing both through would still have run `label`.
+    await runAxeScan({} as any, { rules: ['image-alt', 'label'], disableRules: ['label'] });
+    expect(builderCalls.withRules).toEqual([['image-alt']]);
+    expect(builderCalls.disableRules).toEqual([]);
+  });
+
+  it('refuses a rule list that disableRules empties, instead of silently scanning everything', async () => {
+    resetBuilderCalls();
+    await expect(runAxeScan({} as any, { rules: ['image-alt'], disableRules: ['image-alt'] }))
+        .rejects.toThrow(/disableRules disabled every rule in withRules \(image-alt\)/);
+    expect(builderCalls.withRules).toEqual([]);
+    expect(builderCalls.withTags).toEqual([]);
+  });
+
+  it('rejects an unknown rule id in withRules instead of scanning nothing', async () => {
+    resetBuilderCalls();
+    await expect(runAxeScan({} as any, { rules: ['image-alt', 'image-altt'] }))
+        .rejects.toThrow(/Unknown Axe rule id\(s\) in withRules: image-altt/);
+    expect(builderCalls.withRules).toEqual([]);
+  });
+
+  it('rejects an unknown rule id in disableRules instead of disabling nothing', async () => {
+    resetBuilderCalls();
+    await expect(runAxeScan({} as any, { disableRules: ['colour-contrast'] }))
+        .rejects.toThrow(/Unknown Axe rule id\(s\) in disableRules: colour-contrast/);
+    expect(builderCalls.disableRules).toEqual([]);
+  });
+
+  it('validates rule ids before touching the page, so a bad id cannot cost a scan', async () => {
+    resetBuilderCalls();
+    const page = { evaluate: () => { throw new Error('page should not be touched'); } } as any;
+    await expect(runAxeScan(page, { rules: ['nope'], include: ['#content'] }))
+        .rejects.toThrow(/Unknown Axe rule id/);
+  });
+
+  it('accepts every rule id axe-core actually ships', async () => {
+    resetBuilderCalls();
+    // Guards against the catalogue check drifting from the injected axe build.
+    await runAxeScan({} as any, { rules: ['color-contrast', 'region', 'frame-tested', 'aria-allowed-attr'] });
+    expect(builderCalls.withRules[0]).toHaveLength(4);
+  });
+
+  it('validates rule options without a page, so crawlers can check them before navigating', () => {
+    expect(assertRuleOptionsValid({})).toEqual([]);
+    expect(assertRuleOptionsValid({ disableRules: ['color-contrast'] })).toEqual([]);
+    expect(assertRuleOptionsValid({ rules: ['image-alt', 'label'], disableRules: ['label'] })).toEqual(['image-alt']);
+    expect(() => assertRuleOptionsValid({ rules: ['image-altt'] }))
+        .toThrow(/Unknown Axe rule id\(s\) in withRules: image-altt/);
+    expect(() => assertRuleOptionsValid({ disableRules: ['colour-contrast'] }))
+        .toThrow(/Unknown Axe rule id\(s\) in disableRules: colour-contrast/);
+    expect(() => assertRuleOptionsValid({ rules: ['image-alt'], disableRules: ['image-alt'] }))
+        .toThrow(/disableRules disabled every rule in withRules \(image-alt\)/);
+  });
+
+  it('validates rule ids against the exact axe-core build @axe-core/playwright injects', async () => {
+    // The catalogue check is only meaningful while both resolve to one version,
+    // which is why package.json pins axe-core exactly.
+    const [ownPackage, installedAxeCore] = await Promise.all([
+      import('../package.json', { with: { type: 'json' } }),
+      import('axe-core/package.json', { with: { type: 'json' } }),
+    ]);
+    expect(ownPackage.default.dependencies['axe-core']).toBe(installedAxeCore.default.version);
   });
 
   it('applies include and exclude selectors to the builder', async () => {

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -60,7 +60,7 @@ describe('scan_page_matrix tool', () => {
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
   });
 
-  it('passes tags and scope selectors through to the axe scan', async () => {
+  it('passes tags, rule filters and scope selectors through to the axe scan', async () => {
     const runAxeScanSpy = vi.spyOn(axe, 'runAxeScan')
         .mockResolvedValue(createAxeResult('https://example.com/page', []));
     const { context, response } = createMatrixHarness('/tmp/scan-scope.json');
@@ -74,13 +74,23 @@ describe('scan_page_matrix tool', () => {
       reloadBetweenVariants: false,
       includeSelectors: ['#checkout'],
       excludeSelectors: ['#cookie-banner'],
+      withRules: ['image-alt'],
+      disableRules: ['color-contrast'],
     } as any, response);
 
     expect(runAxeScanSpy.mock.calls[0][1]).toEqual({
       tags: ['wcag2aa'],
+      rules: ['image-alt'],
+      disableRules: ['color-contrast'],
       include: ['#checkout'],
       exclude: ['#cookie-banner'],
     });
+
+    // The report has to say which rule filter produced it, or a stored matrix
+    // run cannot be told apart from a full scan.
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(report.metadata.options.withRules).toEqual(['image-alt']);
+    expect(report.metadata.options.disableRules).toEqual(['color-contrast']);
   });
 
   it('records incomplete results per variant only when enabled', async () => {

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -270,7 +270,7 @@ describe('Snapshot Tools', () => {
       return { context, response, text };
     }
 
-    it('passes tags and scope selectors through to the axe scan', async () => {
+    it('passes tags, rule filters and scope selectors through to the axe scan', async () => {
       const runAxeScanSpy = vi.spyOn(axe, 'runAxeScan').mockResolvedValue(scanResult([]));
       const { context, response } = scanHarness();
 
@@ -280,10 +280,14 @@ describe('Snapshot Tools', () => {
         maxNodesPerViolation: 10,
         includeSelectors: ['#checkout'],
         excludeSelectors: ['#cookie-banner'],
+        withRules: ['image-alt'],
+        disableRules: ['color-contrast'],
       } as any, response as any);
 
       expect(runAxeScanSpy.mock.calls[0][1]).toEqual({
         tags: ['wcag2aa'],
+        rules: ['image-alt'],
+        disableRules: ['color-contrast'],
         include: ['#checkout'],
         exclude: ['#cookie-banner'],
       });


### PR DESCRIPTION
Fifth in a stack of 5. **Base: `stack/4-wcag22-keyboard` (#144)** — review #141–#144 first.

`withRules` and `disableRules` on `scan_page`, `audit_site` and `scan_page_matrix`, via a shared `axeRuleSchemaShape`. Use `withRules` to re-check one rule after a fix, `disableRules` to mute one already triaged.

## Two axe behaviours that are easy to get wrong

**1. `withRules` and `withTags` both assign `runOnly` — last call wins.** They cannot compose. Explicit rule ids take precedence over tags, documented in both the schema descriptions and the README. (A schema default makes "user passed tags" indistinguishable from "default applied", so erroring on the combination is not possible without guessing.)

**2. `disableRules` does *not* compose with `withRules`.** I had assumed it did; it does not. Axe's `ruleShouldRun` returns on the `runOnly.type === 'rule'` branch **before** it ever reads the per-rule `enabled` flag that `disableRules` sets. Caught live in a harness run:

```
withRules: ['image-alt','label'] + disableRules: ['image-alt']   ->  still reported 2 image-alt nodes
```

Fixed by subtracting `disableRules` from the rule list up front, so the two options mean the same thing together as apart. If that empties the list it errors — axe's own message names neither option, and falling back to the tag set would scan far *more* than requested.

## Unknown rule ids

Validated against `axe.getRules()` before the browser is touched, so a typo fails naming the id instead of producing an opaque post-injection `frame.evaluate: Error: unknown rule ...`. The catalogue is free: `@axe-core/playwright` already requires `axe-core` in-process for `axe.source`, so it is the same build that gets injected — no second injection, no drift. `axe-core` is a **direct dependency pinned to the exact `4.12.1`**, not a range: it is imported here for the catalogue, so relying on it transitively breaks under pnpm/Yarn PnP, and only an exact pin cannot resolve to a build different from the one `AxeBuilder` injects. A test asserts the pinned spec equals the installed version.

Rule ids are **run-wide input, so the tools that mutate state validate them up front**, in `assertRuleOptionsValid`, before touching anything:

- `audit_site` checks before it opens a tab. Otherwise, with `strategy: "provided"`, an unknown id visited every supplied URL, marked each page errored, and wrote a "completed" report.
- `scan_page_matrix` checks before the first variant is applied. Otherwise a bad id resized the viewport, re-emulated media, reloaded the page (`reloadBetweenVariants`) and slept `waitAfterApplyMs` first; the `finally` block restores emulation but cannot restore form state the reload discarded. Measured on the built server: `2028ms` and a wiped `<input>` before, `1ms` and the value intact after.

Scope selectors stay per-page on purpose — a component may legitimately be absent from some pages of a crawl.

No `enum` of the 105 rule ids in the zod schema: it would bloat every tool's advertised schema, and runtime validation gives a better message and cannot go stale.

## Verification

typecheck, 36 test files, oxlint, build, full 28-tool harness — all green. Every guard was confirmed to catch its bug by breaking it and watching the check go red, then restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
