### PR TITLE
feat: add pre-push-review skill distilled from Codex PR review findings

### DIFF
--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -7,7 +7,7 @@ description: Self-review a code change against the recurring defect patterns tha
 
 This repo's PRs are reviewed by the OpenAI Codex bot. An analysis of all 179 inline findings it left across ~50 PRs shows the same defect classes recurring again and again. Almost every one of them was detectable from the diff alone — which means you can catch them locally.
 
-Work through the checklist below against your actual diff (`git diff origin/main...HEAD` plus staged/unstaged changes). Don't treat it as a form to tick off: for each section, ask "does my change touch this territory?" — if yes, actively hunt for the failure mode described. Fix what you find, then run the final gate.
+Work through the checklist below against your actual diff — everything that differs from the default branch (`git diff origin/main...HEAD`, or `git diff main...HEAD` in a checkout with no `origin` remote; if neither ref exists, diff against the merge base of whatever ref tracks the default branch) plus any staged and unstaged changes. Don't treat it as a form to tick off: for each section, ask "does my change touch this territory?" — if yes, actively hunt for the failure mode described. Fix what you find, then run the final gate.
 
 For concrete examples of every pattern (real findings with file/PR references), read `references/codex-findings-catalog.md`. Consult it whenever a section below feels abstract or you want to see what the failure looks like in practice.
 

--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pre-push-review
+description: Self-review a code change against the recurring defect patterns that automated PR review (Codex) keeps finding in this repo, and fix them locally before committing or pushing. Use this skill every time you are about to commit, push, or open a PR in this repository — after implementing a feature, fix, refactor, or dependency bump — even if the change looks small or you believe it is already correct. Also use it when asked to "review my changes", "check before pushing", or "make sure Codex won't flag this".
+---
+
+# Pre-push review: catch Codex findings before they reach GitHub
+
+This repo's PRs are reviewed by the OpenAI Codex bot. An analysis of all 179 inline findings it left across ~50 PRs shows the same defect classes recurring again and again. Almost every one of them was detectable from the diff alone — which means you can catch them locally.
+
+Work through the checklist below against your actual diff (`git diff origin/main...HEAD` plus staged/unstaged changes). Don't treat it as a form to tick off: for each section, ask "does my change touch this territory?" — if yes, actively hunt for the failure mode described. Fix what you find, then run the final gate.
+
+For concrete examples of every pattern (real findings with file/PR references), read `references/codex-findings-catalog.md`. Consult it whenever a section below feels abstract or you want to see what the failure looks like in practice.
+
+## 1. Trace every option end-to-end — no silent no-ops
+
+The single most common Codex finding (~20 occurrences): a flag, config field, or env var is accepted but silently ignored on some code path. `--storage-state` validated at startup but dropped by the VS Code/extension/CDP context factories; `--mobile` accepted with `remoteEndpoint`/`cdpLaunch`/`--extension` where context options are never applied; a configurable timeout that the SDK's own default overrides; a progress token forwarded but notifications never bridged through the proxy backend.
+
+If your change adds or touches any option, setting, or env var:
+
+- Enumerate **every** consumer path: launch modes (persistent, `--isolated`, `remoteEndpoint`, `cdpEndpoint`, `cdpLaunch`, `--extension`, `--vscode`), transports (stdio, HTTP), and the proxy backend. Grep for where the value is read.
+- For each path, the option must be either **applied** or **rejected with a clear error at startup**. "Accepted but ignored" is never acceptable — the user believes they got the behavior (e.g. runs an "authenticated" audit that is actually anonymous).
+- Validate against the **merged** config (CLI + config file + env), not just `cliOptions` — Codex caught mobile validation that only inspected the CLI flag while the config file smuggled in a CDP endpoint.
+- Check the value is honored at runtime too: does a later runtime update (e.g. `browser_default_timeout`) actually reach the code that reads the config snapshot?
+- Env var parsing: a present-but-blank value must not become `0`/`{}` and change semantics (blank `PING_TIMEOUT` disabled the heartbeat entirely). Values containing commas/colons must survive parsing (comma-splitting broke comma-valued headers).
+- Consistency between what you advertise and what you enforce: the server printed a `0.0.0.0` URL that its own Host-header allowlist then rejected with 403.
+
+## 2. Validate inputs before side effects
+
+Codex repeatedly flagged validation that happens *after* navigation, page mutation, or crawl start — so bad input destructively alters state or produces a completed-looking report:
+
+- Validate all tool arguments (rule IDs, URLs, selectors, files) **before** navigating, reloading, changing viewport/media/zoom, or starting a crawl. A `finally` that restores emulation cannot restore form or application state lost to a reload.
+- Reject explicitly-empty inputs rather than coercing them to defaults: empty `--input-file` must not become `{}` and run a default invocation; `withRules: []` must not silently fall back to scanning everything.
+- Constrain numeric schemas fully: positive **and** integer (`clickCount: 1.5` performed one click while reporting 1.5). Test the boundary values.
+- An invalid argument must reject the call — not be converted into per-page "errors" while the tool still writes a completed report.
+
+## 3. Never report success for work not performed
+
+A "clean" result must be distinguishable from "nothing was evaluated":
+
+- If every element ref went stale, every navigation failed, or annotation markers were hidden by page CSS, do **not** return "0 findings / no issues detected". Fail, retry, or prominently report what could not be evaluated.
+- Structured output: a count that was never collected must be `null`/omitted, not `0` — consumers can't tell "uncollected" from "genuinely clean".
+- If you count something as done (marked, scanned, downloaded), verify the artifact actually exists/is visible at response time. Codex found responses advertising file paths that eviction had already deleted, and screenshots "marked" whose annotations were clipped, off-canvas, or painted over.
+
+## 4. Sanitizers, truncators, and parsers: enumerate paths and attack the boundaries
+
+The data-URL truncation work drew 30 findings over two PRs — the largest cluster. When you write anything that filters/truncates/rewrites text in output:
+
+- **Enumerate every output path** that can carry the data: snapshot body, page/tab URL line, page title, console messages (both the snapshot copy and the dedicated tool), network request URLs *and query params*, modal-dialog descriptions, `browser_find` snippets, downloads. Sanitizing one path while five others leak defeats the purpose.
+- **Try to bypass your own matcher**: uppercase/mixed-case scheme, percent-encoded forms (`data%3A`, `%2C`), mixed encoding, wrappers (quotes, `url(...)`, JSON), Unicode case-mapping offset shifts, embedding inside another URL's query parameter.
+- **Try to corrupt ordinary text**: does the substring match rewrite `metadata:text,abc` or prose like `data: total, average`? Anchor to real token boundaries.
+- **Consume completely, preserve the rest**: partial consumption left payload tails after the ellipsis; over-consumption swallowed closing quotes, `[ref=...]` markers, query params, and fragments — breaking follow-up element targeting. Whatever follows the matched region must survive byte-for-byte.
+- Write unit tests for each bypass/corruption case you considered. Codex re-reviewed after every fix commit and kept finding fresh bypasses; a test corpus is the only way to stay ahead.
+
+## 5. Async, timers, cancellation, and shared state
+
+- Every `setTimeout` used in a `Promise.race` must be cleared when the other branch wins — the losing timer otherwise accumulates per iteration (one leaked timer every 3s per HTTP session).
+- Abort/cancellation signals must be **raced against** the pending I/O, not checked before/after it — and re-checked after any `await`, because an already-fired abort event is not replayed.
+- Never `process.exit()` while async cleanup (context disposal, trace finalization) is still running — await it.
+- Cleanup must run on **failure** paths too: a spawned CDP child process must be killed when `browser.newContext()` rejects, not only on success.
+- Shared mutable state across overlapping calls: an unconditional `pop()` in `finally` corrupts a stack when calls finish out of order — use per-call tokens or `AsyncLocalStorage`. Anything keyed on "the newest/current entry" is suspect.
+- Anything that deletes files (eviction, cleanup) must account for in-flight producers: active traces, pending downloads (including from already-closed tabs), sibling sessions in HTTP mode, and **other processes** sharing a temp root. Ask: "what is being written *right now* that my delete walk can see?"
+- If tabs/pages are involved: does your state go stale when a background tab changes, when bfcache/history traversal changes the URL without lifecycle events, or when the page rerenders after a snapshot?
+
+## 6. Enforce caps and limits exactly
+
+- Chunked loops must respect the remaining budget on the final chunk (`maxElements: 51` analyzed 100; `maxElements: 1` analyzed 49 extra).
+- Apply filters **before** consuming the budget: slicing raw refs let hidden elements exhaust the cap so visible content was never audited.
+- Test a cap value that is not a multiple of your chunk size, and cap+1.
+
+## 7. Generated code and structured output must be valid
+
+- Any "Ran Playwright code" snippet must be replayable JavaScript: quote object keys that aren't identifiers (`{ 'text/plain': ... }`), keep the `(element) =>` parameter for locator-scoped expressions, don't emit a quoted string where a function is expected.
+- Output embedded in a YAML/markdown fence must keep the fence parseable — a bare notice line inside the ```yaml fence made large snapshots invalid YAML.
+- Don't `eval` in the page when Playwright can pass the function through — strict-CSP pages (`script-src` without `unsafe-eval`) break otherwise. Don't call values just because `typeof === 'function'` (`window.open`!); decide function-vs-expression from the source form.
+
+## 8. DOM and accessibility heuristics: the recurring edge-case set
+
+Every a11y heuristic PR (screen-reader audit, keyboard audit, annotations) got flagged for the same environments. When writing or changing any in-page heuristic, walk this list:
+
+- **Shadow DOM** (labels/text in shadow roots; Axe selector paths through shadow boundaries)
+- **Iframes** (aria-hidden does not cross the boundary via `closest()`; direction/metrics must come from the child document)
+- **aria-hidden**: case-insensitive values (`"TRUE"`), inheritance, hidden elements consuming analysis budget
+- **Visibility subtleties**: a `visibility:hidden` root with a `visibility:visible` descendant still renders text; `opacity:0` on an ancestor hides painted children; hit-testing (`elementFromPoint`) is not visual occlusion — transparent overlays win hit-tests, `pointer-events:none` overlays lose them
+- **Off-canvas/clipped** elements: nonzero rects that never appear in a screenshot; `getBoundingClientRect()` ignores ancestor `overflow`/`clip-path` clipping; CSS zoom/transform scales rect coordinates
+- **Top layer**: `<dialog>`, popover, fullscreen render above anything appended to `body`
+- **Elements without text nodes**: `<input type="submit" value=...>` has a visible label but no child text
+- **Snapshot parsing**: Playwright YAML-quotes keys whose accessible name contains `: `, `#`, braces — a regex that misses the quoted form silently drops the control
+- **Normalize before comparing**: relative vs absolute `href`s are the same destination; raw attribute comparison creates false "different target" findings
+- **Injected UI** must survive the page: unique per-scan IDs (the page may already use your ID), style isolation against author CSS, animations frozen between measurement and capture
+- Measure the spec's semantics, not a proxy: "inline" for WCAG target-size means *in a sentence*, not `display === 'inline'`; disabled controls aren't pointer targets.
+
+False positives matter as much as false negatives — several findings were "this reports a violation a screen-reader user would never encounter". When you deliberately accept a detection ceiling, document it (the owner rejected several findings with measurements; that's a valid outcome, but a *decided* one).
+
+## 9. Refactors and dependency bumps: don't narrow behavior silently
+
+- After a refactor, diff the *behavior*, not just the code: "refresh all tabs" quietly became "refresh current tab"; SHA-256 fingerprints became a 32-bit FNV hash with demonstrated collisions; forcing `noDefaults` for **all** CDP sessions removed download/focus/media defaults with no opt-out.
+- **Lockfile diffs are review surface.** Twice, a regenerated `package-lock.json` dropped `libc` fields from native optional deps (npm 10 vs 11), making `npm ci` install incompatible glibc/musl binaries. Also check for version splits (`playwright` bumped while `@playwright/test` lagged, nesting a duplicate runtime). Don't ship unrelated lockfile rewrites inside a focused change.
+- Never change `engines.node` (or any published contract: package name, binary name, tool names, report fields) as a side effect of an unrelated change.
+- ESM/CJS interop: use default-import + destructure for CommonJS bundles (`playwright-core/lib/...`); named ESM imports from CJS rely on lexer heuristics.
+- If a consumed field/behavior was removed or renamed, grep the whole repo for readers of the old name.
+
+## 10. CLI and process robustness
+
+- Error paths must honor the output contract: `--output json` must emit JSON on failure too (wrap as an `isError` payload), not plain stderr text.
+- Handle `EPIPE` on stdout so `list-tools | head` doesn't crash with a stack trace.
+- Commander: variadic options swallow following subcommands (`--cdp-header X interactive` ate `interactive`); use repeatable single-value options with an accumulator.
+- Exit codes and cleanup ordering (see §5 on `process.exit`).
+
+## 11. Docs and contract sync
+
+AGENTS.md requires README updates for user-facing changes, and Codex enforces it:
+
+- Grep `README.md`, `SKILL.md`, and `openwiki/` for every flag, field, tool output line, or behavior you changed. A report field you renamed (`sessionLoss` → `sessionLosses`) leaves recipes reading an absent field.
+- Docs must describe what the code *does*: don't claim the harness builds first when it doesn't, or document an install command that also runs the full harness.
+- New user-visible output lines (e.g. `HTTP status:`) are part of the documented tool response format — document them.
+
+## 12. Tests and harness hygiene
+
+- Assertions must match the *actual* output format (the harness asserted an unquoted arrow function while the tool emits a quoted one; it referenced tool names that aren't exposed — `browser_network_request` vs `browser_network_requests`).
+- No fragile timeouts: budget for cold CI runners (loader startup blew a 15s budget), and prefer testing built entrypoints over `ts-node/esm` startup.
+- Nothing in the default test/coverage path may require uncommitted build output (`lib/`) without building first or saying so.
+- User-supplied regexes executed server-side need RE2 or bounding — `(a+)+$` hangs the event loop (the repo already uses RE2 for crawl exclusions; match that).
+
+## Final gate
+
+After fixing what the checklist surfaced, run and pass:
+
+```bash
+npm run lint    # oxlint --type-aware + tsc --noEmit
+npm test        # vitest
+npm run build   # tsc — required before test:mcp, which runs the built cli.js
+```
+
+Then re-read your full diff one last time with fresh eyes, asking the two questions Codex asks best:
+
+1. *"On which input, mode, or timing does this silently do the wrong thing?"*
+2. *"Does everything this change claims (in output, docs, and option surface) actually happen on every path?"*
+
+Only then push.

--- a/.claude/skills/pre-push-review/references/codex-findings-catalog.md
+++ b/.claude/skills/pre-push-review/references/codex-findings-catalog.md
@@ -1,0 +1,146 @@
+# Codex findings catalog
+
+Condensed catalog of the 179 inline review findings the Codex bot (`chatgpt-codex-connector`) left on this repo's PRs (#44–#148, reviewed 2026). Organized by the defect pattern each illustrates; each entry cites the PR so you can read the full thread. Severity was P2 unless marked P1.
+
+Codex's review behavior, for calibration: it re-reviews after every fix commit and escalates with fresh bypass evidence (PR #96 got 26 findings over 8 commits, #98 got 18); it reads cross-file context (CI workflows, factories, session log) rather than just the diff; and it reasons about concrete failure inputs, not style.
+
+## Contents
+
+1. [Silent no-op configuration](#1-silent-no-op-configuration)
+2. [Validation after side effects](#2-validation-after-side-effects)
+3. [Success reported for work not performed](#3-success-reported-for-work-not-performed)
+4. [Sanitizer/truncator bypasses and corruption](#4-sanitizertruncator-bypasses-and-corruption)
+5. [Races, timers, cancellation, shared state](#5-races-timers-cancellation-shared-state)
+6. [Caps and limits](#6-caps-and-limits)
+7. [Generated code and output validity](#7-generated-code-and-output-validity)
+8. [DOM/a11y heuristic edge cases](#8-domally-heuristic-edge-cases)
+9. [Refactor and dependency-bump regressions](#9-refactor-and-dependency-bump-regressions)
+10. [CLI robustness](#10-cli-robustness)
+11. [Docs drift](#11-docs-drift)
+12. [Test and harness hygiene](#12-test-and-harness-hygiene)
+
+## 1. Silent no-op configuration
+
+- `--vscode --storage-state`: startup guard passes, but the VS Code factory returns `browser.contexts()[0]` without `setStorageState` — authenticated scans silently run anonymously (P1, #148).
+- `--extension --isolated --storage-state`: guard validated `IsolatedContextFactory`, but the program then starts `ExtensionContextFactory`, which never applies `contextOptions` (#143).
+- Storage state rejected for `remoteEndpoint`/CDP+isolated even though those factories create fresh contexts and could forward it; and rejected for persistent/CDP contexts even though pinned Playwright has `BrowserContext.setStorageState()` (#143, #142).
+- `--mobile` silently ignored with `cdpLaunch`, `--extension`, and config-file `remoteEndpoint`/`cdpEndpoint`/env endpoints — validation only saw `cliOptions.cdpEndpoint`, not the merged config; `--mobile` + config-file `browserName: webkit` fell back to Chromium (#118, five findings).
+- `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` above 60000 had no effect: `server.ping()` was called without request options, so the SDK's default timeout fired first (#91).
+- `browser_default_timeout` updates `page.setDefaultTimeout` but snapshot/title guards hard-coded `context.config.timeouts.defaultTimeout` — user-extended timeouts ignored (#93).
+- Proxy backend forwarded `progressToken` but never bridged `onprogress` → `sendNotification`: progress silently dropped through the proxy (#50).
+- Extension relay never forwarded `PLAYWRIGHT_MCP_EXTENSION_TOKEN` as a query param, so token-based reconnect fell back to manual approval (#131).
+- Advertised vs enforced: with `--host 0.0.0.0` the server printed `http://0.0.0.0:<port>/mcp`, but its own Host-header allowlist rejected that Host with 403; earlier, wildcard binds never added interface IPs to `allowedHosts`, 403ing LAN/Docker clients (#73, #51).
+- Blank env value: `Number('')` is `0`, so a present-but-empty `PING_TIMEOUT` hit the `<= 0` branch and disabled the heartbeat entirely, contra README (#91).
+- `PLAYWRIGHT_MCP_CDP_HEADERS` split on commas broke comma-valued headers (`X-Forwarded-For: a, b`) (#101).
+
+## 2. Validation after side effects
+
+- Unknown `withRules`/`disableRules` IDs validated only after navigation; per-page catch turned the error into page failures, so `provided`-strategy audits visited every URL, marked all errored, and wrote a completed report instead of rejecting (#145).
+- Same in `scan_page_matrix`: rule validation ran after viewport/media/zoom mutation and possible reload; `finally` restores emulation but not form/app state lost to the reload (#145).
+- Empty `--input-file` → `''` parsed as `{}` → a default tool invocation ran instead of failing fast (#44).
+- `withRules: []` treated as omitted, silently scanning the full tag set (#145).
+- `clickCount` accepted 0/negative/fractional; after `.min(1)` was added, `1.5` still performed one click while reporting 1.5 — needed `.int()` too (#105, two rounds).
+
+## 3. Success reported for work not performed
+
+- When every snapshot ref went stale, `audit_screen_reader` returned `Findings: 0` / "No screen-reader-level issues detected" with `resolvedCount` zero — an unevaluated page presented as clean (#145).
+- `includeIncomplete: false` suppressed detail blocks but the summary still printed `Incomplete: N`; conversely `totalIncomplete: 0` was emitted when collection was disabled — uncollected indistinguishable from clean (#141).
+- Annotation layer: page CSS could hide the entire injected overlay while `marked` still counted every node; labels clipped by `overflow:hidden` on small elements; markers for off-canvas elements never appear in the PNG yet count as marked (#142).
+- Completed download reported as `Downloaded file ... to <path>` after eviction had already unlinked the file (#98).
+- Session-loss detection: skipped after failed navigations, so the *next* successful URL was blamed; redirect target not reported (`sessionLoss.url` kept the requested URL) (#143).
+
+## 4. Sanitizer/truncator bypasses and corruption
+
+PR #96 (data-URL truncation, 26 findings) and #95 (4 findings) — the canonical cluster. Grouped:
+
+**Unsanitized output paths**: page/tab URL line; page `<title>`; `browser_console_messages` tool output (only the snapshot copy was sanitized); modal-dialog descriptions (the `modalStates` branch never reached the sanitized renderer); network request *query params* (`?src=data:...` didn't start with `data:`); `browser_find` snippets bypassed `truncateDataUrls` entirely (#95, #96, #111).
+
+**Matcher bypasses**: uppercase `DATA:`; percent-encoded `data%3A` via URLSearchParams; mixed encoding (`base64%2C`); encoded metadata (`text%2Fhtml`); encoded wrapper prefix (`%22data%3A...`); Unicode case-mapping length shifts (`İ`) desyncing lowercase-search offsets; escaped spaces in media params rejected as invalid so nothing truncated (#96).
+
+**Partial consumption (payload leaks)**: scan stopped at `<` for raw SVG/HTML payloads and appended the rest unchanged; `&` inside a raw HTML payload treated as query separator; huge media-type parameters copied wholesale before the ellipsis; `secret:1<tail>` colon treated as source-location suffix (#95, #96).
+
+**Over-consumption (output corruption)**: closing quote and `[ref=e1]` swallowed, breaking follow-up element targeting; `#fragment` consumed as payload; console `@ file:line` suffix dropped; `%3E`-ending payloads never "complete" so trailing context eaten; nested encoded URL's `%26id%3D123` params dropped (#96).
+
+**False positives on ordinary text**: `metadata:text,abc` rewritten because the substring matched; prose `data: total, average` treated as a data URL; `?type=data:text/html;base64&tags=a,b` corrupted by accepting the *next* parameter's comma as delimiter (#95, #96).
+
+## 5. Races, timers, cancellation, shared state
+
+- Heartbeat `Promise.race`: losing `setTimeout` never cleared — one leaked timer every 3s per HTTP session (#91).
+- Wedged CDP page: after `captureSnapshot()`'s title read timed out, the all-tabs refresh immediately retried `updateTitle()` on the same tab, doubling the stall (#93).
+- Abort signals: profile-discovery I/O merely *checked* the signal afterwards — an abort during `readdir` left context creation hung; an already-fired abort event is not replayed by a listener registered later (#136, two findings).
+- Extension approval: protocol v2 opens the socket only after the user clicks Allow, but a 5s race timed out normal first-time approval (P1, #131).
+- Interactive REPL called `process.exit(0)` before async `serverClosed()` disposal finished (#55).
+- CDP child process left running when `browser.newContext()` rejected — cleanup existed only on the success path (#142).
+- Running-tool stack: unconditional `pop()` in `finally` corrupted attribution when overlapping calls finished out of order; the first fix still read "newest entry" and was re-flagged; final fix used `AsyncLocalStorage` (#98, two rounds).
+- Output eviction (`--output-max-size`, 13 race findings in #98): deleted a tool's own just-written screenshots before its response returned; active trace files mid-`tracing.stop()`; session-log `*.snapshot.yml` siblings of the protected `session.md`; pending downloads (including from already-closed tabs, and completed ones not yet reported); cross-session in HTTP mode (shared output dir, per-context protection was needed); cross-process via the shared `/tmp` fallback root (pid-scoping was needed); eviction not serialized with overlapping tools (a gate was needed).
+- MCP HTTP init: 5s fallback timer fired on idle sessions, permanently initializing the backend with `[]` roots; any session GET marked the transport initialized before SSE validation accepted it (#109).
+- Seed-tab cleanup: two overlapping `createTarget` calls both claimed the same seed tab; URL-prefix matching closed *another relay's* connect page; `_knownTabs` URLs go stale (no `onUpdated` listener), so a navigated former seed tab — now a real page — was closed (P1, #133).
+- Stale tab state: `browser_navigate_back` / bfcache traversal changes the URL without a `response` event, so the rendered `HTTP status:` line showed the previous page's 402/500 (#110, #111); background tabs' titles went stale once `finish()` refreshed only the current tab (#93).
+- Download listener used the 5s op timeout while navigation runs 60s — late-starting downloads made `browser_navigate` report an error though the download succeeded (#136).
+- Annotations: animations left enabled between measure and capture, so markers drifted (#142).
+
+## 6. Caps and limits
+
+- `maxElements` not enforced on the final 50-element chunk: `51` analyzed 100, `1` analyzed 50 (#146, re-flagged in #145).
+- Hidden (`aria-hidden`) refs consumed the analysis budget before filtering — 400 hidden refs meant zero visible elements audited (#146).
+- Serial 1s timeout waits per stale ref: default audit could stall ~400s, max ~2000s (#146).
+- `browser_find`: per-match `ancestorIndices` scanned backward through the whole tree — O(n²) on nested matches (#118).
+- User-supplied regex run with backtracking `RegExp` — `(a+)+$` blocks the event loop; repo precedent is RE2 (#111).
+
+## 7. Generated code and output validity
+
+- `browser_drop` data with MIME keys emitted `{ data: { text/plain: 'hello' } }` — invalid JS in the repro snippet (#117).
+- Locator-scoped bare expression emitted `locator.evaluate('() => (element.textContent)')` — replaying fails, `element` undefined (#117).
+- In-page `eval` for expression support: CSP without `unsafe-eval` broke even `() => document.title` (P1 regression, #126, first raised #117); `typeof value === 'function'` auto-invoked `window.open`/`el.click` (Illegal invocation) (#126); direct `eval` shadowed page globals (`() => result` hit the wrapper's TDZ const) (#126); `(${expression})` rejected trailing semicolons (#126).
+- ARIA compression appended its notice as a bare line inside the ```yaml fence — invalid YAML for parsing clients (#107).
+- Harness assertions expected the unquoted arrow-function form while the tool emits `javascript.quote`d code (#120).
+
+## 8. DOM/a11y heuristic edge cases
+
+From the screen-reader audit (#146/#145/#148), keyboard audit (#144), and annotations (#142):
+
+- **Shadow DOM**: visible label in shadow root → `visibleText: null`, check skipped; Axe shadow selector paths misclassified as iframes (#146, #142).
+- **Iframes**: child-doc elements can't reach the embedding `aria-hidden` iframe via `closest()`; iframe-root sibling direction measured from the outer document (#146).
+- **aria-hidden**: `"TRUE"` missed by case-sensitive selector (#145).
+- **Visibility**: `visibility:hidden` root + `visibility:visible` descendant still renders text — root short-circuit wrong (#148); `opacity:0` element's text counted as "visible" for label-in-name (#145); `opacity:0` *ancestor* not checked before accepting a painted child in `paintsOver` (#144); hit-test ≠ visual occlusion — transparent overlay wins `elementFromPoint` (false "obscured"), `pointer-events:none` opaque overlay loses it (false pass) (#144).
+- **Geometry**: `getBoundingClientRect()` ignores ancestor `overflow`/`clip-path` clipping (rejected as a documented ceiling after measurement) and returns scaled offsets under CSS zoom/transform that get re-applied doubled (#144, #142); off-canvas elements have nonzero rects but never appear in screenshots (#142); top layer (`<dialog>`/popover/fullscreen) paints above a `body`-appended overlay (#142).
+- **No-text-node labels**: `<input type="submit" value="Send" aria-label="...">` bypassed label-in-name (#146).
+- **Snapshot parsing**: YAML-quoted keys (`'button "Warning: Delete" [ref=e1]'`) silently dropped by the role regex, mis-parenting descendants (#146, re-flagged #145).
+- **Normalize before comparing**: relative vs absolute same-destination `href`s flagged as "different targets"; element refs used as "targets" made repeated Save buttons always ambiguous (#146).
+- **Spec semantics vs proxy**: inline exception is "in a sentence", not `display === 'inline'`; sentence detection must walk inline ancestors (`<strong><a>` wrapper); disabled controls aren't spacing neighbors; undersized-neighbor check needs box-vs-circle, not center distance; contenteditable is a target and must be measured for obscuration (#144).
+- **Role coverage**: `option` missing from named-roles; filename-alt-text check ran on links, not just images; treegrid rows and range widgets (`separator`, `scrollbar`) and `[cursor=pointer]` nodes unprotected from compression (#146, #107).
+- **Injected UI**: fixed `id` collides with page's own element (cleanup removed the page's node); inline styles overridable by author CSS `!important` (#142).
+- **Session-loss cookie logic** (#142/#143/#148): track by name+domain+path, not name; snapshot the baseline once at crawl start (cookies minted mid-crawl aren't baseline); extend scope as URLs are discovered; keep monitoring after the first loss (list, not single); exclude cookies expiring at their own stated expiry; check after failed navigations too.
+
+## 9. Refactor and dependency-bump regressions
+
+- `package-lock.json` regenerated with npm 10 vs 11 dropped `libc` fields from native optional deps (`@rolldown/binding-*`, Oxlint, Lightning CSS) — `npm ci` installs incompatible glibc/musl binaries. Happened twice (#87, #139); the second time bundled into an unrelated one-line fix.
+- `engines.node` raised to `>=24` inside a test-only PR — `EBADENGINE` for Node 18/20/22 consumers (P1, #63).
+- `playwright`/`playwright-core` bumped to 1.62-alpha while `@playwright/test` stayed 1.61 — nested duplicate runtime, CLI/browser revision mismatch (#124).
+- `finish()` narrowed "refresh all tabs" to "refresh current tab" — background tab titles went stale (#93).
+- SHA-256 dedup fingerprint replaced with 32-bit FNV-1a; Codex produced two colliding HTML strings, showing occurrences silently skipped (#80).
+- `noDefaults` forced for **all** CDP attach sessions removed `acceptDownloads`/focus/media defaults with no opt-out (#120); the behavior change also wasn't documented (#121).
+- Named ESM imports from the CJS `playwright-core/lib/coreBundle` — works only via lexer heuristics; use default import + destructure (P1, #76).
+- `SKILL.md` recipe still read the removed singular `sessionLoss` field after the rename to `sessionLosses` (#148).
+
+## 10. CLI robustness
+
+- `call --output json` emitted plain stderr text when `callTool` threw — JSON mode must wrap failures as `isError` payloads (#44).
+- `list-tools | head` crashed with unhandled `EPIPE` (#44).
+- Commander variadic `--cdp-header` consumed the following `interactive` subcommand as a header value (#101).
+
+## 11. Docs drift
+
+- README not updated for: new `HTTP status:` response line (#110); CDP `noDefaults` behavior change (#121). AGENTS.md mandates README sync and Codex checks it.
+- OpenWiki claims vs reality (#127): quickstart said `install chromium` but the default channel is branded `chrome`; testing doc claimed the harness builds first (it runs whatever `lib/` exists); runbook's "install browsers" command actually ran the whole harness; browser-backed tests silently skip without the install.
+- Coverage/harness scripts requiring uncommitted `lib/` build output on a clean checkout without saying so (#126, #127).
+
+## 12. Test and harness hygiene
+
+- Harness tests referenced non-exposed tool names (`browser_network_request`, `browser_drop`) — coverage verification fails (#120).
+- Assertions didn't match actual generated-code format (quoted vs unquoted function) (#120).
+- 15s `runCLI` abort on `ts-node/esm` startup → false `ETIMEDOUT` on cold CI runners; test the built entrypoint or relax the budget (#55).
+
+## Owner-rejected findings (calibration)
+
+Not every finding was accepted. The owner rejected some with measurements and documented them as ceilings: ref-less exposed nodes (decorative-dominated), ancestor-clipping detection (4 false positives per true positive), visual-occlusion false-negative half, auth-cookie classification (unimplementable without silent failures), experimental-rule tags mapping to real success criteria (README reworded instead). The lesson: a deliberate, measured, *documented* limitation is a valid answer to a checklist item — an unexamined one is not.

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ coverage/
 
 .DS_Store
 .idea/
-.claude/
+# Ignore local Claude state, but track repository-owned skills
+.claude/*
+!.claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Reuse existing helpers before introducing new abstractions.
 - Prefer targeted validation first, then broader checks if needed.
 - When touching build, lint, or test behavior, run the relevant npm script before finalizing.
+- Before committing or pushing, self-review your diff against `.claude/skills/pre-push-review/SKILL.md` — a checklist of the recurring defect patterns automated PR review keeps finding in this repo.
 - Avoid introducing ignored or generated artifacts into version control; `.gitignore` already excludes `lib/`, `coverage/`, Playwright reports, and similar outputs.
 
 <!-- OPENWIKI:START -->


### PR DESCRIPTION
Analyzed all 179 inline review comments the Codex bot left across PRs
#44-#148 and distilled the recurring defect patterns into a project
skill at .claude/skills/pre-push-review/. The SKILL.md is a pre-push
self-review checklist (silent no-op config paths, validation before
side effects, sanitizer bypass/corruption testing, race and timer
hygiene, cap enforcement, generated-code validity, DOM/a11y edge cases,
dep-bump regressions, CLI robustness, docs sync, harness hygiene), and
references/codex-findings-catalog.md preserves the concrete findings
with PR citations. AGENTS.md now points agents at the checklist before
they commit or push.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013TMyP7hpSb3BC7jQ3hTexF