### PR TITLE
feat(screenshot): add webp output format for browser_take_screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Evaluate a JavaScript expression on the page, or on a specific element when a `r
 
 #### `browser_take_screenshot`
 Take a screenshot of the current page.
-- Parameters: `filename` (optional), `type` (`png` or `jpeg`), `scale` (`css` or `device`, default `css`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
+- Parameters: `filename` (optional), `type` (`png`, `jpeg`, or `webp`), `scale` (`css` or `device`, default `css`), `fullPage` (optional), `element`/`ref` pair (for element screenshots)
 - `scale: device` captures a high-resolution screenshot using device pixels (accounts for the device pixel ratio); `scale: css` keeps the image sized in CSS pixels.
 
 #### `browser_pdf_save`

--- a/SKILL.md
+++ b/SKILL.md
@@ -195,7 +195,7 @@ These tools are always available and work in the interactive REPL.
 | `browser_close` | Close the page |
 | `browser_resize` | Resize window: `{"width": 1280, "height": 720}` |
 | `browser_snapshot` | Capture accessibility snapshot |
-| `browser_take_screenshot` | Take screenshot (png/jpeg, fullPage option) |
+| `browser_take_screenshot` | Take screenshot (png/jpeg/webp, fullPage option) |
 | `browser_wait_for` | Wait for text/time: `{"text": "loaded"}` or `{"time": 5}` |
 
 ### Interaction

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -23,9 +23,9 @@ import { generateLocator } from './utils.js';
 import type * as playwright from 'playwright';
 
 const screenshotSchema = z.object({
-  type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
+  type: z.enum(['png', 'jpeg', 'webp']).default('png').describe('Image format for the screenshot. Default is png.'),
   scale: z.enum(['css', 'device']).default('css').describe(`Image resolution scale. 'css' produces a screenshot sized in CSS pixels (smaller, consistent across devices). 'device' produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.`),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg|webp}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
@@ -81,7 +81,7 @@ const screenshot = defineTabTool({
     // Never return large images to LLM, saving them to the file system is enough.
     if (!params.fullPage) {
       response.addImage({
-        contentType: fileType === 'png' ? 'image/png' : 'image/jpeg',
+        contentType: `image/${fileType}`,
         data: buffer
       });
     }

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -74,4 +74,33 @@ describe('Screenshot Tools', () => {
 
     expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ scale: 'device' }));
   });
+
+  it('should default the image format to png', () => {
+    const params = screenshotTool.schema.inputSchema.parse({});
+    expect(params.type).toBe('png');
+  });
+
+  it('should accept webp as an image format', () => {
+    const params = screenshotTool.schema.inputSchema.parse({ type: 'webp' });
+    expect(params.type).toBe('webp');
+  });
+
+  it('should reject an unsupported image format', () => {
+    expect(() => screenshotTool.schema.inputSchema.parse({ type: 'gif' })).toThrow();
+  });
+
+  it('should pass the webp type and a lossy quality through to page.screenshot', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ type: 'webp' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ type: 'webp', quality: 90 }));
+  });
+
+  it('should return the webp screenshot with an image/webp content type', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ type: 'webp' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    const image = response.images().find(i => i.contentType === 'image/webp');
+    expect(image).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Automated upstream-monitoring run against [microsoft/playwright](https://github.com/microsoft/playwright), focused on Playwright MCP changes. This PR unblocks and resolves [#123](https://github.com/JustasMonkev/mcp-accessibility-scanner/issues/123).

## Upstream change

- **PR:** [microsoft/playwright#41152 — feat(screenshot): add webp output format](https://github.com/microsoft/playwright/pull/41152)
- **Commit:** [`f3114b3`](https://github.com/microsoft/playwright/commit/f3114b3e9f1aea9f0c123551ebf67ded08dddca2)

Upstream added `'webp'` as an output format to **both** the core screenshot API (`page.screenshot()` / `locator.screenshot()`) **and** the MCP `browser_take_screenshot` tool — the tool's `type` schema went from `z.enum(['png', 'jpeg'])` to `z.enum(['png', 'jpeg', 'webp'])`.

## Why it matters here

This repo mirrors that exact tool in [`src/tools/screenshot.ts`](https://github.com/JustasMonkev/mcp-accessibility-scanner/blob/main/src/tools/screenshot.ts). The tool surface had diverged: users of this MCP server could not request WebP screenshots even though upstream supports it.

## Why it was blocked — and why it's now unblocked

`#41152` is a **new Playwright core capability**, not just an MCP wrapper change, so mirroring the enum required the pinned Playwright to actually support `type: 'webp'`. Issue #123 was filed while the repo pinned `1.61.0`, where `page.screenshot({ type: 'webp' })` would both fail typecheck and throw at runtime.

The repo has since bumped to **`playwright` / `playwright-core` `1.62.0`** ([#151](https://github.com/JustasMonkev/mcp-accessibility-scanner/pull/151)). I verified the pinned `1.62.0` types declare `type?: "png"|"jpeg"|"webp"` on the screenshot options (and document webp quality semantics), so the mirror is now safe to land.

## Changes

- `src/tools/screenshot.ts`: add `webp` to the `type` enum and to the filename default hint (`{png|jpeg|webp}`); the returned image `contentType` now derives from the format directly (`image/${fileType}`), which is unchanged for `png`/`jpeg` and yields `image/webp` for webp. webp reuses the existing non-png `quality: 90` (lossy), matching jpeg handling.
- `README.md` / `SKILL.md`: document the new `webp` option on `browser_take_screenshot`.
- `tests/tools-screenshot.test.ts`: cover webp parsing, the type/quality passed through to `page.screenshot`, the `image/webp` content type, the `png` default, and rejection of an unsupported format.

Change is minimal and gated on the version bump, exactly as proposed in #123.

## Validation

- `npm run lint` (oxlint --type-aware + `tsc --noEmit`) — clean
- `npm run build` — clean
- `npm test` — screenshot suite passes (10/10). The only failures in the full run are pre-existing `tools-auditScreenReader.test.ts` cases that require a real Chromium binary (`chromium.launch()`), unavailable in this environment and unrelated to this change.

Resolves #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uUMuUp2u1khWseCLuxAy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018uUMuUp2u1khWseCLuxAy3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebP support for browser screenshots.
  * Screenshot responses now use the appropriate image format.

* **Documentation**
  * Updated screenshot documentation to include WebP alongside PNG and JPEG.

* **Tests**
  * Added coverage for WebP requests, quality settings, default PNG behavior, and format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->