### PR TITLE
feat: sync browser tools with upstream Playwright MCP (#116)

### DIFF
--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -62,10 +62,16 @@ const tests = [
   }),
 
   test('browser_evaluate', async () => {
-    await navigate('<title>Evaluate</title><h1 id="answer">OK</h1>');
+    const snapshot = await navigate('<title>Evaluate</title><h1 id="answer">OK</h1>');
     const result = await callTool('browser_evaluate', { function: '() => 2 + 2' });
     assertText(result, /\b4\b/);
+    // Bare expressions are wrapped into a function, on the page and on an element.
+    assertText(await callTool('browser_evaluate', { function: 'document.title' }), /Evaluate/);
+    assertText(await callTool('browser_evaluate', { function: '{ id: document.getElementById("answer").id }' }), /"id":\s*"answer"/);
+    const ref = refFor(snapshot, 'OK');
+    assertText(await callTool('browser_evaluate', { function: 'element.textContent', element: 'Answer heading', ref }), /OK/);
   }),
+
 
   test('browser_resize', async () => {
     await navigate('<title>Resize</title><h1>Resize</h1>');
@@ -154,6 +160,26 @@ const tests = [
     await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-json` });
     const result = await callTool('browser_network_requests', {});
     assertText(result, /network-json/);
+    assertText(result, /^\[1\] \[GET\]/m);
+  }),
+
+  test('browser_network_request', async () => {
+    await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-json` });
+    const list = await callTool('browser_network_requests', {});
+    const result = await callTool('browser_network_request', { index: indexFor(resultText(list), /\/network-json/) });
+    assertText(result, /#### Request headers/);
+    assertText(result, /x-mcp-fixture: network-json/);
+    assertText(result, /#### Response\n\[200\] OK/);
+    assertText(result, /\{"ok":true\}/);
+
+    // An out-of-range index reports the usable range instead of a stack trace.
+    await assertToolError('browser_network_request', { index: 999 }, /No network request with index 999/);
+
+    // A real binary payload must be summarised, never rendered as text.
+    await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-png` });
+    const pngList = await callTool('browser_network_requests', {});
+    const png = await callTool('browser_network_request', { index: indexFor(resultText(pngList), /\/network-png\.png/) });
+    assertText(png, /<binary data, \d+ bytes, image\/png>/);
   }),
 
   test('browser_take_screenshot', async () => {
@@ -189,6 +215,26 @@ const tests = [
       endElement: 'Drop target',
       endRef,
     });
+  }),
+
+  test('browser_drop', async () => {
+    const snapshot = await navigate([
+      '<title>Drop</title>',
+      '<div role="region" aria-label="Drop zone" style="width:160px;height:60px;background:#cfa" ',
+      'ondragover="event.preventDefault()" ',
+      'ondrop="event.preventDefault();document.body.dataset.dropped=event.dataTransfer.getData(\'text/plain\')">Drop here</div>',
+    ].join(''));
+    const ref = refFor(snapshot, 'Drop zone');
+    await callTool('browser_drop', {
+      element: 'Drop zone',
+      ref,
+      data: { 'text/plain': 'dropped-payload' },
+    });
+    const result = await callTool('browser_evaluate', { function: '() => document.body.dataset.dropped' });
+    assertText(result, /dropped-payload/);
+
+    // Neither paths nor data means there is nothing to drop.
+    await assertToolError('browser_drop', { element: 'Drop zone', ref }, /Provide "paths", "data" or both/);
   }),
 
   test('browser_hover', async () => {
@@ -871,6 +917,16 @@ function refFor(snapshotText, label) {
   return match[1];
 }
 
+// Picks the number browser_network_requests printed for the first request whose
+// line matches, so browser_network_request can be called with a real index.
+function indexFor(listText, pattern) {
+  const line = listText.split('\n').find(candidate => /^\[\d+\] /.test(candidate) && pattern.test(candidate));
+  const match = line?.match(/^\[(\d+)\]/);
+  if (!match)
+    throw new Error(`Could not find a request matching ${pattern} in listing:\n${listText.slice(0, 4000)}`);
+  return Number(match[1]);
+}
+
 function appendSummary(tool, status, detail, logPath) {
   const cleanDetail = String(detail || '').replace(/\s+/g, ' ').slice(0, 300);
   fs.appendFileSync(summaryPath, `${tool}\t${status}\t${cleanDetail}\t${logPath}\n`);
@@ -967,6 +1023,18 @@ function startFixtureServer() {
         'x-mcp-fixture': 'network-json',
       });
       response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (request.url === '/network-png') {
+      response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      response.end('<!doctype html><html><head><title>Network PNG</title></head><body><img src="/network-png.png" alt="pixel"></body></html>');
+      return;
+    }
+    if (request.url === '/network-png.png') {
+      response.writeHead(200, { 'content-type': 'image/png' });
+      // A 1x1 transparent PNG: real binary bytes, so the tool must not try to
+      // render it as text.
+      response.end(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', 'base64'));
       return;
     }
     response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });

--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -72,7 +72,6 @@ const tests = [
     assertText(await callTool('browser_evaluate', { function: 'element.textContent', element: 'Answer heading', ref }), /OK/);
   }),
 
-
   test('browser_resize', async () => {
     await navigate('<title>Resize</title><h1>Resize</h1>');
     await callTool('browser_resize', { width: 640, height: 480 });

--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -175,6 +175,15 @@ const tests = [
     // An out-of-range index reports the usable range instead of a stack trace.
     await assertToolError('browser_network_request', { index: 999 }, /No network request with index 999/);
 
+    // Real Chromium header names must hit the redaction set: sign in so the
+    // next request carries a session cookie, then prove it is not echoed back.
+    await callTool('browser_navigate', { url: `${state.fixtureOrigin}/login` });
+    await callTool('browser_navigate', { url: `${state.fixtureOrigin}/secure` });
+    const secureList = await callTool('browser_network_requests', {});
+    const secure = await callTool('browser_network_request', { index: indexFor(resultText(secureList), /\/secure/) });
+    assertText(secure, /cookie: <redacted, \d+ characters>/);
+    assertNoText(secure, /mcp_session=granted/);
+
     // A real binary payload must be summarised, never rendered as text.
     await callTool('browser_navigate', { url: `${state.fixtureOrigin}/network-png` });
     const pngList = await callTool('browser_network_requests', {});

--- a/README.md
+++ b/README.md
@@ -504,6 +504,12 @@ Hover over element on page.
 Perform drag and drop between two elements.
 - Parameters: `startElement`, `startRef`, `endElement`, `endRef`
 
+#### `browser_drop`
+Simulate an external drag and drop of files or clipboard-like data onto an element, for testing drop zones that never see a drag start inside the page.
+- Parameters: `element`, `ref`, `paths` (optional array of absolute file paths), `data` (optional map of mime type to value, e.g. `{"text/plain": "hello"}`)
+- At least one of `paths` or `data` is required.
+- Fails if the target's `dragover` handler does not accept the payload.
+
 #### `browser_select_option`
 Select an option in a dropdown.
 - Parameters: `element`, `ref`, `values` (array)
@@ -519,6 +525,7 @@ Press a key on the keyboard.
 #### `browser_evaluate`
 Evaluate a JavaScript expression on the page, or on a specific element when a `ref` is provided. The function's return value is serialized back as the result.
 - Parameters: `function` (e.g., `() => document.title` or `(element) => element.textContent`), `element` (optional), `ref` (optional)
+- A bare expression is also accepted and is wrapped automatically: `document.title` behaves like `() => document.title`, and `element.textContent` behaves like `(element) => element.textContent` when a `ref` is provided.
 
 ### Screenshot & Visual Tools
 
@@ -559,8 +566,15 @@ Returns all console messages from the page.
 Large `data:` URL payloads in console messages are truncated to their media type prefix.
 
 #### `browser_network_requests`
-Returns all network requests since loading the page.
+Returns all network requests since loading the page, numbered so a single one can be inspected with `browser_network_request`.
 Large `data:` URL payloads in request URLs are truncated to their media type prefix.
+
+#### `browser_network_request`
+Returns the request headers, response headers and response body of one request from the `browser_network_requests` listing.
+- Parameters: `index` (the number shown in the listing, starting at 1)
+- The listing is reset on navigation, so re-run `browser_network_requests` before using an index from an earlier page.
+- Binary response bodies are reported as `<binary data, N bytes, mime/type>` rather than dumped; textual bodies over 20000 characters are truncated with a trailing note.
+- Headers are reported verbatim, including `cookie` and `authorization`.
 
 ### Utility Tools
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Simulate an external drag and drop of files or clipboard-like data onto an eleme
 - Parameters: `element`, `ref`, `paths` (optional array of absolute file paths), `data` (optional map of mime type to value, e.g. `{"text/plain": "hello"}`)
 - At least one of `paths` or `data` is required.
 - Fails if the target's `dragover` handler does not accept the payload.
+- `paths` are read from the filesystem of the machine running the server, exactly as `browser_file_upload` does, and a relative path resolves against the server's working directory. Unlike `browser_file_upload` this needs no file chooser to be open, so any page with a `dragover` handler is a valid target — treat it as a tool that can hand local file contents to the page.
 
 #### `browser_select_option`
 Select an option in a dropdown.
@@ -525,7 +526,9 @@ Press a key on the keyboard.
 #### `browser_evaluate`
 Evaluate a JavaScript expression on the page, or on a specific element when a `ref` is provided. The function's return value is serialized back as the result.
 - Parameters: `function` (e.g., `() => document.title` or `(element) => element.textContent`), `element` (optional), `ref` (optional)
-- A bare expression is also accepted and is wrapped automatically: `document.title` behaves like `() => document.title`, and `element.textContent` behaves like `(element) => element.textContent` when a `ref` is provided.
+- `element` and `ref` must be supplied together, or not at all; supplying one without the other is rejected.
+- A bare expression is also accepted and is wrapped automatically: `document.title` behaves like `() => document.title`, and, when `element` and `ref` are both given, `element.textContent` behaves like `(element) => element.textContent`. The parameter is always named `element`.
+- Whether the input is a function or an expression is decided from its source form, never from what it evaluates to, so an expression such as `window.open` is returned rather than called.
 
 ### Screenshot & Visual Tools
 
@@ -568,13 +571,18 @@ Large `data:` URL payloads in console messages are truncated to their media type
 #### `browser_network_requests`
 Returns all network requests since loading the page, numbered so a single one can be inspected with `browser_network_request`.
 Large `data:` URL payloads in request URLs are truncated to their media type prefix.
+When there is at least one request, a closing line points at `browser_network_request`.
 
 #### `browser_network_request`
-Returns the request headers, response headers and response body of one request from the `browser_network_requests` listing.
+Returns the request headers, request body, response headers and response body of one request from the `browser_network_requests` listing.
 - Parameters: `index` (the number shown in the listing, starting at 1)
-- The listing is reset on navigation, so re-run `browser_network_requests` before using an index from an earlier page.
-- Binary request and response bodies are reported as `<binary data, N bytes, mime/type>` rather than dumped; textual bodies over 20000 characters are truncated with a trailing note.
-- Credential-bearing headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-auth-token`) are reported as `<redacted, N characters>`, so their presence and size stay visible but the secret never reaches the transcript. All other headers are reported in full.
+- The listing is cleared by `browser_navigate` and when the tab closes; other navigations (link clicks, form submits, `history` calls) leave it in place and keep appending. Re-run `browser_network_requests` to get current indexes.
+- Credential-bearing headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-auth-token`) are reported as `<redacted, N characters>`, so their presence and size stay visible but the secret never reaches the transcript. All other headers are reported in full, one line each.
+- Binary request and response bodies are reported as `<binary data, N bytes, mime/type>` rather than dumped. The type decides: `text/*`, `+json`/`+xml` suffixes and known textual types are text; `image/`, `audio/`, `video/`, `font/`, `model/` and known binary types are binary; anything else (`multipart/form-data`, custom types, a missing type) is decided by inspecting the bytes.
+- Textual bodies are decoded using the charset in `content-type`, and are truncated at 20000 characters with a trailing note. The cap applies to the request body and the response body separately, so one call can return up to two truncated bodies.
+- Bodies are wrapped in a code fence, so page-controlled content cannot forge the report's own section headings.
+- A request that failed after its response arrived reports both the status and the failure.
+- Sections that could not be read are reported in place (`<headers unavailable: ...>`, `<body unavailable: ...>`) rather than failing the whole call; reads are bounded by the default timeout, so a still-streaming response cannot hang the tool.
 
 ### Utility Tools
 

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ Large `data:` URL payloads in request URLs are truncated to their media type pre
 Returns the request headers, response headers and response body of one request from the `browser_network_requests` listing.
 - Parameters: `index` (the number shown in the listing, starting at 1)
 - The listing is reset on navigation, so re-run `browser_network_requests` before using an index from an earlier page.
-- Binary response bodies are reported as `<binary data, N bytes, mime/type>` rather than dumped; textual bodies over 20000 characters are truncated with a trailing note.
-- Headers are reported verbatim, including `cookie` and `authorization`.
+- Binary request and response bodies are reported as `<binary data, N bytes, mime/type>` rather than dumped; textual bodies over 20000 characters are truncated with a trailing note.
+- Credential-bearing headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-auth-token`) are reported as `<redacted, N characters>`, so their presence and size stay visible but the secret never reaches the transcript. All other headers are reported in full.
 
 ### Utility Tools
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -207,7 +207,7 @@ These tools are always available and work in the interactive REPL.
 | `browser_press_key` | Press key: `{"key": "Enter"}` |
 | `browser_hover` | Hover over element |
 | `browser_drag` | Drag between elements |
-| `browser_drop` | Drop external files or data onto an element: `{"element": "Dropzone", "ref": "s1e7", "paths": ["/path/to/file"]}` |
+| `browser_drop` | Drop external files or data onto an element: `{"element": "Dropzone", "ref": "e7", "paths": ["/path/to/file"]}` (paths are read on the server host) |
 | `browser_select_option` | Select dropdown option |
 | `browser_fill_form` | Fill multiple form fields at once |
 | `browser_file_upload` | Upload files: `{"paths": ["/path/to/file"]}` |
@@ -228,7 +228,7 @@ These tools are always available and work in the interactive REPL.
 |------|-------------|
 | `browser_console_messages` | Get all console messages |
 | `browser_network_requests` | Get all network requests, numbered |
-| `browser_network_request` | Get headers and response body of one request: `{"index": 3}` |
+| `browser_network_request` | Get headers and bodies of one request: `{"index": 3}` (credential headers redacted, binary bodies summarised) |
 
 ### Optional Tools (require `--caps`)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -207,11 +207,12 @@ These tools are always available and work in the interactive REPL.
 | `browser_press_key` | Press key: `{"key": "Enter"}` |
 | `browser_hover` | Hover over element |
 | `browser_drag` | Drag between elements |
+| `browser_drop` | Drop external files or data onto an element: `{"element": "Dropzone", "ref": "s1e7", "paths": ["/path/to/file"]}` |
 | `browser_select_option` | Select dropdown option |
 | `browser_fill_form` | Fill multiple form fields at once |
 | `browser_file_upload` | Upload files: `{"paths": ["/path/to/file"]}` |
 | `browser_handle_dialog` | Handle browser dialog: `{"accept": true}` |
-| `browser_evaluate` | Run JavaScript on page |
+| `browser_evaluate` | Run JavaScript on page: a function or a bare expression such as `{"function": "document.title"}` |
 
 ### Tabs & Config
 
@@ -226,7 +227,8 @@ These tools are always available and work in the interactive REPL.
 | Tool | Description |
 |------|-------------|
 | `browser_console_messages` | Get all console messages |
-| `browser_network_requests` | Get all network requests |
+| `browser_network_requests` | Get all network requests, numbered |
+| `browser_network_request` | Get headers and response body of one request: `{"index": 3}` |
 
 ### Optional Tools (require `--caps`)
 

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -243,6 +243,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     return this._requests;
   }
 
+  // Playwright resolves `Request.allHeaders()` and `Response.body()` with no
+  // timeout of their own, so a still-streaming response would hang a tool call
+  // until the page closed. Callers outside this class need the same bound the
+  // page-state reads above use.
+  async withPageStateTimeout<T>(promise: Promise<T>, description: string): Promise<T> {
+    return this._withPageStateTimeout(promise, description);
+  }
+
   async captureSnapshot(): Promise<TabSnapshot> {
     let tabSnapshot: TabSnapshot | undefined;
     const modalStates = await this._raceAgainstModalStates(async () => {

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -39,6 +39,11 @@ const evaluate = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
+    // Half a pair used to fall back to page scope, so `element.textContent`
+    // with only a `ref` failed with a bare `element is not defined`.
+    if (!!params.ref !== !!params.element)
+      throw new Error('Provide both "element" and "ref" to evaluate against an element, or neither to evaluate against the page.');
+
     response.setIncludeSnapshot();
 
     const onElement = !!(params.ref && params.element);
@@ -68,20 +73,43 @@ const evaluate = defineTabTool({
 /**
  * `evaluate()` needs a function, but callers routinely pass a bare expression
  * such as `document.title`. Wrap anything that is not already a function form.
+ *
+ * The decision is made from the source form and never from the runtime type of
+ * the result: `window.open` is an expression that happens to evaluate to a
+ * function, and it must be returned rather than called.
  */
 export function toFunctionSource(source: string, onElement: boolean): string {
   if (isFunctionSource(source))
     return source;
+  // A trailing `;` would turn the expression into a statement.
+  const expression = source.replace(/\s*;+\s*$/, '');
+  if (!expression.trim())
+    throw new Error('The "function" argument is empty. Pass a function such as `() => document.title`, or an expression such as `document.title`.');
   // The parentheses keep an object literal such as `{ a: 1 }` from parsing as a
-  // block, and keep a comma expression from splitting into two arguments.
-  return onElement ? `(element) => (${source})` : `() => (${source})`;
+  // block and a comma expression from splitting into two arguments; the
+  // newlines keep a trailing `// comment` from swallowing the closing paren.
+  return onElement ? `(element) => (\n${expression}\n)` : `() => (\n${expression}\n)`;
 }
 
 function isFunctionSource(source: string): boolean {
-  const body = source.slice(skipLeadingTrivia(source));
-  if (/^(async\b\s*)?function\b/.test(body))
-    return true;
-  return hasArrowHead(body);
+  let body = source.slice(skipTrivia(source, 0));
+  for (;;) {
+    if (/^function\b/.test(body.slice(skipAsyncKeyword(body))))
+      return true;
+    if (hasArrowHead(body))
+      return true;
+    // `(() => 1)` and `(function () {})` are function literals inside grouping
+    // parentheses. Look inside before concluding this is an expression.
+    const inner = stripEnclosingParens(body);
+    if (inner === null)
+      return false;
+    body = inner.slice(skipTrivia(inner, 0));
+  }
+}
+
+function skipAsyncKeyword(source: string): number {
+  const keyword = /^async\b/.exec(source)?.[0];
+  return keyword ? skipTrivia(source, keyword.length) : 0;
 }
 
 /**
@@ -89,34 +117,69 @@ function isFunctionSource(source: string): boolean {
  * without matching a parenthesised expression such as `(a + b)`.
  */
 function hasArrowHead(source: string): boolean {
-  let offset = /^async\b\s*/.exec(source)?.[0].length ?? 0;
+  let offset = skipAsyncKeyword(source);
   if (source[offset] === '(') {
     const end = matchingParen(source, offset);
+    // The scanner does not model every parameter-list construct (regex literals
+    // and nested template substitutions among them). When the match cannot be
+    // found, treat the source as a function: passing a function through is the
+    // behaviour that predates expression support, and a wrongly wrapped
+    // function silently returns `undefined`, while a wrongly passed-through
+    // expression fails loudly.
     if (end === -1)
-      return false;
+      return true;
     offset = end + 1;
   } else {
-    const identifier = /^[A-Za-z_$][\w$]*/.exec(source.slice(offset))?.[0];
+    const identifier = /^[\p{ID_Start}$_][\p{ID_Continue}$]*/u.exec(source.slice(offset))?.[0];
     if (!identifier)
       return false;
     offset += identifier.length;
   }
-  offset += skipLeadingTrivia(source.slice(offset));
-  return source.startsWith('=>', offset);
+  return source.startsWith('=>', skipTrivia(source, offset));
+}
+
+function stripEnclosingParens(source: string): string | null {
+  if (source[0] !== '(')
+    return null;
+  const end = matchingParen(source, 0);
+  // Only a group that wraps the whole source: `(a) => a` closes early and its
+  // parentheses are a parameter list, not a group.
+  if (end === -1 || skipTrivia(source, end + 1) !== source.length)
+    return null;
+  return source.slice(1, end);
 }
 
 function matchingParen(source: string, start: number): number {
+  return matchingDelimiter(source, start, '(', ')');
+}
+
+/**
+ * Finds the delimiter closing the one at `start`, stepping over comments,
+ * strings, template substitutions and regular expression literals so that a
+ * bracket inside any of them is not counted.
+ */
+function matchingDelimiter(source: string, start: number, open: string, close: string): number {
   let depth = 0;
   for (let offset = start; offset < source.length; offset++) {
     const char = source[offset];
-    if (char === '"' || char === '\'' || char === '`') {
+    if (char === '/' && (source[offset + 1] === '/' || source[offset + 1] === '*')) {
+      const end = skipTrivia(source, offset);
+      if (end === offset)
+        return -1;
+      offset = end - 1;
+    } else if (char === '"' || char === '\'' || char === '`') {
       const end = endOfString(source, offset);
       if (end === -1)
         return -1;
       offset = end;
-    } else if (char === '(') {
+    } else if (char === '/' && startsRegex(source, offset)) {
+      const end = endOfRegex(source, offset);
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === open) {
       depth++;
-    } else if (char === ')') {
+    } else if (char === close) {
       depth--;
       if (!depth)
         return offset;
@@ -128,16 +191,50 @@ function matchingParen(source: string, start: number): number {
 function endOfString(source: string, start: number): number {
   const quote = source[start];
   for (let offset = start + 1; offset < source.length; offset++) {
-    if (source[offset] === '\\')
+    const char = source[offset];
+    if (char === '\\') {
       offset++;
-    else if (source[offset] === quote)
+    } else if (quote === '`' && char === '$' && source[offset + 1] === '{') {
+      // A substitution can hold anything, including another template.
+      const end = matchingDelimiter(source, offset + 1, '{', '}');
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === quote) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+// A slash directly after a value is division; anywhere else it opens a regular
+// expression. Parameter defaults are the case that matters here: `(a = /)/)`.
+function startsRegex(source: string, offset: number): boolean {
+  let index = offset - 1;
+  while (index >= 0 && /\s/.test(source[index]))
+    index--;
+  return index < 0 || !/[\w$)\]]/.test(source[index]);
+}
+
+function endOfRegex(source: string, start: number): number {
+  let inCharacterClass = false;
+  for (let offset = start + 1; offset < source.length; offset++) {
+    const char = source[offset];
+    if (char === '\\')
+      offset++;
+    else if (char === '\n')
+      return -1;
+    else if (inCharacterClass)
+      inCharacterClass = char !== ']';
+    else if (char === '[')
+      inCharacterClass = true;
+    else if (char === '/')
       return offset;
   }
   return -1;
 }
 
-function skipLeadingTrivia(source: string): number {
-  let offset = 0;
+function skipTrivia(source: string, offset: number): number {
   for (;;) {
     while (offset < source.length && /\s/.test(source[offset]))
       offset++;

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import { defineTabTool } from './tool.js';
 import * as javascript from '../utils/codegen.js';
 import { generateLocator } from './utils.js';
+import { isFunctionSource } from '../utils/jsSource.js';
 
 import type * as playwright from 'playwright';
 
@@ -26,6 +27,11 @@ const evaluateSchema = z.object({
   function: z.string().describe('() => { /* code */ } or (element) => { /* code */ } when element is provided. A bare expression such as document.title, or element.textContent when element is provided, is also accepted.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to interact with the element'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot'),
+}).refine(data => {
+  return !!data.element === !!data.ref;
+}, {
+  message: 'Both element and ref must be provided or neither.',
+  path: ['ref', 'element'],
 });
 
 const evaluate = defineTabTool({
@@ -39,14 +45,10 @@ const evaluate = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    // Half a pair used to fall back to page scope, so `element.textContent`
-    // with only a `ref` failed with a bare `element is not defined`.
-    if (!!params.ref !== !!params.element)
-      throw new Error('Provide both "element" and "ref" to evaluate against an element, or neither to evaluate against the page.');
-
     response.setIncludeSnapshot();
 
-    const onElement = !!(params.ref && params.element);
+    // The schema pairs them, so one implies the other.
+    const onElement = !!params.ref;
     const source = toFunctionSource(params.function, onElement);
 
     let locator: playwright.Locator | undefined;
@@ -82,176 +84,13 @@ export function toFunctionSource(source: string, onElement: boolean): string {
   if (isFunctionSource(source))
     return source;
   // A trailing `;` would turn the expression into a statement.
-  const expression = source.replace(/\s*;+\s*$/, '');
+  const expression = source.replace(/[\s;]+$/, '');
   if (!expression.trim())
     throw new Error('The "function" argument is empty. Pass a function such as `() => document.title`, or an expression such as `document.title`.');
   // The parentheses keep an object literal such as `{ a: 1 }` from parsing as a
   // block and a comma expression from splitting into two arguments; the
   // newlines keep a trailing `// comment` from swallowing the closing paren.
   return onElement ? `(element) => (\n${expression}\n)` : `() => (\n${expression}\n)`;
-}
-
-function isFunctionSource(source: string): boolean {
-  let body = source.slice(skipTrivia(source, 0));
-  for (;;) {
-    if (/^function\b/.test(body.slice(skipAsyncKeyword(body))))
-      return true;
-    if (hasArrowHead(body))
-      return true;
-    // `(() => 1)` and `(function () {})` are function literals inside grouping
-    // parentheses. Look inside before concluding this is an expression.
-    const inner = stripEnclosingParens(body);
-    if (inner === null)
-      return false;
-    body = inner.slice(skipTrivia(inner, 0));
-  }
-}
-
-function skipAsyncKeyword(source: string): number {
-  const keyword = /^async\b/.exec(source)?.[0];
-  return keyword ? skipTrivia(source, keyword.length) : 0;
-}
-
-/**
- * Matches the head of an arrow function -- `x =>`, `(a, b) =>`, `async () =>` --
- * without matching a parenthesised expression such as `(a + b)`.
- */
-function hasArrowHead(source: string): boolean {
-  let offset = skipAsyncKeyword(source);
-  if (source[offset] === '(') {
-    const end = matchingParen(source, offset);
-    // The scanner does not model every parameter-list construct (regex literals
-    // and nested template substitutions among them). When the match cannot be
-    // found, treat the source as a function: passing a function through is the
-    // behaviour that predates expression support, and a wrongly wrapped
-    // function silently returns `undefined`, while a wrongly passed-through
-    // expression fails loudly.
-    if (end === -1)
-      return true;
-    offset = end + 1;
-  } else {
-    const identifier = /^[\p{ID_Start}$_][\p{ID_Continue}$]*/u.exec(source.slice(offset))?.[0];
-    if (!identifier)
-      return false;
-    offset += identifier.length;
-  }
-  return source.startsWith('=>', skipTrivia(source, offset));
-}
-
-function stripEnclosingParens(source: string): string | null {
-  if (source[0] !== '(')
-    return null;
-  const end = matchingParen(source, 0);
-  // Only a group that wraps the whole source: `(a) => a` closes early and its
-  // parentheses are a parameter list, not a group.
-  if (end === -1 || skipTrivia(source, end + 1) !== source.length)
-    return null;
-  return source.slice(1, end);
-}
-
-function matchingParen(source: string, start: number): number {
-  return matchingDelimiter(source, start, '(', ')');
-}
-
-/**
- * Finds the delimiter closing the one at `start`, stepping over comments,
- * strings, template substitutions and regular expression literals so that a
- * bracket inside any of them is not counted.
- */
-function matchingDelimiter(source: string, start: number, open: string, close: string): number {
-  let depth = 0;
-  for (let offset = start; offset < source.length; offset++) {
-    const char = source[offset];
-    if (char === '/' && (source[offset + 1] === '/' || source[offset + 1] === '*')) {
-      const end = skipTrivia(source, offset);
-      if (end === offset)
-        return -1;
-      offset = end - 1;
-    } else if (char === '"' || char === '\'' || char === '`') {
-      const end = endOfString(source, offset);
-      if (end === -1)
-        return -1;
-      offset = end;
-    } else if (char === '/' && startsRegex(source, offset)) {
-      const end = endOfRegex(source, offset);
-      if (end === -1)
-        return -1;
-      offset = end;
-    } else if (char === open) {
-      depth++;
-    } else if (char === close) {
-      depth--;
-      if (!depth)
-        return offset;
-    }
-  }
-  return -1;
-}
-
-function endOfString(source: string, start: number): number {
-  const quote = source[start];
-  for (let offset = start + 1; offset < source.length; offset++) {
-    const char = source[offset];
-    if (char === '\\') {
-      offset++;
-    } else if (quote === '`' && char === '$' && source[offset + 1] === '{') {
-      // A substitution can hold anything, including another template.
-      const end = matchingDelimiter(source, offset + 1, '{', '}');
-      if (end === -1)
-        return -1;
-      offset = end;
-    } else if (char === quote) {
-      return offset;
-    }
-  }
-  return -1;
-}
-
-// A slash directly after a value is division; anywhere else it opens a regular
-// expression. Parameter defaults are the case that matters here: `(a = /)/)`.
-function startsRegex(source: string, offset: number): boolean {
-  let index = offset - 1;
-  while (index >= 0 && /\s/.test(source[index]))
-    index--;
-  return index < 0 || !/[\w$)\]]/.test(source[index]);
-}
-
-function endOfRegex(source: string, start: number): number {
-  let inCharacterClass = false;
-  for (let offset = start + 1; offset < source.length; offset++) {
-    const char = source[offset];
-    if (char === '\\')
-      offset++;
-    else if (char === '\n')
-      return -1;
-    else if (inCharacterClass)
-      inCharacterClass = char !== ']';
-    else if (char === '[')
-      inCharacterClass = true;
-    else if (char === '/')
-      return offset;
-  }
-  return -1;
-}
-
-function skipTrivia(source: string, offset: number): number {
-  for (;;) {
-    while (offset < source.length && /\s/.test(source[offset]))
-      offset++;
-    if (source.startsWith('//', offset)) {
-      const lineEnd = source.indexOf('\n', offset);
-      if (lineEnd === -1)
-        return source.length;
-      offset = lineEnd + 1;
-    } else if (source.startsWith('/*', offset)) {
-      const commentEnd = source.indexOf('*/', offset + 2);
-      if (commentEnd === -1)
-        return source.length;
-      offset = commentEnd + 2;
-    } else {
-      return offset;
-    }
-  }
 }
 
 export default [

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -23,7 +23,7 @@ import { generateLocator } from './utils.js';
 import type * as playwright from 'playwright';
 
 const evaluateSchema = z.object({
-  function: z.string().describe('() => { /* code */ } or (element) => { /* code */ } when element is provided'),
+  function: z.string().describe('() => { /* code */ } or (element) => { /* code */ } when element is provided. A bare expression such as document.title, or element.textContent when element is provided, is also accepted.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to interact with the element'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot'),
 });
@@ -41,12 +41,15 @@ const evaluate = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
+    const onElement = !!(params.ref && params.element);
+    const source = toFunctionSource(params.function, onElement);
+
     let locator: playwright.Locator | undefined;
-    if (params.ref && params.element) {
-      locator = await tab.refLocator({ ref: params.ref, element: params.element });
-      response.addCode(`await page.${await generateLocator(locator)}.evaluate(${javascript.quote(params.function)});`);
+    if (onElement) {
+      locator = await tab.refLocator({ ref: params.ref!, element: params.element! });
+      response.addCode(`await page.${await generateLocator(locator)}.evaluate(${javascript.quote(source)});`);
     } else {
-      response.addCode(`await page.evaluate(${javascript.quote(params.function)});`);
+      response.addCode(`await page.evaluate(${javascript.quote(source)});`);
     }
 
     await tab.waitForCompletion(async () => {
@@ -55,12 +58,104 @@ const evaluate = defineTabTool({
       // argument via `Function.prototype.toString`, so hand it an empty function
       // whose `toString()` returns the user-supplied source instead.
       const func = new Function() as any;
-      func.toString = () => params.function;
+      func.toString = () => source;
       const result = locator ? await locator.evaluate(func) : await tab.page.evaluate(func);
       response.addResult(JSON.stringify(result, null, 2) || 'undefined');
     });
   },
 });
+
+/**
+ * `evaluate()` needs a function, but callers routinely pass a bare expression
+ * such as `document.title`. Wrap anything that is not already a function form.
+ */
+export function toFunctionSource(source: string, onElement: boolean): string {
+  if (isFunctionSource(source))
+    return source;
+  // The parentheses keep an object literal such as `{ a: 1 }` from parsing as a
+  // block, and keep a comma expression from splitting into two arguments.
+  return onElement ? `(element) => (${source})` : `() => (${source})`;
+}
+
+function isFunctionSource(source: string): boolean {
+  const body = source.slice(skipLeadingTrivia(source));
+  if (/^(async\b\s*)?function\b/.test(body))
+    return true;
+  return hasArrowHead(body);
+}
+
+/**
+ * Matches the head of an arrow function -- `x =>`, `(a, b) =>`, `async () =>` --
+ * without matching a parenthesised expression such as `(a + b)`.
+ */
+function hasArrowHead(source: string): boolean {
+  let offset = /^async\b\s*/.exec(source)?.[0].length ?? 0;
+  if (source[offset] === '(') {
+    const end = matchingParen(source, offset);
+    if (end === -1)
+      return false;
+    offset = end + 1;
+  } else {
+    const identifier = /^[A-Za-z_$][\w$]*/.exec(source.slice(offset))?.[0];
+    if (!identifier)
+      return false;
+    offset += identifier.length;
+  }
+  offset += skipLeadingTrivia(source.slice(offset));
+  return source.startsWith('=>', offset);
+}
+
+function matchingParen(source: string, start: number): number {
+  let depth = 0;
+  for (let offset = start; offset < source.length; offset++) {
+    const char = source[offset];
+    if (char === '"' || char === '\'' || char === '`') {
+      const end = endOfString(source, offset);
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (!depth)
+        return offset;
+    }
+  }
+  return -1;
+}
+
+function endOfString(source: string, start: number): number {
+  const quote = source[start];
+  for (let offset = start + 1; offset < source.length; offset++) {
+    if (source[offset] === '\\')
+      offset++;
+    else if (source[offset] === quote)
+      return offset;
+  }
+  return -1;
+}
+
+function skipLeadingTrivia(source: string): number {
+  let offset = 0;
+  for (;;) {
+    while (offset < source.length && /\s/.test(source[offset]))
+      offset++;
+    if (source.startsWith('//', offset)) {
+      const lineEnd = source.indexOf('\n', offset);
+      if (lineEnd === -1)
+        return source.length;
+      offset = lineEnd + 1;
+    } else if (source.startsWith('/*', offset)) {
+      const commentEnd = source.indexOf('*/', offset + 2);
+      if (commentEnd === -1)
+        return source.length;
+      offset = commentEnd + 2;
+    } else {
+      return offset;
+    }
+  }
+}
 
 export default [
   evaluate,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -20,6 +20,10 @@ import { truncateDataUrls } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
 
+// Bodies land in the model's context verbatim, so cap what a single detail call
+// can contribute. Anything longer is reported as truncated rather than dropped.
+export const maxBodyLength = 20000;
+
 const requests = defineTabTool({
   capability: 'core',
 
@@ -32,19 +36,147 @@ const requests = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const requests = tab.requests();
-    [...requests.entries()].forEach(([req, res]) => response.addResult(renderRequest(req, res)));
+    const entries = [...tab.requests().entries()];
+    entries.forEach(([req, res], index) => response.addResult(renderRequest(index + 1, req, res)));
+    if (entries.length)
+      response.addResult('\nCall browser_network_request with one of the indexes above to see the headers and response body of that request.');
   },
 });
 
-function renderRequest(request: playwright.Request, response: playwright.Response | null) {
+const requestDetails = defineTabTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_network_request',
+    title: 'Get network request details',
+    description: 'Returns the request headers, response headers and response body of a single network request listed by browser_network_requests',
+    inputSchema: z.object({
+      index: z.number().int().min(1).describe('Index of the request in the browser_network_requests listing, starting at 1'),
+    }),
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    const entries = [...tab.requests().entries()];
+    const entry = entries[params.index - 1];
+    if (!entry) {
+      response.addError(entries.length
+        ? `Error: No network request with index ${params.index}. The current list is numbered 1 to ${entries.length}; run browser_network_requests for the up-to-date list.`
+        : 'Error: No network requests have been recorded since the page was loaded.');
+      return;
+    }
+
+    const [req, res] = entry;
+    for (const line of await renderRequestDetails(params.index, req, res))
+      response.addResult(line);
+  },
+});
+
+function renderRequest(index: number, request: playwright.Request, response: playwright.Response | null) {
   const result: string[] = [];
-  result.push(`[${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
+  result.push(`[${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
   if (response)
     result.push(`=> [${response.status()}] ${response.statusText()}`);
   return result.join(' ');
 }
 
+async function renderRequestDetails(index: number, request: playwright.Request, response: playwright.Response | null): Promise<string[]> {
+  const result: string[] = [
+    `### [${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`,
+    '',
+    '#### Request headers',
+    ...renderHeaders(await request.allHeaders()),
+  ];
+
+  const postData = request.postData();
+  if (postData)
+    result.push('', '#### Request body', ...renderText(postData));
+
+  if (!response) {
+    const failure = request.failure();
+    result.push('', '#### Response', failure ? `The request failed: ${failure.errorText}` : 'The request has not completed yet.');
+    return result;
+  }
+
+  result.push(
+      '',
+      '#### Response',
+      `[${response.status()}] ${response.statusText()}`,
+      '',
+      '#### Response headers',
+      ...renderHeaders(await response.allHeaders()),
+      '',
+      '#### Response body',
+      ...await renderResponseBody(response),
+  );
+  return result;
+}
+
+function renderHeaders(headers: Record<string, string>): string[] {
+  const names = Object.keys(headers).sort();
+  if (!names.length)
+    return ['<none>'];
+  return names.map(name => `${name}: ${truncateDataUrls(headers[name])}`);
+}
+
+async function renderResponseBody(response: playwright.Response): Promise<string[]> {
+  let body: Buffer;
+  try {
+    body = await response.body();
+  } catch (error) {
+    // Redirects and responses whose body the browser never retained reject
+    // here; the rest of the report is still worth showing.
+    return [`<body unavailable: ${error instanceof Error ? error.message : String(error)}>`];
+  }
+
+  if (!body.length)
+    return ['<empty>'];
+
+  const mimeType = ((await response.headerValue('content-type')) ?? '').split(';')[0].trim().toLowerCase();
+  if (!isTextualMimeType(mimeType, body))
+    return [`<binary data, ${body.length} bytes${mimeType ? `, ${mimeType}` : ''}>`];
+
+  return renderText(body.toString('utf8'));
+}
+
+function renderText(text: string): string[] {
+  if (text.length <= maxBodyLength)
+    return [truncateDataUrls(text)];
+  return [
+    truncateDataUrls(text.slice(0, maxBodyLength)),
+    `<truncated, showing the first ${maxBodyLength} of ${text.length} characters>`,
+  ];
+}
+
+const textualMimeTypes = new Set([
+  'application/ecmascript',
+  'application/graphql',
+  'application/javascript',
+  'application/json',
+  'application/x-ecmascript',
+  'application/x-javascript',
+  'application/x-www-form-urlencoded',
+  'application/xml',
+]);
+
+function isTextualMimeType(mimeType: string, body: Buffer): boolean {
+  if (!mimeType)
+    return !looksBinary(body);
+  if (mimeType.startsWith('text/'))
+    return true;
+  // Structured syntax suffixes: `image/svg+xml`, `application/ld+json`, ...
+  if (mimeType.endsWith('+json') || mimeType.endsWith('+xml') || mimeType.endsWith('+text'))
+    return true;
+  return textualMimeTypes.has(mimeType);
+}
+
+function looksBinary(body: Buffer): boolean {
+  // A NUL byte is the cheapest reliable signal that a payload is not text --
+  // UTF-8 encoded text never contains one outside of a deliberate \0.
+  return body.subarray(0, 1024).includes(0);
+}
+
 export default [
   requests,
+  requestDetails,
 ];

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -81,16 +81,19 @@ function renderRequest(index: number, request: playwright.Request, response: pla
 }
 
 async function renderRequestDetails(index: number, request: playwright.Request, response: playwright.Response | null): Promise<string[]> {
+  const requestHeaders = await request.allHeaders();
   const result: string[] = [
     `### [${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`,
     '',
     '#### Request headers',
-    ...renderHeaders(await request.allHeaders()),
+    ...renderHeaders(requestHeaders),
   ];
 
-  const postData = request.postData();
-  if (postData)
-    result.push('', '#### Request body', ...renderText(postData));
+  // `postData()` decodes as UTF-8, which mangles file uploads and protobuf
+  // payloads, so go through the buffer and let the same binary check decide.
+  const postData = request.postDataBuffer();
+  if (postData?.length)
+    result.push('', '#### Request body', ...renderBody(postData, mimeTypeOf(requestHeaders)));
 
   if (!response) {
     const failure = request.failure();
@@ -98,28 +101,52 @@ async function renderRequestDetails(index: number, request: playwright.Request, 
     return result;
   }
 
+  const responseHeaders = await response.allHeaders();
   result.push(
       '',
       '#### Response',
       `[${response.status()}] ${response.statusText()}`,
       '',
       '#### Response headers',
-      ...renderHeaders(await response.allHeaders()),
+      ...renderHeaders(responseHeaders),
       '',
       '#### Response body',
-      ...await renderResponseBody(response),
+      ...await renderResponseBody(response, mimeTypeOf(responseHeaders)),
   );
   return result;
 }
+
+// Credentials must never reach the model's context: this tool is the first one
+// here to surface raw headers, and a session cookie copied into a transcript is
+// as good as leaked. The length keeps the header's presence debuggable.
+const sensitiveHeaderNames = new Set([
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+]);
 
 function renderHeaders(headers: Record<string, string>): string[] {
   const names = Object.keys(headers).sort();
   if (!names.length)
     return ['<none>'];
-  return names.map(name => `${name}: ${truncateDataUrls(headers[name])}`);
+  return names.map(name => {
+    const value = headers[name];
+    return sensitiveHeaderNames.has(name.toLowerCase())
+      ? `${name}: <redacted, ${value.length} characters>`
+      : `${name}: ${truncateDataUrls(value)}`;
+  });
 }
 
-async function renderResponseBody(response: playwright.Response): Promise<string[]> {
+function mimeTypeOf(headers: Record<string, string>): string {
+  // `allHeaders()` lower-cases the names and joins repeats with a comma; only
+  // the first media type matters for deciding how to render the payload.
+  return (headers['content-type'] ?? '').split(';')[0].split(',')[0].trim().toLowerCase();
+}
+
+async function renderResponseBody(response: playwright.Response, mimeType: string): Promise<string[]> {
   let body: Buffer;
   try {
     body = await response.body();
@@ -128,14 +155,14 @@ async function renderResponseBody(response: playwright.Response): Promise<string
     // here; the rest of the report is still worth showing.
     return [`<body unavailable: ${error instanceof Error ? error.message : String(error)}>`];
   }
+  return renderBody(body, mimeType);
+}
 
+function renderBody(body: Buffer, mimeType: string): string[] {
   if (!body.length)
     return ['<empty>'];
-
-  const mimeType = ((await response.headerValue('content-type')) ?? '').split(';')[0].trim().toLowerCase();
   if (!isTextualMimeType(mimeType, body))
     return [`<binary data, ${body.length} bytes${mimeType ? `, ${mimeType}` : ''}>`];
-
   return renderText(body.toString('utf8'));
 }
 
@@ -143,9 +170,20 @@ function renderText(text: string): string[] {
   if (text.length <= maxBodyLength)
     return [truncateDataUrls(text)];
   return [
-    truncateDataUrls(text.slice(0, maxBodyLength)),
+    truncateDataUrls(sliceWholeCharacters(text, maxBodyLength)),
     `<truncated, showing the first ${maxBodyLength} of ${text.length} characters>`,
   ];
+}
+
+// Never cut between the halves of a surrogate pair -- a lone half renders as a
+// replacement character and can corrupt the JSON the response is packed into.
+function sliceWholeCharacters(text: string, length: number): string {
+  const end = isHighSurrogate(text.charCodeAt(length - 1)) ? length - 1 : length;
+  return text.slice(0, end);
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
 }
 
 const textualMimeTypes = new Set([
@@ -159,15 +197,34 @@ const textualMimeTypes = new Set([
   'application/xml',
 ]);
 
+const binaryMimePrefixes = ['audio/', 'font/', 'image/', 'model/', 'video/'];
+
+const binaryMimeTypes = new Set([
+  'application/grpc',
+  'application/gzip',
+  'application/octet-stream',
+  'application/pdf',
+  'application/protobuf',
+  'application/wasm',
+  'application/x-gzip',
+  'application/x-protobuf',
+  'application/x-tar',
+  'application/zip',
+]);
+
 function isTextualMimeType(mimeType: string, body: Buffer): boolean {
-  if (!mimeType)
-    return !looksBinary(body);
   if (mimeType.startsWith('text/'))
     return true;
   // Structured syntax suffixes: `image/svg+xml`, `application/ld+json`, ...
   if (mimeType.endsWith('+json') || mimeType.endsWith('+xml') || mimeType.endsWith('+text'))
     return true;
-  return textualMimeTypes.has(mimeType);
+  if (textualMimeTypes.has(mimeType))
+    return true;
+  if (binaryMimeTypes.has(mimeType) || binaryMimePrefixes.some(prefix => mimeType.startsWith(prefix)))
+    return false;
+  // Absent or unrecognised type -- `multipart/form-data` posts are the common
+  // case, and those are text until a file part makes them otherwise.
+  return !looksBinary(body);
 }
 
 function looksBinary(body: Buffer): boolean {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -67,77 +67,102 @@ const requestDetails = defineTabTool({
       return;
     }
 
-    const [req, res] = entry;
-    for (const line of await renderRequestDetails(tab, params.index, req, res))
+    // Every read that can block lives here, bounded by the tab's page-state
+    // timeout; the rendering below is pure so it can be tested with plain data.
+    const [request, res] = entry;
+    const details: RequestDetails = {
+      index: params.index,
+      request,
+      requestHeaders: await read(tab, () => request.allHeaders(), 'reading the request headers'),
+      response: res,
+      responseHeaders: res ? await read(tab, () => res.allHeaders(), 'reading the response headers') : undefined,
+      responseBody: res ? await read(tab, () => res.body(), 'reading the response body') : undefined,
+    };
+    for (const line of renderRequestDetails(details))
       response.addResult(line);
   },
 });
 
-function renderRequest(index: number, request: playwright.Request, response: playwright.Response | null) {
-  const result: string[] = [];
-  result.push(`[${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`);
-  if (response)
-    result.push(`=> [${response.status()}] ${response.statusText()}`);
-  return result.join(' ');
+function requestLine(index: number, request: playwright.Request): string {
+  return `[${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`;
 }
 
-async function renderRequestDetails(tab: Tab, index: number, request: playwright.Request, response: playwright.Response | null): Promise<string[]> {
-  const requestHeaders = await readHeaders(tab, () => request.allHeaders(), 'reading the request headers');
-  const result: string[] = [
-    `### [${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`,
-    '',
-    '#### Request headers',
-    ...renderHeaderSection(requestHeaders),
+function renderRequest(index: number, request: playwright.Request, response: playwright.Response | null) {
+  const line = requestLine(index, request);
+  return response ? `${line} => [${response.status()}] ${response.statusText()}` : line;
+}
+
+function section(title: string, lines: string[]): string[] {
+  return ['', `#### ${title}`, ...lines];
+}
+
+type Read<T> = { value: T } | { error: string };
+
+type RequestDetails = {
+  index: number,
+  request: playwright.Request,
+  requestHeaders: Read<Record<string, string>>,
+  response: playwright.Response | null,
+  responseHeaders?: Read<Record<string, string>>,
+  responseBody?: Read<Buffer>,
+};
+
+function renderRequestDetails(details: RequestDetails): string[] {
+  const { index, request, response } = details;
+  const requestHeaders = headersOf(details.requestHeaders);
+  const result = [
+    `### ${requestLine(index, request)}`,
+    ...section('Request headers', renderHeaderSection(details.requestHeaders)),
   ];
 
   // `postData()` decodes as UTF-8, which mangles file uploads and protobuf
   // payloads, so go through the buffer and let the same binary check decide.
   const postData = request.postDataBuffer();
   if (postData?.length)
-    result.push('', '#### Request body', ...renderBody(postData, contentTypeOf(requestHeaders)));
+    result.push(...section('Request body', renderBody(postData, contentTypeOf(requestHeaders))));
 
   // Playwright records a failure on the request even when a response already
   // arrived — a connection reset mid-body is a 200 that never completed.
   const failure = request.failure();
-  if (!response) {
-    result.push('', '#### Response', failure ? `The request failed: ${failure.errorText}` : 'The request has not completed yet.');
-    return result;
-  }
+  if (!response)
+    return [...result, ...section('Response', [failure ? `The request failed: ${failure.errorText}` : 'The request has not completed yet.'])];
 
-  const responseHeaders = await readHeaders(tab, () => response.allHeaders(), 'reading the response headers');
+  const responseHeaders = headersOf(details.responseHeaders);
   result.push(
-      '',
-      '#### Response',
-      `[${response.status()}] ${response.statusText()}`,
-      ...(failure ? [`The transfer then failed: ${failure.errorText}`] : []),
-      '',
-      '#### Response headers',
-      ...renderHeaderSection(responseHeaders),
-      '',
-      '#### Response body',
-      ...await renderResponseBody(tab, response, contentTypeOf(responseHeaders)),
+      ...section('Response', [
+        `[${response.status()}] ${response.statusText()}`,
+        ...(failure ? [`The transfer then failed: ${failure.errorText}`] : []),
+      ]),
+      ...section('Response headers', renderHeaderSection(details.responseHeaders)),
+      ...section('Response body', renderResponseBody(details.responseBody, contentTypeOf(responseHeaders))),
   );
   return result;
 }
 
-type HeaderRead = { headers: Record<string, string> } | { error: string };
-
-async function readHeaders(tab: Tab, read: () => Promise<Record<string, string>>, description: string): Promise<HeaderRead> {
+// A failed read must not discard what the rest of the report already has.
+async function read<T>(tab: Tab, fetch: () => Promise<T>, description: string): Promise<Read<T>> {
   try {
-    return { headers: await tab.withPageStateTimeout(read(), description) };
+    return { value: await tab.withPageStateTimeout(fetch(), description) };
   } catch (error) {
-    // Losing the headers must not discard the status and URL already gathered.
-    return { error: errorMessage(error) };
+    return { error: error instanceof Error ? error.message : String(error) };
   }
 }
 
-function renderHeaderSection(read: HeaderRead): string[] {
-  return 'error' in read ? [`<headers unavailable: ${read.error}>`] : renderHeaders(read.headers);
+function headersOf(read: Read<Record<string, string>> | undefined): Record<string, string> {
+  return read && 'value' in read ? read.value : {};
+}
+
+function renderHeaderSection(read: Read<Record<string, string>> | undefined): string[] {
+  if (!read)
+    return ['<none>'];
+  return 'error' in read ? [`<headers unavailable: ${read.error}>`] : renderHeaders(read.value);
 }
 
 // Credentials must never reach the model's context: this tool is the first one
 // here to surface raw headers, and a session cookie copied into a transcript is
 // as good as leaked. The length keeps the header's presence debuggable.
+const newlines = /\r?\n/g;
+
 const sensitiveHeaderNames = new Set([
   'authorization',
   'cookie',
@@ -157,38 +182,28 @@ function renderHeaders(headers: Record<string, string>): string[] {
       return `${name}: <redacted, ${value.length} characters>`;
     // `allHeaders()` joins repeated headers (`set-cookie` especially) with a
     // newline; keep one line per header so `name: value` stays parseable.
-    return `${name}: ${truncateDataUrls(value).replace(/\r?\n/g, '\\n')}`;
+    return `${name}: ${truncateDataUrls(value).replace(newlines, '\\n')}`;
   });
 }
 
 type ContentType = { mimeType: string, charset: string };
 
-function contentTypeOf(read: HeaderRead): ContentType {
-  const raw = 'error' in read ? '' : (read.headers['content-type'] ?? '');
+function contentTypeOf(headers: Record<string, string>): ContentType {
   // `allHeaders()` joins a repeated header with a comma, so only the first
   // media type and its parameters describe the payload.
-  const [mimeType, ...parameters] = raw.split(',')[0].split(';');
-  const charset = parameters
-      .map(parameter => parameter.trim())
-      .find(parameter => parameter.toLowerCase().startsWith('charset='))
-      ?.slice('charset='.length);
-  return { mimeType: unquote(mimeType.trim().toLowerCase()), charset: unquote(charset?.trim() ?? '') };
+  const first = (headers['content-type'] ?? '').split(',')[0];
+  return {
+    mimeType: first.split(';')[0].trim().toLowerCase(),
+    charset: /;\s*charset\s*=\s*"?([^";]*)/i.exec(first)?.[1].trim() ?? '',
+  };
 }
 
-function unquote(value: string): string {
-  return value.replace(/^"(.*)"$/, '$1');
-}
-
-async function renderResponseBody(tab: Tab, response: playwright.Response, contentType: ContentType): Promise<string[]> {
-  let body: Buffer;
-  try {
-    body = await tab.withPageStateTimeout(response.body(), 'reading the response body');
-  } catch (error) {
-    // Redirects, responses whose body the browser never retained, and bodies
-    // still streaming all end up here; the rest of the report is worth showing.
-    return [`<body unavailable: ${errorMessage(error)}>`];
-  }
-  return renderBody(body, contentType);
+function renderResponseBody(read: Read<Buffer> | undefined, contentType: ContentType): string[] {
+  if (!read)
+    return ['<empty>'];
+  // Redirects, responses whose body the browser never retained, and bodies
+  // still streaming all fail the read; the rest of the report is worth showing.
+  return 'error' in read ? [`<body unavailable: ${read.error}>`] : renderBody(read.value, contentType);
 }
 
 // A body large enough to matter is decoded only up to the cap: a 100MB response
@@ -227,24 +242,16 @@ function decodeText(body: Buffer, charset: string): string {
 // `####` sections around it, and the fence is grown past any run of backticks
 // inside so the block still terminates where it should.
 function fence(text: string): string[] {
-  const longestRun = Math.max(0, ...[...text.matchAll(/`+/g)].map(match => match[0].length));
-  const delimiter = '`'.repeat(Math.max(3, longestRun + 1));
+  const delimiter = '`'.repeat(Math.max(3, ...[...text.matchAll(/`+/g)].map(match => match[0].length + 1)));
   return [delimiter, text, delimiter];
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 // Never cut between the halves of a surrogate pair -- a lone half renders as a
 // replacement character and can corrupt the JSON the response is packed into.
 function sliceWholeCharacters(text: string, length: number): string {
-  const end = isHighSurrogate(text.charCodeAt(length - 1)) ? length - 1 : length;
-  return text.slice(0, end);
-}
-
-function isHighSurrogate(code: number): boolean {
-  return code >= 0xd800 && code <= 0xdbff;
+  const last = text.charCodeAt(length - 1);
+  const isHighSurrogate = last >= 0xd800 && last <= 0xdbff;
+  return text.slice(0, isHighSurrogate ? length - 1 : length);
 }
 
 const textualMimeTypes = new Set([

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -19,6 +19,7 @@ import { defineTabTool } from './tool.js';
 import { truncateDataUrls } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
+import type { Tab } from '../tab.js';
 
 // Bodies land in the model's context verbatim, so cap what a single detail call
 // can contribute. Anything longer is reported as truncated rather than dropped.
@@ -67,7 +68,7 @@ const requestDetails = defineTabTool({
     }
 
     const [req, res] = entry;
-    for (const line of await renderRequestDetails(params.index, req, res))
+    for (const line of await renderRequestDetails(tab, params.index, req, res))
       response.addResult(line);
   },
 });
@@ -80,40 +81,58 @@ function renderRequest(index: number, request: playwright.Request, response: pla
   return result.join(' ');
 }
 
-async function renderRequestDetails(index: number, request: playwright.Request, response: playwright.Response | null): Promise<string[]> {
-  const requestHeaders = await request.allHeaders();
+async function renderRequestDetails(tab: Tab, index: number, request: playwright.Request, response: playwright.Response | null): Promise<string[]> {
+  const requestHeaders = await readHeaders(tab, () => request.allHeaders(), 'reading the request headers');
   const result: string[] = [
     `### [${index}] [${request.method().toUpperCase()}] ${truncateDataUrls(request.url())}`,
     '',
     '#### Request headers',
-    ...renderHeaders(requestHeaders),
+    ...renderHeaderSection(requestHeaders),
   ];
 
   // `postData()` decodes as UTF-8, which mangles file uploads and protobuf
   // payloads, so go through the buffer and let the same binary check decide.
   const postData = request.postDataBuffer();
   if (postData?.length)
-    result.push('', '#### Request body', ...renderBody(postData, mimeTypeOf(requestHeaders)));
+    result.push('', '#### Request body', ...renderBody(postData, contentTypeOf(requestHeaders)));
 
+  // Playwright records a failure on the request even when a response already
+  // arrived — a connection reset mid-body is a 200 that never completed.
+  const failure = request.failure();
   if (!response) {
-    const failure = request.failure();
     result.push('', '#### Response', failure ? `The request failed: ${failure.errorText}` : 'The request has not completed yet.');
     return result;
   }
 
-  const responseHeaders = await response.allHeaders();
+  const responseHeaders = await readHeaders(tab, () => response.allHeaders(), 'reading the response headers');
   result.push(
       '',
       '#### Response',
       `[${response.status()}] ${response.statusText()}`,
+      ...(failure ? [`The transfer then failed: ${failure.errorText}`] : []),
       '',
       '#### Response headers',
-      ...renderHeaders(responseHeaders),
+      ...renderHeaderSection(responseHeaders),
       '',
       '#### Response body',
-      ...await renderResponseBody(response, mimeTypeOf(responseHeaders)),
+      ...await renderResponseBody(tab, response, contentTypeOf(responseHeaders)),
   );
   return result;
+}
+
+type HeaderRead = { headers: Record<string, string> } | { error: string };
+
+async function readHeaders(tab: Tab, read: () => Promise<Record<string, string>>, description: string): Promise<HeaderRead> {
+  try {
+    return { headers: await tab.withPageStateTimeout(read(), description) };
+  } catch (error) {
+    // Losing the headers must not discard the status and URL already gathered.
+    return { error: errorMessage(error) };
+  }
+}
+
+function renderHeaderSection(read: HeaderRead): string[] {
+  return 'error' in read ? [`<headers unavailable: ${read.error}>`] : renderHeaders(read.headers);
 }
 
 // Credentials must never reach the model's context: this tool is the first one
@@ -134,45 +153,87 @@ function renderHeaders(headers: Record<string, string>): string[] {
     return ['<none>'];
   return names.map(name => {
     const value = headers[name];
-    return sensitiveHeaderNames.has(name.toLowerCase())
-      ? `${name}: <redacted, ${value.length} characters>`
-      : `${name}: ${truncateDataUrls(value)}`;
+    if (sensitiveHeaderNames.has(name.toLowerCase()))
+      return `${name}: <redacted, ${value.length} characters>`;
+    // `allHeaders()` joins repeated headers (`set-cookie` especially) with a
+    // newline; keep one line per header so `name: value` stays parseable.
+    return `${name}: ${truncateDataUrls(value).replace(/\r?\n/g, '\\n')}`;
   });
 }
 
-function mimeTypeOf(headers: Record<string, string>): string {
-  // `allHeaders()` lower-cases the names and joins repeats with a comma; only
-  // the first media type matters for deciding how to render the payload.
-  return (headers['content-type'] ?? '').split(';')[0].split(',')[0].trim().toLowerCase();
+type ContentType = { mimeType: string, charset: string };
+
+function contentTypeOf(read: HeaderRead): ContentType {
+  const raw = 'error' in read ? '' : (read.headers['content-type'] ?? '');
+  // `allHeaders()` joins a repeated header with a comma, so only the first
+  // media type and its parameters describe the payload.
+  const [mimeType, ...parameters] = raw.split(',')[0].split(';');
+  const charset = parameters
+      .map(parameter => parameter.trim())
+      .find(parameter => parameter.toLowerCase().startsWith('charset='))
+      ?.slice('charset='.length);
+  return { mimeType: unquote(mimeType.trim().toLowerCase()), charset: unquote(charset?.trim() ?? '') };
 }
 
-async function renderResponseBody(response: playwright.Response, mimeType: string): Promise<string[]> {
+function unquote(value: string): string {
+  return value.replace(/^"(.*)"$/, '$1');
+}
+
+async function renderResponseBody(tab: Tab, response: playwright.Response, contentType: ContentType): Promise<string[]> {
   let body: Buffer;
   try {
-    body = await response.body();
+    body = await tab.withPageStateTimeout(response.body(), 'reading the response body');
   } catch (error) {
-    // Redirects and responses whose body the browser never retained reject
-    // here; the rest of the report is still worth showing.
-    return [`<body unavailable: ${error instanceof Error ? error.message : String(error)}>`];
+    // Redirects, responses whose body the browser never retained, and bodies
+    // still streaming all end up here; the rest of the report is worth showing.
+    return [`<body unavailable: ${errorMessage(error)}>`];
   }
-  return renderBody(body, mimeType);
+  return renderBody(body, contentType);
 }
 
-function renderBody(body: Buffer, mimeType: string): string[] {
+// A body large enough to matter is decoded only up to the cap: a 100MB response
+// must not become a 200MB string, and `toString` throws outright past ~512MB.
+const maxBodyBytes = maxBodyLength * 4;
+
+function renderBody(body: Buffer, contentType: ContentType): string[] {
   if (!body.length)
     return ['<empty>'];
-  if (!isTextualMimeType(mimeType, body))
-    return [`<binary data, ${body.length} bytes${mimeType ? `, ${mimeType}` : ''}>`];
-  return renderText(body.toString('utf8'));
+  if (!isTextualMimeType(contentType.mimeType, body))
+    return [`<binary data, ${body.length} bytes${contentType.mimeType ? `, ${contentType.mimeType}` : ''}>`];
+
+  // Collapse data: URLs before measuring — doing it after would let the
+  // replacement text push the rendered body back over the cap.
+  const text = truncateDataUrls(decodeText(body.subarray(0, maxBodyBytes), contentType.charset));
+  if (body.length <= maxBodyBytes && text.length <= maxBodyLength)
+    return fence(text);
+
+  const shown = sliceWholeCharacters(text, maxBodyLength);
+  return [...fence(shown), `<truncated, showing the first ${shown.length} characters of a ${body.length}-byte body>`];
 }
 
-function renderText(text: string): string[] {
-  if (text.length <= maxBodyLength)
-    return [truncateDataUrls(text)];
-  return [
-    truncateDataUrls(sliceWholeCharacters(text, maxBodyLength)),
-    `<truncated, showing the first ${maxBodyLength} of ${text.length} characters>`,
-  ];
+function decodeText(body: Buffer, charset: string): string {
+  if (!charset || /^utf-?8$/i.test(charset))
+    return body.toString('utf8');
+  try {
+    // Legacy pages really do serve windows-1252 and shift_jis; decoding those
+    // as UTF-8 turns the body into replacement characters.
+    return new TextDecoder(charset).decode(body);
+  } catch {
+    return body.toString('utf8');
+  }
+}
+
+// The body is page-controlled. Fencing it stops a response from forging the
+// `####` sections around it, and the fence is grown past any run of backticks
+// inside so the block still terminates where it should.
+function fence(text: string): string[] {
+  const longestRun = Math.max(0, ...[...text.matchAll(/`+/g)].map(match => match[0].length));
+  const delimiter = '`'.repeat(Math.max(3, longestRun + 1));
+  return [delimiter, text, delimiter];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 // Never cut between the halves of a surrogate pair -- a lone half renders as a
@@ -187,14 +248,21 @@ function isHighSurrogate(code: number): boolean {
 }
 
 const textualMimeTypes = new Set([
+  'application/csv',
   'application/ecmascript',
   'application/graphql',
   'application/javascript',
   'application/json',
+  'application/ndjson',
+  'application/sql',
   'application/x-ecmascript',
   'application/x-javascript',
+  'application/x-ndjson',
+  'application/x-sh',
   'application/x-www-form-urlencoded',
+  'application/x-yaml',
   'application/xml',
+  'application/yaml',
 ]);
 
 const binaryMimePrefixes = ['audio/', 'font/', 'image/', 'model/', 'video/'];

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -537,6 +537,9 @@ const drag = defineTabTool({
 const dropSchema = elementSchema.extend({
   paths: z.array(z.string()).optional().describe('The absolute paths of the files to drop onto the element. Can be a single file or multiple files.'),
   data: z.record(z.string(), z.string()).optional().describe('Clipboard-like payload to drop onto the element, as a map of mime type to value, for example { "text/plain": "hello", "text/uri-list": "https://example.com" }'),
+}).superRefine((params, context) => {
+  if (!params.paths?.length && !Object.keys(params.data ?? {}).length)
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Provide "paths", "data" or both to describe what to drop onto the element.' });
 });
 
 const drop = defineTabTool({
@@ -552,13 +555,12 @@ const drop = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
+    // The schema guarantees at least one of them is non-empty.
     const payload: { files?: string[], data?: Record<string, string> } = {};
     if (params.paths?.length)
       payload.files = params.paths;
-    if (params.data && Object.keys(params.data).length)
+    if (Object.keys(params.data ?? {}).length)
       payload.data = params.data;
-    if (!payload.files && !payload.data)
-      throw new Error('Provide "paths", "data" or both to describe what to drop onto the element.');
 
     const locator = await tab.refLocator(params);
     response.addCode(`await page.${await generateLocator(locator)}.drop(${JSON.stringify(payload)});`);

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -534,6 +534,44 @@ const drag = defineTabTool({
   },
 });
 
+const dropSchema = elementSchema.extend({
+  paths: z.array(z.string()).optional().describe('The absolute paths of the files to drop onto the element. Can be a single file or multiple files.'),
+  data: z.record(z.string(), z.string()).optional().describe('Clipboard-like payload to drop onto the element, as a map of mime type to value, for example { "text/plain": "hello", "text/uri-list": "https://example.com" }'),
+});
+
+const drop = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_drop',
+    title: 'Drop onto element',
+    description: 'Simulate an external drag and drop of files or clipboard-like data onto an element',
+    inputSchema: dropSchema,
+    type: 'destructive',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const payload: { files?: string[], data?: Record<string, string> } = {};
+    if (params.paths?.length)
+      payload.files = params.paths;
+    if (params.data && Object.keys(params.data).length)
+      payload.data = params.data;
+    if (!payload.files && !payload.data)
+      throw new Error('Provide "paths", "data" or both to describe what to drop onto the element.');
+
+    const locator = await tab.refLocator(params);
+    response.addCode(`await page.${await generateLocator(locator)}.drop(${JSON.stringify(payload)});`);
+
+    await tab.waitForCompletion(async () => {
+      // `drop` rejects when the target's dragover listener never calls
+      // preventDefault(), which is Playwright's way of saying the element does
+      // not accept the payload.
+      await locator.drop(payload);
+    });
+  },
+});
+
 const hover = defineTabTool({
   capability: 'core',
   schema: {
@@ -587,6 +625,7 @@ export default [
   find,
   click,
   drag,
+  drop,
   hover,
   selectOption,
   scanPage

--- a/src/utils/jsSource.ts
+++ b/src/utils/jsSource.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Just enough of a JavaScript lexer to tell a function literal from an
+// expression, for callers that must decide from the source form alone. A parser
+// would be more exact, but the repo ships no runtime one and reaching into
+// Playwright's bundled Babel would add a deep private import for one question.
+
+const whitespace = /\s/;
+const identifierStart = /^[\p{ID_Start}$_][\p{ID_Continue}$]*/u;
+
+/**
+ * Whether `source` is a function literal -- `() => {}`, `function () {}`,
+ * `async x => x` -- as opposed to an expression that may merely evaluate to one.
+ */
+export function isFunctionSource(source: string): boolean {
+  let body = source.slice(skipTrivia(source, 0));
+  for (;;) {
+    const afterAsync = body.slice(skipAsyncKeyword(body));
+    if (/^function\b/.test(afterAsync) || hasArrowHead(afterAsync))
+      return true;
+    // `(() => 1)` and `(function () {})` are function literals inside grouping
+    // parentheses. Look inside before concluding this is an expression.
+    const inner = stripEnclosingParens(body);
+    if (inner === null)
+      return false;
+    body = inner.slice(skipTrivia(inner, 0));
+  }
+}
+
+function skipAsyncKeyword(source: string): number {
+  const keyword = /^async\b/.exec(source)?.[0];
+  return keyword ? skipTrivia(source, keyword.length) : 0;
+}
+
+/**
+ * Matches the head of an arrow function -- `x =>`, `(a, b) =>` -- without
+ * matching a parenthesised expression such as `(a + b)`. The `async` keyword is
+ * already stripped by the caller.
+ */
+function hasArrowHead(source: string): boolean {
+  let offset = 0;
+  if (source[0] === '(') {
+    const end = matchingParen(source, 0);
+    // The scanner does not model every parameter-list construct. When the match
+    // cannot be found, call it a function: passing a function through is the
+    // conservative answer, since a wrongly wrapped function fails silently
+    // while a wrongly passed-through expression fails loudly.
+    if (end === -1)
+      return true;
+    offset = end + 1;
+  } else {
+    const identifier = identifierStart.exec(source)?.[0];
+    if (!identifier)
+      return false;
+    offset = identifier.length;
+  }
+  return source.startsWith('=>', skipTrivia(source, offset));
+}
+
+function stripEnclosingParens(source: string): string | null {
+  if (source[0] !== '(')
+    return null;
+  const end = matchingParen(source, 0);
+  // Only a group that wraps the whole source: `(a) => a` closes early and its
+  // parentheses are a parameter list, not a group.
+  if (end === -1 || skipTrivia(source, end + 1) !== source.length)
+    return null;
+  return source.slice(1, end);
+}
+
+function matchingParen(source: string, start: number): number {
+  return matchingDelimiter(source, start, '(', ')');
+}
+
+/**
+ * Finds the delimiter closing the one at `start`, stepping over comments,
+ * strings, template substitutions and regular expression literals so that a
+ * bracket inside any of them is not counted.
+ */
+function matchingDelimiter(source: string, start: number, open: string, close: string): number {
+  let depth = 0;
+  for (let offset = start; offset < source.length; offset++) {
+    const char = source[offset];
+    if (char === '/' && (source[offset + 1] === '/' || source[offset + 1] === '*')) {
+      const end = skipTrivia(source, offset);
+      if (end === offset)
+        return -1;
+      offset = end - 1;
+    } else if (char === '"' || char === '\'' || char === '`') {
+      const end = endOfString(source, offset);
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === '/' && startsRegex(source, offset)) {
+      const end = endOfRegex(source, offset);
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === open) {
+      depth++;
+    } else if (char === close) {
+      depth--;
+      if (!depth)
+        return offset;
+    }
+  }
+  return -1;
+}
+
+function endOfString(source: string, start: number): number {
+  const quote = source[start];
+  for (let offset = start + 1; offset < source.length; offset++) {
+    const char = source[offset];
+    if (char === '\\') {
+      offset++;
+    } else if (quote === '`' && char === '$' && source[offset + 1] === '{') {
+      // A substitution can hold anything, including another template.
+      const end = matchingDelimiter(source, offset + 1, '{', '}');
+      if (end === -1)
+        return -1;
+      offset = end;
+    } else if (char === quote) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+// A slash directly after a value is division; anywhere else it opens a regular
+// expression. Parameter defaults are the case that matters here: `(a = /)/)`.
+function startsRegex(source: string, offset: number): boolean {
+  let index = offset - 1;
+  while (index >= 0 && whitespace.test(source[index]))
+    index--;
+  return index < 0 || !/[\w$)\]]/.test(source[index]);
+}
+
+function endOfRegex(source: string, start: number): number {
+  let inCharacterClass = false;
+  for (let offset = start + 1; offset < source.length; offset++) {
+    const char = source[offset];
+    if (char === '\\')
+      offset++;
+    else if (char === '\n')
+      return -1;
+    else if (inCharacterClass)
+      inCharacterClass = char !== ']';
+    else if (char === '[')
+      inCharacterClass = true;
+    else if (char === '/')
+      return offset;
+  }
+  return -1;
+}
+
+/** Offset of the first character at or after `offset` that is not whitespace or a comment. */
+export function skipTrivia(source: string, offset: number): number {
+  for (;;) {
+    while (offset < source.length && whitespace.test(source[offset]))
+      offset++;
+    if (source.startsWith('//', offset)) {
+      const lineEnd = source.indexOf('\n', offset);
+      if (lineEnd === -1)
+        return source.length;
+      offset = lineEnd + 1;
+    } else if (source.startsWith('/*', offset)) {
+      const commentEnd = source.indexOf('*/', offset + 2);
+      if (commentEnd === -1)
+        return source.length;
+      offset = commentEnd + 2;
+    } else {
+      return offset;
+    }
+  }
+}

--- a/tests/tools-evaluate.test.ts
+++ b/tests/tools-evaluate.test.ts
@@ -105,7 +105,7 @@ describe('browser_evaluate tool', () => {
   it('wraps a bare page expression into a function', async () => {
     await evaluateTool.handle(mockContext, { function: 'document.title' }, response);
 
-    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (\ndocument.title\n)');
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe(toFunctionSource('document.title', false));
     expect(response.code()).toContain('document.title');
   });
 
@@ -122,13 +122,14 @@ describe('browser_evaluate tool', () => {
         response
     );
 
-    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(element) => (\nelement.textContent\n)');
+    // The element case also proves the onElement plumbing picks the (element) form.
+    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe(toFunctionSource('element.textContent', true));
   });
 
   it('wraps an object literal expression without it parsing as a block', async () => {
     await evaluateTool.handle(mockContext, { function: '{ title: document.title }' }, response);
 
-    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (\n{ title: document.title }\n)');
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe(toFunctionSource('{ title: document.title }', false));
   });
 });
 
@@ -175,7 +176,6 @@ describe('toFunctionSource', () => {
     // Non-ASCII parameter names are still parameter names.
     'é => document.title',
     'ünnamed => document.title',
-    '_ => 1',
   ];
 
   for (const source of functionSources) {
@@ -231,32 +231,12 @@ describe('toFunctionSource', () => {
 });
 
 describe('browser_evaluate element pairing', () => {
-  function harness() {
-    const tab = {
-      modalStates: vi.fn().mockReturnValue([]),
-      page: { evaluate: vi.fn().mockResolvedValue('page-scope') },
-      refLocator: vi.fn(),
-      waitForCompletion: vi.fn(async (callback: () => Promise<void>) => await callback()),
-    };
-    return { tab, context: { currentTabOrDie: () => tab } as any };
-  }
+  const schema = evaluateTool.schema.inputSchema;
 
-  it('rejects a ref without an element instead of silently using page scope', async () => {
-    const { tab, context } = harness();
-    const response = new Response(context, 'browser_evaluate', {});
-
-    await expect(evaluateTool.handle(context, { function: 'element.textContent', ref: 'e1' }, response))
-        .rejects.toThrow(/Provide both "element" and "ref"/);
-
-    expect(tab.page.evaluate).not.toHaveBeenCalled();
-    expect(tab.refLocator).not.toHaveBeenCalled();
-  });
-
-  it('rejects an element without a ref', async () => {
-    const { context } = harness();
-    const response = new Response(context, 'browser_evaluate', {});
-
-    await expect(evaluateTool.handle(context, { function: 'element.id', element: 'the button' }, response))
-        .rejects.toThrow(/Provide both "element" and "ref"/);
+  it('requires element and ref together, so a lone ref cannot fall back to page scope', () => {
+    expect(schema.safeParse({ function: 'document.title' }).success).toBe(true);
+    expect(schema.safeParse({ function: 'element.id', element: 'the button', ref: 'e1' }).success).toBe(true);
+    expect(schema.safeParse({ function: 'element.textContent', ref: 'e1' }).success).toBe(false);
+    expect(schema.safeParse({ function: 'element.id', element: 'the button' }).success).toBe(false);
   });
 });

--- a/tests/tools-evaluate.test.ts
+++ b/tests/tools-evaluate.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import evaluateTools from '../src/tools/evaluate.js';
+import evaluateTools, { toFunctionSource } from '../src/tools/evaluate.js';
 import { Response } from '../src/response.js';
 import type { Context } from '../src/context.js';
 import type { Tab } from '../src/tab.js';
@@ -101,4 +101,83 @@ describe('browser_evaluate tool', () => {
     expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(el) => el.textContent');
     expect(response.result()).toContain('hello');
   });
+
+  it('wraps a bare page expression into a function', async () => {
+    await evaluateTool.handle(mockContext, { function: 'document.title' }, response);
+
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (document.title)');
+    expect(response.code()).toContain('() => (document.title)');
+  });
+
+  it('wraps a bare element expression so it can reference element', async () => {
+    const locatorEvaluate = vi.fn().mockResolvedValue('hello');
+    mockTab.refLocator.mockResolvedValue({
+      evaluate: locatorEvaluate,
+      _resolveSelector: async () => ({ resolvedSelector: 'internal:role=button' }),
+    });
+
+    await evaluateTool.handle(
+        mockContext,
+        { function: 'element.textContent', element: 'the button', ref: 'e1' },
+        response
+    );
+
+    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(element) => (element.textContent)');
+  });
+
+  it('wraps an object literal expression without it parsing as a block', async () => {
+    await evaluateTool.handle(mockContext, { function: '{ title: document.title }' }, response);
+
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => ({ title: document.title })');
+  });
+});
+
+describe('toFunctionSource', () => {
+  const functionSources = [
+    '() => 2 + 2',
+    '() => { return 2 + 2; }',
+    '(element) => element.textContent',
+    '(a, b) => a + b',
+    'element => element.textContent',
+    '_ => 1',
+    '$el => $el.id',
+    'async () => await fetch("/x")',
+    'async (element) => element.id',
+    'async(element) => element.id',
+    'function () { return 1; }',
+    'function named() { return 1; }',
+    'async function () { return 1; }',
+    '  \n () => 1',
+    '// pick the title\n() => document.title',
+    '/* pick the title */ () => document.title',
+    '({ a = (1, 2) }) => a',
+    '(a = ") => x") => a',
+  ];
+
+  for (const source of functionSources) {
+    it(`leaves the function form ${JSON.stringify(source)} untouched`, () => {
+      expect(toFunctionSource(source, false)).toBe(source);
+      expect(toFunctionSource(source, true)).toBe(source);
+    });
+  }
+
+  const expressionSources = [
+    'document.title',
+    '2 + 2',
+    'window.location.href',
+    '(a + b)',
+    '(1, 2)',
+    '{ a: 1 }',
+    'functionally.named.thing',
+    'asyncThing.value',
+    'async',
+    'document.querySelectorAll("a").length',
+  ];
+
+  for (const source of expressionSources) {
+    it(`wraps the expression ${JSON.stringify(source)}`, () => {
+      expect(toFunctionSource(source, false)).toBe(`() => (${source})`);
+      expect(toFunctionSource(source, true)).toBe(`(element) => (${source})`);
+    });
+  }
 });

--- a/tests/tools-evaluate.test.ts
+++ b/tests/tools-evaluate.test.ts
@@ -105,8 +105,8 @@ describe('browser_evaluate tool', () => {
   it('wraps a bare page expression into a function', async () => {
     await evaluateTool.handle(mockContext, { function: 'document.title' }, response);
 
-    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (document.title)');
-    expect(response.code()).toContain('() => (document.title)');
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (\ndocument.title\n)');
+    expect(response.code()).toContain('document.title');
   });
 
   it('wraps a bare element expression so it can reference element', async () => {
@@ -122,13 +122,13 @@ describe('browser_evaluate tool', () => {
         response
     );
 
-    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(element) => (element.textContent)');
+    expect(locatorEvaluate.mock.calls[0][0].toString()).toBe('(element) => (\nelement.textContent\n)');
   });
 
   it('wraps an object literal expression without it parsing as a block', async () => {
     await evaluateTool.handle(mockContext, { function: '{ title: document.title }' }, response);
 
-    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => ({ title: document.title })');
+    expect(pageEvaluate.mock.calls[0][0].toString()).toBe('() => (\n{ title: document.title }\n)');
   });
 });
 
@@ -152,6 +152,30 @@ describe('toFunctionSource', () => {
     '/* pick the title */ () => document.title',
     '({ a = (1, 2) }) => a',
     '(a = ") => x") => a',
+    // Function literals inside grouping parentheses: wrapping these would make
+    // the tool return a function value, which serializes to `undefined`.
+    '(() => document.title)',
+    '( () => document.title )',
+    '((element) => element.textContent)',
+    '(function () { return document.title; })',
+    '(async () => document.title)',
+    '((() => 1))',
+    '(\n  () => document.title\n)',
+    '(() => document.title) // trailing',
+    // Comments the scanner has to step over rather than count as parentheses.
+    'async /*c*/ () => document.title',
+    'async\n// why\n() => 1',
+    '(a /* ) */) => document.title',
+    "(a /* don't */) => document.title",
+    '(\n  a, // one )\n  b\n) => document.title',
+    'async /*c*/ function () { return 1; }',
+    // Parameter lists whose brackets hide inside a regex or a nested template.
+    '(a = /[)]/) => document.title',
+    '(a = `${`)`}`) => document.title',
+    // Non-ASCII parameter names are still parameter names.
+    'é => document.title',
+    'ünnamed => document.title',
+    '_ => 1',
   ];
 
   for (const source of functionSources) {
@@ -176,8 +200,63 @@ describe('toFunctionSource', () => {
 
   for (const source of expressionSources) {
     it(`wraps the expression ${JSON.stringify(source)}`, () => {
-      expect(toFunctionSource(source, false)).toBe(`() => (${source})`);
-      expect(toFunctionSource(source, true)).toBe(`(element) => (${source})`);
+      expect(toFunctionSource(source, false)).toBe(`() => (\n${source}\n)`);
+      expect(toFunctionSource(source, true)).toBe(`(element) => (\n${source}\n)`);
     });
   }
+
+  it('drops a trailing semicolon so the expression stays an expression', () => {
+    expect(toFunctionSource('document.title;', false)).toBe('() => (\ndocument.title\n)');
+    expect(toFunctionSource('document.title ; ', false)).toBe('() => (\ndocument.title\n)');
+  });
+
+  it('keeps a trailing line comment from swallowing the closing paren', () => {
+    const wrapped = toFunctionSource('document.title // the title', false);
+
+    expect(wrapped).toBe('() => (\ndocument.title // the title\n)');
+    expect(() => new Function(`return ${wrapped}`)).not.toThrow();
+  });
+
+  it('rejects an empty expression instead of emitting broken source', () => {
+    for (const empty of ['', '   ', '\n', ';', ' ;; '])
+      expect(() => toFunctionSource(empty, false)).toThrow(/empty/);
+  });
+
+  it('produces parseable source for every wrapped expression', () => {
+    for (const source of expressionSources) {
+      for (const onElement of [false, true])
+        expect(() => new Function(`return ${toFunctionSource(source, onElement)}`)).not.toThrow();
+    }
+  });
+});
+
+describe('browser_evaluate element pairing', () => {
+  function harness() {
+    const tab = {
+      modalStates: vi.fn().mockReturnValue([]),
+      page: { evaluate: vi.fn().mockResolvedValue('page-scope') },
+      refLocator: vi.fn(),
+      waitForCompletion: vi.fn(async (callback: () => Promise<void>) => await callback()),
+    };
+    return { tab, context: { currentTabOrDie: () => tab } as any };
+  }
+
+  it('rejects a ref without an element instead of silently using page scope', async () => {
+    const { tab, context } = harness();
+    const response = new Response(context, 'browser_evaluate', {});
+
+    await expect(evaluateTool.handle(context, { function: 'element.textContent', ref: 'e1' }, response))
+        .rejects.toThrow(/Provide both "element" and "ref"/);
+
+    expect(tab.page.evaluate).not.toHaveBeenCalled();
+    expect(tab.refLocator).not.toHaveBeenCalled();
+  });
+
+  it('rejects an element without a ref', async () => {
+    const { context } = harness();
+    const response = new Response(context, 'browser_evaluate', {});
+
+    await expect(evaluateTool.handle(context, { function: 'element.id', element: 'the button' }, response))
+        .rejects.toThrow(/Provide both "element" and "ref"/);
+  });
 });

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import networkTools from '../src/tools/network.js';
+import networkTools, { maxBodyLength } from '../src/tools/network.js';
 import { Response } from '../src/response.js';
 import type { Context } from '../src/context.js';
 import type { Tab } from '../src/tab.js';
@@ -162,6 +162,273 @@ describe('Network Tools', () => {
 
       expect(response.result()).toContain('https://api.example/upload?src=data%3Atext%2Fhtml%3Bbase64%2C...&id=123');
       expect(response.result()).not.toContain(payload);
+    });
+
+    it('should number the requests and point at the detail tool', async () => {
+      await networkTool.handle(mockContext, {}, response);
+
+      const result = response.result();
+      expect(result).toContain('[1] [GET] https://api.example.com/data => [200] OK');
+      expect(result).toContain('[2] [POST] https://api.example.com/user => [201] Created');
+      expect(result).toContain('[3] [GET] https://api.example.com/missing');
+      expect(result).toContain('browser_network_request');
+    });
+
+    it('should not advertise the detail tool when there are no requests', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(new Map());
+
+      await networkTool.handle(mockContext, {}, response);
+
+      expect(response.result()).toBe('');
+    });
+  });
+
+  describe('browser_network_request tool', () => {
+    const detailTool = networkTools.find(t => t.schema.name === 'browser_network_request')!;
+
+    function detailedRequests(overrides: {
+      request?: Record<string, unknown>,
+      response?: Record<string, unknown> | null,
+    } = {}) {
+      const request = {
+        url: () => 'https://api.example.com/data',
+        method: () => 'GET',
+        allHeaders: async () => ({ 'accept': 'application/json', 'x-trace': 'abc' }),
+        postData: () => null,
+        failure: () => null,
+        ...overrides.request,
+      };
+      const res = overrides.response === null ? null : {
+        status: () => 200,
+        statusText: () => 'OK',
+        allHeaders: async () => ({ 'content-type': 'application/json; charset=utf-8' }),
+        headerValue: async (name: string) => (name === 'content-type' ? 'application/json; charset=utf-8' : null),
+        body: async () => Buffer.from('{"ok":true}'),
+        ...overrides.response,
+      };
+      return new Map([[request, res]]);
+    }
+
+    it('should exist with the expected schema', () => {
+      expect(detailTool).toBeDefined();
+      expect(detailTool.schema.title).toBe('Get network request details');
+      expect(detailTool.schema.type).toBe('readOnly');
+    });
+
+    it('should report request headers, response headers and the response body', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).toContain('### [1] [GET] https://api.example.com/data');
+      expect(result).toContain('#### Request headers');
+      expect(result).toContain('accept: application/json');
+      expect(result).toContain('x-trace: abc');
+      expect(result).toContain('#### Response\n[200] OK');
+      expect(result).toContain('#### Response headers');
+      expect(result).toContain('content-type: application/json; charset=utf-8');
+      expect(result).toContain('#### Response body\n{"ok":true}');
+      expect(response.isError()).toBeFalsy();
+    });
+
+    it('should sort headers by name', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { allHeaders: async () => ({ 'zulu': '1', 'alpha': '2' }) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result.indexOf('alpha: 2')).toBeLessThan(result.indexOf('zulu: 1'));
+    });
+
+    it('should include the request body when there is post data', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { method: () => 'POST', postData: () => '{"name":"ada"}' },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('#### Request body\n{"name":"ada"}');
+    });
+
+    it('should omit the request body section when there is no post data', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).not.toContain('#### Request body');
+    });
+
+    it('should render a placeholder for binary response bodies', async () => {
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]);
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          headerValue: async () => 'image/png',
+          body: async () => bytes,
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain(`<binary data, ${bytes.length} bytes, image/png>`);
+    });
+
+    it('should render svg and other +xml bodies as text', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          headerValue: async () => 'image/svg+xml',
+          body: async () => Buffer.from('<svg></svg>'),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('<svg></svg>');
+    });
+
+    it('should sniff a missing content type and treat NUL bytes as binary', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          headerValue: async () => null,
+          body: async () => Buffer.from([0x61, 0x00, 0x62]),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('<binary data, 3 bytes>');
+    });
+
+    it('should treat a missing content type without NUL bytes as text', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          headerValue: async () => null,
+          body: async () => Buffer.from('plain text'),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('plain text');
+    });
+
+    it('should truncate long textual bodies', async () => {
+      const body = 'a'.repeat(maxBodyLength + 25);
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(body) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).toContain(`<truncated, showing the first ${maxBodyLength} of ${body.length} characters>`);
+      expect(result).not.toContain(body);
+    });
+
+    it('should leave a body of exactly the cap untruncated', async () => {
+      const body = 'a'.repeat(maxBodyLength);
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(body) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain(body);
+      expect(response.result()).not.toContain('<truncated');
+    });
+
+    it('should truncate a body one character over the cap', async () => {
+      const body = 'a'.repeat(maxBodyLength + 1);
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(body) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain(`<truncated, showing the first ${maxBodyLength} of ${maxBodyLength + 1} characters>`);
+    });
+
+    it('should reject a non-positive or fractional index at the schema', () => {
+      const schema = detailTool.schema.inputSchema;
+
+      expect(schema.safeParse({ index: 1 }).success).toBe(true);
+      expect(schema.safeParse({ index: 0 }).success).toBe(false);
+      expect(schema.safeParse({ index: -1 }).success).toBe(false);
+      expect(schema.safeParse({ index: 1.5 }).success).toBe(false);
+    });
+
+    it('should truncate data URLs inside the response body', async () => {
+      const payload = Buffer.from('<p>hello</p>').toString('base64');
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(`{"src":"data:text/html;base64,${payload}"}`) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('data:text/html;base64,...');
+      expect(response.result()).not.toContain(payload);
+    });
+
+    it('should report an empty response body', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.alloc(0) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('#### Response body\n<empty>');
+    });
+
+    it('should keep the report when the body cannot be read', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => { throw new Error('Response body is unavailable for redirect responses'); } },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).toContain('#### Response headers');
+      expect(result).toContain('<body unavailable: Response body is unavailable for redirect responses>');
+      expect(response.isError()).toBeFalsy();
+    });
+
+    it('should report a request that failed', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { failure: () => ({ errorText: 'net::ERR_CONNECTION_REFUSED' }) },
+        response: null,
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('The request failed: net::ERR_CONNECTION_REFUSED');
+    });
+
+    it('should report a request that is still in flight', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({ response: null }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('The request has not completed yet.');
+    });
+
+    it('should error on an out of range index', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
+
+      await detailTool.handle(mockContext, { index: 4 }, response);
+
+      expect(response.isError()).toBe(true);
+      expect(response.result()).toContain('numbered 1 to 1');
+    });
+
+    it('should error when nothing has been recorded', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(new Map());
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.isError()).toBe(true);
+      expect(response.result()).toContain('No network requests have been recorded');
     });
   });
 

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -41,6 +41,7 @@ describe('Network Tools', () => {
     mockTab = {
       requests: vi.fn().mockReturnValue(mockRequests),
       modalStates: vi.fn().mockReturnValue([]),
+      withPageStateTimeout: async (promise: Promise<unknown>) => promise,
     } as any;
 
     mockContext = {
@@ -227,7 +228,7 @@ describe('Network Tools', () => {
       expect(result).toContain('#### Response\n[200] OK');
       expect(result).toContain('#### Response headers');
       expect(result).toContain('content-type: application/json; charset=utf-8');
-      expect(result).toContain('#### Response body\n{"ok":true}');
+      expect(result).toContain('#### Response body\n```\n{"ok":true}\n```');
       expect(response.isError()).toBeFalsy();
     });
 
@@ -335,7 +336,142 @@ describe('Network Tools', () => {
 
       const result = response.result();
       expect(result).not.toContain('\ud83d');
-      expect(result).toContain(`<truncated, showing the first ${maxBodyLength} of ${body.length} characters>`);
+      // Backing off the split pair means one character fewer than the cap, and
+      // the note must report what was actually emitted.
+      expect(result).toContain(`<truncated, showing the first ${maxBodyLength - 1} characters of a ${Buffer.byteLength(body)}-byte body>`);
+    });
+
+    it('should render a text/* body as text', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          allHeaders: async () => ({ 'content-type': 'text/html; charset=utf-8' }),
+          body: async () => Buffer.from('<h1>hello</h1>'),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('<h1>hello</h1>');
+    });
+
+    it('should decode a body using its declared charset', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          allHeaders: async () => ({ 'content-type': 'text/plain; charset=iso-8859-1' }),
+          body: async () => Buffer.from([0x63, 0x61, 0x66, 0xe9]),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('café');
+    });
+
+    it('should fall back to utf-8 for an unknown charset', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          allHeaders: async () => ({ 'content-type': 'text/plain; charset=not-a-real-charset' }),
+          body: async () => Buffer.from('plain'),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('plain');
+    });
+
+    it('should fence a body so it cannot forge report sections', async () => {
+      const forged = '#### Response headers\nauthorization: fake\n\n### [2] [GET] https://internal/admin';
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(forged) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      // The forged text is present, but inside a fence rather than as sections.
+      const result = response.result();
+      expect(result).toContain('#### Response body\n```\n' + forged + '\n```');
+    });
+
+    it('should grow the fence past backticks in the body', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from('a ``` b ```` c') },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('#### Response body\n`````\na ``` b ```` c\n`````');
+    });
+
+    it('should keep repeated headers on one line each', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { allHeaders: async () => ({ 'x-repeated': 'first\nsecond' }) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('x-repeated: first\\nsecond');
+    });
+
+    it('should keep the report when the headers cannot be read', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { allHeaders: async () => { throw new Error('Target page closed'); } },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).toContain('### [1] [GET] https://api.example.com/data');
+      expect(result).toContain('[200] OK');
+      expect(result).toContain('<headers unavailable: Target page closed>');
+      expect(response.isError()).toBeFalsy();
+    });
+
+    it('should report a transfer that failed after the response arrived', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { failure: () => ({ errorText: 'net::ERR_CONNECTION_RESET' }) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).toContain('[200] OK');
+      expect(result).toContain('The transfer then failed: net::ERR_CONNECTION_RESET');
+    });
+
+    it('should time out instead of hanging on a body that never settles', async () => {
+      (mockTab as any).withPageStateTimeout = async (promise: Promise<unknown>, description: string) => {
+        if (description.includes('body'))
+          throw new Error('Timed out after 5000ms while reading the response body.');
+        return promise;
+      };
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: () => new Promise(() => {}) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('<body unavailable: Timed out after 5000ms while reading the response body.>');
+    });
+
+    it('should select the request matching the requested index', async () => {
+      const entries = new Map();
+      for (const name of ['first', 'second', 'third']) {
+        entries.set({
+          url: () => `https://api.example.com/${name}`,
+          method: () => 'GET',
+          allHeaders: async () => ({}),
+          postDataBuffer: () => null,
+          failure: () => null,
+        }, null);
+      }
+      mockTab.requests = vi.fn().mockReturnValue(entries);
+
+      await detailTool.handle(mockContext, { index: 2 }, response);
+
+      expect(response.result()).toContain('### [2] [GET] https://api.example.com/second');
+      expect(response.result()).not.toContain('/first');
+      expect(response.result()).not.toContain('/third');
     });
 
     it('should sort headers by name', async () => {
@@ -356,7 +492,7 @@ describe('Network Tools', () => {
 
       await detailTool.handle(mockContext, { index: 1 }, response);
 
-      expect(response.result()).toContain('#### Request body\n{"name":"ada"}');
+      expect(response.result()).toContain('#### Request body\n```\n{"name":"ada"}\n```');
     });
 
     it('should omit the request body section when there is no post data', async () => {
@@ -429,7 +565,7 @@ describe('Network Tools', () => {
       await detailTool.handle(mockContext, { index: 1 }, response);
 
       const result = response.result();
-      expect(result).toContain(`<truncated, showing the first ${maxBodyLength} of ${body.length} characters>`);
+      expect(result).toContain(`<truncated, showing the first ${maxBodyLength} characters of a ${body.length}-byte body>`);
       expect(result).not.toContain(body);
     });
 
@@ -453,7 +589,7 @@ describe('Network Tools', () => {
 
       await detailTool.handle(mockContext, { index: 1 }, response);
 
-      expect(response.result()).toContain(`<truncated, showing the first ${maxBodyLength} of ${maxBodyLength + 1} characters>`);
+      expect(response.result()).toContain(`<truncated, showing the first ${maxBodyLength} characters of a ${maxBodyLength + 1}-byte body>`);
     });
 
     it('should reject a non-positive or fractional index at the schema', () => {

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -194,7 +194,7 @@ describe('Network Tools', () => {
         url: () => 'https://api.example.com/data',
         method: () => 'GET',
         allHeaders: async () => ({ 'accept': 'application/json', 'x-trace': 'abc' }),
-        postData: () => null,
+        postDataBuffer: () => null,
         failure: () => null,
         ...overrides.request,
       };
@@ -202,7 +202,6 @@ describe('Network Tools', () => {
         status: () => 200,
         statusText: () => 'OK',
         allHeaders: async () => ({ 'content-type': 'application/json; charset=utf-8' }),
-        headerValue: async (name: string) => (name === 'content-type' ? 'application/json; charset=utf-8' : null),
         body: async () => Buffer.from('{"ok":true}'),
         ...overrides.response,
       };
@@ -232,6 +231,113 @@ describe('Network Tools', () => {
       expect(response.isError()).toBeFalsy();
     });
 
+    it('should redact credential-bearing headers', async () => {
+      const secrets = {
+        'authorization': 'Bearer sk-secret-token-value',
+        'cookie': 'session=abc123; theme=dark',
+        'proxy-authorization': 'Basic dXNlcjpwYXNz',
+        'x-api-key': 'key-12345',
+        'x-auth-token': 'token-67890',
+      };
+      const setCookie = 'session=xyz789; HttpOnly';
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { allHeaders: async () => ({ ...secrets, 'accept': 'application/json' }) },
+        response: { allHeaders: async () => ({ 'content-type': 'application/json', 'set-cookie': setCookie }) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      for (const [name, value] of Object.entries(secrets)) {
+        expect(result).not.toContain(value);
+        expect(result).toContain(`${name}: <redacted, ${value.length} characters>`);
+      }
+      expect(result).not.toContain(setCookie);
+      expect(result).toContain(`set-cookie: <redacted, ${setCookie.length} characters>`);
+      // Non-sensitive headers are still reported in full.
+      expect(result).toContain('accept: application/json');
+    });
+
+    it('should redact sensitive headers regardless of name casing', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: { allHeaders: async () => ({ 'Authorization': 'Bearer leaky', 'Cookie': 'session=leaky' }) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).not.toContain('leaky');
+    });
+
+    it('should summarise a binary request body instead of decoding it as text', async () => {
+      const upload = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe]);
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        request: {
+          method: () => 'POST',
+          allHeaders: async () => ({ 'content-type': 'image/png' }),
+          postDataBuffer: () => upload,
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain(`#### Request body\n<binary data, ${upload.length} bytes, image/png>`);
+      expect(response.result()).not.toContain('�');
+    });
+
+    it('should render a multipart upload as text until a part turns binary', async () => {
+      const textual = detailedRequests({
+        request: {
+          method: () => 'POST',
+          allHeaders: async () => ({ 'content-type': 'multipart/form-data; boundary=----abc' }),
+          postDataBuffer: () => Buffer.from('------abc\r\nContent-Disposition: form-data; name="a"\r\n\r\nvalue\r\n'),
+        },
+      });
+      mockTab.requests = vi.fn().mockReturnValue(textual);
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+      expect(response.result()).toContain('name="a"');
+
+      const binary = detailedRequests({
+        request: {
+          method: () => 'POST',
+          allHeaders: async () => ({ 'content-type': 'multipart/form-data; boundary=----abc' }),
+          postDataBuffer: () => Buffer.from([0x2d, 0x2d, 0x61, 0x00, 0x01, 0x02]),
+        },
+      });
+      const second = new Response(mockContext, 'test_tool', {});
+      mockTab.requests = vi.fn().mockReturnValue(binary);
+
+      await detailTool.handle(mockContext, { index: 1 }, second);
+      expect(second.result()).toContain('<binary data, 6 bytes, multipart/form-data>');
+    });
+
+    it('should treat a content type with no space after the semicolon as text', async () => {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: {
+          allHeaders: async () => ({ 'content-type': 'application/json;charset=utf-8' }),
+          body: async () => Buffer.from('{"ok":true}'),
+        },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      expect(response.result()).toContain('{"ok":true}');
+    });
+
+    it('should not split a surrogate pair when truncating', async () => {
+      // The cap lands exactly between the two halves of the final emoji.
+      const body = 'a'.repeat(maxBodyLength - 1) + '\u{1f600}';
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+        response: { body: async () => Buffer.from(body) },
+      }));
+
+      await detailTool.handle(mockContext, { index: 1 }, response);
+
+      const result = response.result();
+      expect(result).not.toContain('\ud83d');
+      expect(result).toContain(`<truncated, showing the first ${maxBodyLength} of ${body.length} characters>`);
+    });
+
     it('should sort headers by name', async () => {
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
         request: { allHeaders: async () => ({ 'zulu': '1', 'alpha': '2' }) },
@@ -245,7 +351,7 @@ describe('Network Tools', () => {
 
     it('should include the request body when there is post data', async () => {
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        request: { method: () => 'POST', postData: () => '{"name":"ada"}' },
+        request: { method: () => 'POST', postDataBuffer: () => Buffer.from('{"name":"ada"}') },
       }));
 
       await detailTool.handle(mockContext, { index: 1 }, response);
@@ -265,7 +371,7 @@ describe('Network Tools', () => {
       const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]);
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
         response: {
-          headerValue: async () => 'image/png',
+          allHeaders: async () => ({ 'content-type': 'image/png' }),
           body: async () => bytes,
         },
       }));
@@ -278,7 +384,7 @@ describe('Network Tools', () => {
     it('should render svg and other +xml bodies as text', async () => {
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
         response: {
-          headerValue: async () => 'image/svg+xml',
+          allHeaders: async () => ({ 'content-type': 'image/svg+xml' }),
           body: async () => Buffer.from('<svg></svg>'),
         },
       }));
@@ -291,7 +397,7 @@ describe('Network Tools', () => {
     it('should sniff a missing content type and treat NUL bytes as binary', async () => {
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
         response: {
-          headerValue: async () => null,
+          allHeaders: async () => ({}),
           body: async () => Buffer.from([0x61, 0x00, 0x62]),
         },
       }));
@@ -304,7 +410,7 @@ describe('Network Tools', () => {
     it('should treat a missing content type without NUL bytes as text', async () => {
       mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
         response: {
-          headerValue: async () => null,
+          allHeaders: async () => ({}),
           body: async () => Buffer.from('plain text'),
         },
       }));

--- a/tests/tools-network.test.ts
+++ b/tests/tools-network.test.ts
@@ -209,6 +209,16 @@ describe('Network Tools', () => {
       return new Map([[request, res]]);
     }
 
+    // Setup, call and read-back in one step: every detail test needs all three,
+    // and keeping them together removes the chance of asserting on a stale
+    // Response after re-pointing the fixture.
+    async function detail(overrides: Parameters<typeof detailedRequests>[0] = {}, index = 1) {
+      mockTab.requests = vi.fn().mockReturnValue(detailedRequests(overrides));
+      const result = new Response(mockContext, 'browser_network_request', {});
+      await detailTool.handle(mockContext, { index }, result);
+      return result;
+    }
+
     it('should exist with the expected schema', () => {
       expect(detailTool).toBeDefined();
       expect(detailTool.schema.title).toBe('Get network request details');
@@ -216,9 +226,7 @@ describe('Network Tools', () => {
     });
 
     it('should report request headers, response headers and the response body', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      response = await detail();
 
       const result = response.result();
       expect(result).toContain('### [1] [GET] https://api.example.com/data');
@@ -241,12 +249,10 @@ describe('Network Tools', () => {
         'x-auth-token': 'token-67890',
       };
       const setCookie = 'session=xyz789; HttpOnly';
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { allHeaders: async () => ({ ...secrets, 'accept': 'application/json' }) },
         response: { allHeaders: async () => ({ 'content-type': 'application/json', 'set-cookie': setCookie }) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       for (const [name, value] of Object.entries(secrets)) {
@@ -260,79 +266,51 @@ describe('Network Tools', () => {
     });
 
     it('should redact sensitive headers regardless of name casing', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { allHeaders: async () => ({ 'Authorization': 'Bearer leaky', 'Cookie': 'session=leaky' }) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).not.toContain('leaky');
     });
 
     it('should summarise a binary request body instead of decoding it as text', async () => {
       const upload = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe]);
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: {
           method: () => 'POST',
           allHeaders: async () => ({ 'content-type': 'image/png' }),
           postDataBuffer: () => upload,
         },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain(`#### Request body\n<binary data, ${upload.length} bytes, image/png>`);
       expect(response.result()).not.toContain('�');
     });
 
-    it('should render a multipart upload as text until a part turns binary', async () => {
-      const textual = detailedRequests({
+    // An unrecognised type is decided by the bytes, so the same content type
+    // renders either way depending on what the parts actually hold.
+    it.each([
+      ['text parts', Buffer.from('------abc\r\nContent-Disposition: form-data; name="a"\r\n\r\nvalue\r\n'), 'name="a"'],
+      ['a binary part', Buffer.from([0x2d, 0x2d, 0x61, 0x00, 0x01, 0x02]), '<binary data, 6 bytes, multipart/form-data>'],
+    ])('should render a multipart upload with %s accordingly', async (_name, postData, expected) => {
+      response = await detail({
         request: {
           method: () => 'POST',
           allHeaders: async () => ({ 'content-type': 'multipart/form-data; boundary=----abc' }),
-          postDataBuffer: () => Buffer.from('------abc\r\nContent-Disposition: form-data; name="a"\r\n\r\nvalue\r\n'),
+          postDataBuffer: () => postData,
         },
       });
-      mockTab.requests = vi.fn().mockReturnValue(textual);
 
-      await detailTool.handle(mockContext, { index: 1 }, response);
-      expect(response.result()).toContain('name="a"');
-
-      const binary = detailedRequests({
-        request: {
-          method: () => 'POST',
-          allHeaders: async () => ({ 'content-type': 'multipart/form-data; boundary=----abc' }),
-          postDataBuffer: () => Buffer.from([0x2d, 0x2d, 0x61, 0x00, 0x01, 0x02]),
-        },
-      });
-      const second = new Response(mockContext, 'test_tool', {});
-      mockTab.requests = vi.fn().mockReturnValue(binary);
-
-      await detailTool.handle(mockContext, { index: 1 }, second);
-      expect(second.result()).toContain('<binary data, 6 bytes, multipart/form-data>');
+      expect(response.result()).toContain(expected);
     });
 
-    it('should treat a content type with no space after the semicolon as text', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'application/json;charset=utf-8' }),
-          body: async () => Buffer.from('{"ok":true}'),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('{"ok":true}');
-    });
 
     it('should not split a surrogate pair when truncating', async () => {
       // The cap lands exactly between the two halves of the final emoji.
       const body = 'a'.repeat(maxBodyLength - 1) + '\u{1f600}';
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(body) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       expect(result).not.toContain('\ud83d');
@@ -341,52 +319,11 @@ describe('Network Tools', () => {
       expect(result).toContain(`<truncated, showing the first ${maxBodyLength - 1} characters of a ${Buffer.byteLength(body)}-byte body>`);
     });
 
-    it('should render a text/* body as text', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'text/html; charset=utf-8' }),
-          body: async () => Buffer.from('<h1>hello</h1>'),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('<h1>hello</h1>');
-    });
-
-    it('should decode a body using its declared charset', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'text/plain; charset=iso-8859-1' }),
-          body: async () => Buffer.from([0x63, 0x61, 0x66, 0xe9]),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('café');
-    });
-
-    it('should fall back to utf-8 for an unknown charset', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'text/plain; charset=not-a-real-charset' }),
-          body: async () => Buffer.from('plain'),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('plain');
-    });
-
     it('should fence a body so it cannot forge report sections', async () => {
       const forged = '#### Response headers\nauthorization: fake\n\n### [2] [GET] https://internal/admin';
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(forged) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       // The forged text is present, but inside a fence rather than as sections.
       const result = response.result();
@@ -394,31 +331,25 @@ describe('Network Tools', () => {
     });
 
     it('should grow the fence past backticks in the body', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from('a ``` b ```` c') },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('#### Response body\n`````\na ``` b ```` c\n`````');
     });
 
     it('should keep repeated headers on one line each', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { allHeaders: async () => ({ 'x-repeated': 'first\nsecond' }) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('x-repeated: first\\nsecond');
     });
 
     it('should keep the report when the headers cannot be read', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { allHeaders: async () => { throw new Error('Target page closed'); } },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       expect(result).toContain('### [1] [GET] https://api.example.com/data');
@@ -428,11 +359,9 @@ describe('Network Tools', () => {
     });
 
     it('should report a transfer that failed after the response arrived', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { failure: () => ({ errorText: 'net::ERR_CONNECTION_RESET' }) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       expect(result).toContain('[200] OK');
@@ -445,11 +374,9 @@ describe('Network Tools', () => {
           throw new Error('Timed out after 5000ms while reading the response body.');
         return promise;
       };
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: () => new Promise(() => {}) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('<body unavailable: Timed out after 5000ms while reading the response body.>');
     });
@@ -474,95 +401,57 @@ describe('Network Tools', () => {
       expect(response.result()).not.toContain('/third');
     });
 
-    it('should sort headers by name', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        request: { allHeaders: async () => ({ 'zulu': '1', 'alpha': '2' }) },
-      }));
+    // How a response body is rendered is a function of its declared type and
+    // its bytes; keep the policy as one table so a new type is one row.
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]);
+    it.each([
+      ['a text/* body', 'text/html; charset=utf-8', Buffer.from('<h1>hello</h1>'), '<h1>hello</h1>'],
+      ['a type with no space after the semicolon', 'application/json;charset=utf-8', Buffer.from('{"ok":true}'), '{"ok":true}'],
+      ['a declared non-utf-8 charset', 'text/plain; charset=iso-8859-1', Buffer.from([0x63, 0x61, 0x66, 0xe9]), 'café'],
+      ['an unknown charset, falling back to utf-8', 'text/plain; charset=not-a-real-charset', Buffer.from('plain'), 'plain'],
+      ['a binary type', 'image/png', pngBytes, `<binary data, ${pngBytes.length} bytes, image/png>`],
+      ['a +xml suffix', 'image/svg+xml', Buffer.from('<svg></svg>'), '<svg></svg>'],
+      ['no type, sniffed as binary by its NUL byte', '', Buffer.from([0x61, 0x00, 0x62]), '<binary data, 3 bytes>'],
+      ['no type, sniffed as text', '', Buffer.from('plain text'), 'plain text'],
+    ])('should render %s', async (_name, contentType, body, expected) => {
+      response = await detail({
+        response: {
+          allHeaders: async () => (contentType ? { 'content-type': contentType } : {}),
+          body: async () => body,
+        },
+      });
 
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      expect(response.result()).toContain(expected);
+    });
+
+    it('should sort headers by name', async () => {
+      response = await detail({
+        request: { allHeaders: async () => ({ 'zulu': '1', 'alpha': '2' }) },
+      });
 
       const result = response.result();
       expect(result.indexOf('alpha: 2')).toBeLessThan(result.indexOf('zulu: 1'));
     });
 
     it('should include the request body when there is post data', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { method: () => 'POST', postDataBuffer: () => Buffer.from('{"name":"ada"}') },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('#### Request body\n```\n{"name":"ada"}\n```');
     });
 
     it('should omit the request body section when there is no post data', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      response = await detail();
 
       expect(response.result()).not.toContain('#### Request body');
     });
 
-    it('should render a placeholder for binary response bodies', async () => {
-      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]);
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'image/png' }),
-          body: async () => bytes,
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain(`<binary data, ${bytes.length} bytes, image/png>`);
-    });
-
-    it('should render svg and other +xml bodies as text', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({ 'content-type': 'image/svg+xml' }),
-          body: async () => Buffer.from('<svg></svg>'),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('<svg></svg>');
-    });
-
-    it('should sniff a missing content type and treat NUL bytes as binary', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({}),
-          body: async () => Buffer.from([0x61, 0x00, 0x62]),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('<binary data, 3 bytes>');
-    });
-
-    it('should treat a missing content type without NUL bytes as text', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
-        response: {
-          allHeaders: async () => ({}),
-          body: async () => Buffer.from('plain text'),
-        },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
-
-      expect(response.result()).toContain('plain text');
-    });
-
     it('should truncate long textual bodies', async () => {
       const body = 'a'.repeat(maxBodyLength + 25);
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(body) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       expect(result).toContain(`<truncated, showing the first ${maxBodyLength} characters of a ${body.length}-byte body>`);
@@ -571,11 +460,9 @@ describe('Network Tools', () => {
 
     it('should leave a body of exactly the cap untruncated', async () => {
       const body = 'a'.repeat(maxBodyLength);
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(body) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain(body);
       expect(response.result()).not.toContain('<truncated');
@@ -583,11 +470,9 @@ describe('Network Tools', () => {
 
     it('should truncate a body one character over the cap', async () => {
       const body = 'a'.repeat(maxBodyLength + 1);
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(body) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain(`<truncated, showing the first ${maxBodyLength} characters of a ${maxBodyLength + 1}-byte body>`);
     });
@@ -603,32 +488,26 @@ describe('Network Tools', () => {
 
     it('should truncate data URLs inside the response body', async () => {
       const payload = Buffer.from('<p>hello</p>').toString('base64');
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.from(`{"src":"data:text/html;base64,${payload}"}`) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('data:text/html;base64,...');
       expect(response.result()).not.toContain(payload);
     });
 
     it('should report an empty response body', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => Buffer.alloc(0) },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('#### Response body\n<empty>');
     });
 
     it('should keep the report when the body cannot be read', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         response: { body: async () => { throw new Error('Response body is unavailable for redirect responses'); } },
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       const result = response.result();
       expect(result).toContain('#### Response headers');
@@ -637,28 +516,22 @@ describe('Network Tools', () => {
     });
 
     it('should report a request that failed', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({
+      response = await detail({
         request: { failure: () => ({ errorText: 'net::ERR_CONNECTION_REFUSED' }) },
         response: null,
-      }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      });
 
       expect(response.result()).toContain('The request failed: net::ERR_CONNECTION_REFUSED');
     });
 
     it('should report a request that is still in flight', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests({ response: null }));
-
-      await detailTool.handle(mockContext, { index: 1 }, response);
+      response = await detail({ response: null });
 
       expect(response.result()).toContain('The request has not completed yet.');
     });
 
     it('should error on an out of range index', async () => {
-      mockTab.requests = vi.fn().mockReturnValue(detailedRequests());
-
-      await detailTool.handle(mockContext, { index: 4 }, response);
+      response = await detail({}, 4);
 
       expect(response.isError()).toBe(true);
       expect(response.result()).toContain('numbered 1 to 1');

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -770,6 +770,17 @@ describe('browser_drop', () => {
     }
   });
 
+  it('should refuse to drop while a modal state is pending', async () => {
+    const harness = dropHarness();
+    harness.tab.modalStates = vi.fn().mockReturnValue([{ type: 'dialog', description: 'alert' }]);
+    harness.tab.modalStatesMarkdown = vi.fn().mockReturnValue(['- alert']);
+
+    await dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', data: { 'text/plain': 'hi' } }, harness.response as any);
+
+    expect(harness.drop).not.toHaveBeenCalled();
+    expect(harness.response.addError).toHaveBeenCalledWith(expect.stringContaining('does not handle the modal state'));
+  });
+
   it('should settle the page through waitForCompletion', async () => {
     const harness = dropHarness();
 
@@ -847,6 +858,9 @@ describe.skipIf(!fs.existsSync(chromium.executablePath()))('browser_drop in a re
   it('fails when the target rejects the payload', async () => {
     const rejecting = `<div id="zone" style="width:200px;height:100px">no drops</div>`;
 
-    await expect(runDrop(rejecting, { data: { 'text/plain': 'hello' } })).rejects.toThrow();
+    // Assert the specific rejection, so a setup failure inside runDrop cannot
+    // masquerade as the behaviour under test.
+    await expect(runDrop(rejecting, { data: { 'text/plain': 'hello' } }))
+        .rejects.toThrow(/did not call preventDefault/);
   });
 });

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -706,3 +706,147 @@ function findResponse() {
     addError: vi.fn(),
   };
 }
+
+describe('browser_drop', () => {
+  const dropTool = snapshotTools.find(tool => tool.schema.name === 'browser_drop')!;
+
+  function dropHarness() {
+    const drop = vi.fn().mockResolvedValue(undefined);
+    const locator = { drop, normalize: async () => ({ toString: () => `getByTestId('zone')` }) };
+    const tab = {
+      modalStates: vi.fn().mockReturnValue([]),
+      refLocator: vi.fn().mockResolvedValue(locator),
+      waitForCompletion: vi.fn(async (callback: () => Promise<void>) => await callback()),
+    };
+    const response = { setIncludeSnapshot: vi.fn(), addCode: vi.fn(), addResult: vi.fn(), addError: vi.fn() };
+    return { drop, tab, response, context: { currentTabOrDie: () => tab } };
+  }
+
+  it('should expose a destructive tool with optional paths and data', () => {
+    const jsonSchema = toMcpTool(dropTool.schema).inputSchema as JSONSchema7;
+
+    expect(dropTool.schema.type).toBe('destructive');
+    expect(dropTool.capability).toBe('core');
+    expect((jsonSchema.required ?? []).sort()).toEqual(['element', 'ref']);
+    expect((jsonSchema.properties?.paths as JSONSchema7).type).toBe('array');
+    expect((jsonSchema.properties?.data as JSONSchema7).type).toBe('object');
+  });
+
+  it('should drop files onto the element', async () => {
+    const harness = dropHarness();
+
+    await dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', paths: ['/tmp/a.txt'] }, harness.response as any);
+
+    expect(harness.tab.refLocator).toHaveBeenCalledWith(expect.objectContaining({ ref: 'e1', element: 'Dropzone' }));
+    expect(harness.drop).toHaveBeenCalledWith({ files: ['/tmp/a.txt'] });
+    expect(harness.response.setIncludeSnapshot).toHaveBeenCalled();
+    expect(harness.response.addCode).toHaveBeenCalledWith(`await page.getByTestId('zone').drop({"files":["/tmp/a.txt"]});`);
+  });
+
+  it('should drop clipboard-like data onto the element', async () => {
+    const harness = dropHarness();
+
+    await dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', data: { 'text/plain': 'hello' } }, harness.response as any);
+
+    expect(harness.drop).toHaveBeenCalledWith({ data: { 'text/plain': 'hello' } });
+  });
+
+  it('should drop files and data together', async () => {
+    const harness = dropHarness();
+
+    await dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', paths: ['/tmp/a.txt'], data: { 'text/plain': 'hello' } }, harness.response as any);
+
+    expect(harness.drop).toHaveBeenCalledWith({ files: ['/tmp/a.txt'], data: { 'text/plain': 'hello' } });
+  });
+
+  it('should reject a drop with no payload', async () => {
+    for (const params of [{}, { paths: [] }, { data: {} }, { paths: [], data: {} }]) {
+      const harness = dropHarness();
+
+      await expect(dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', ...params }, harness.response as any))
+          .rejects.toThrow('Provide "paths", "data" or both');
+
+      expect(harness.drop).not.toHaveBeenCalled();
+    }
+  });
+
+  it('should settle the page through waitForCompletion', async () => {
+    const harness = dropHarness();
+
+    await dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', data: { 'text/plain': 'hi' } }, harness.response as any);
+
+    expect(harness.tab.waitForCompletion).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe.skipIf(!fs.existsSync(chromium.executablePath()))('browser_drop in a real browser', () => {
+  const dropTool = snapshotTools.find(tool => tool.schema.name === 'browser_drop')!;
+  let browser: Browser;
+  let scratchDir: string;
+
+  const dropzone = `
+    <div id="zone" style="width:200px;height:100px">drop here</div>
+    <script>
+      window.dropped = null;
+      const zone = document.getElementById('zone');
+      zone.addEventListener('dragover', event => event.preventDefault());
+      zone.addEventListener('drop', event => {
+        event.preventDefault();
+        window.dropped = {
+          text: event.dataTransfer.getData('text/plain'),
+          uri: event.dataTransfer.getData('text/uri-list'),
+          files: [...event.dataTransfer.files].map(file => ({ name: file.name, type: file.type })),
+        };
+      });
+    </script>`;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ headless: true, chromiumSandbox: false });
+    scratchDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-a11y-drop-'));
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await fs.promises.rm(scratchDir, { recursive: true, force: true });
+  });
+
+  async function runDrop(html: string, params: Record<string, unknown>) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.setContent(html);
+    const tab = {
+      modalStates: () => [],
+      refLocator: async () => page.locator('#zone'),
+      waitForCompletion: async (callback: () => Promise<void>) => await callback(),
+    };
+    const response = { setIncludeSnapshot: vi.fn(), addCode: vi.fn(), addResult: vi.fn(), addError: vi.fn() };
+    try {
+      await dropTool.handle({ currentTabOrDie: () => tab } as any, { element: 'Dropzone', ref: 'e1', ...params } as any, response as any);
+      return { dropped: await page.evaluate(() => (window as any).dropped), code: response.addCode.mock.calls.map(call => call[0]).join('\n') };
+    } finally {
+      await context.close();
+    }
+  }
+
+  it('drops clipboard-like data onto a real drop zone', async () => {
+    const { dropped, code } = await runDrop(dropzone, { data: { 'text/plain': 'hello world', 'text/uri-list': 'https://example.com' } });
+
+    expect(dropped).toMatchObject({ text: 'hello world', uri: 'https://example.com' });
+    expect(code).toContain('.drop(');
+  });
+
+  it('drops a real file onto a real drop zone', async () => {
+    const filePath = path.join(scratchDir, 'note.txt');
+    await fs.promises.writeFile(filePath, 'hello');
+
+    const { dropped } = await runDrop(dropzone, { paths: [filePath] });
+
+    expect(dropped.files).toEqual([{ name: 'note.txt', type: 'text/plain' }]);
+  });
+
+  it('fails when the target rejects the payload', async () => {
+    const rejecting = `<div id="zone" style="width:200px;height:100px">no drops</div>`;
+
+    await expect(runDrop(rejecting, { data: { 'text/plain': 'hello' } })).rejects.toThrow();
+  });
+});

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -707,6 +707,10 @@ function findResponse() {
   };
 }
 
+function dropResponse() {
+  return { setIncludeSnapshot: vi.fn(), addCode: vi.fn(), addResult: vi.fn(), addError: vi.fn() };
+}
+
 describe('browser_drop', () => {
   const dropTool = snapshotTools.find(tool => tool.schema.name === 'browser_drop')!;
 
@@ -718,8 +722,7 @@ describe('browser_drop', () => {
       refLocator: vi.fn().mockResolvedValue(locator),
       waitForCompletion: vi.fn(async (callback: () => Promise<void>) => await callback()),
     };
-    const response = { setIncludeSnapshot: vi.fn(), addCode: vi.fn(), addResult: vi.fn(), addError: vi.fn() };
-    return { drop, tab, response, context: { currentTabOrDie: () => tab } };
+    return { drop, tab, response: dropResponse(), context: { currentTabOrDie: () => tab } };
   }
 
   it('should expose a destructive tool with optional paths and data', () => {
@@ -759,15 +762,16 @@ describe('browser_drop', () => {
     expect(harness.drop).toHaveBeenCalledWith({ files: ['/tmp/a.txt'], data: { 'text/plain': 'hello' } });
   });
 
-  it('should reject a drop with no payload', async () => {
+  it('should reject a drop with no payload at the schema', () => {
+    const schema = dropTool.schema.inputSchema;
+
     for (const params of [{}, { paths: [] }, { data: {} }, { paths: [], data: {} }]) {
-      const harness = dropHarness();
-
-      await expect(dropTool.handle(harness.context as any, { element: 'Dropzone', ref: 'e1', ...params }, harness.response as any))
-          .rejects.toThrow('Provide "paths", "data" or both');
-
-      expect(harness.drop).not.toHaveBeenCalled();
+      const parsed = schema.safeParse({ element: 'Dropzone', ref: 'e1', ...params });
+      expect(parsed.success).toBe(false);
+      expect(parsed.error!.issues.some(issue => issue.message.includes('Provide "paths", "data" or both'))).toBe(true);
     }
+    expect(schema.safeParse({ element: 'Dropzone', ref: 'e1', paths: ['/tmp/a.txt'] }).success).toBe(true);
+    expect(schema.safeParse({ element: 'Dropzone', ref: 'e1', data: { 'text/plain': 'x' } }).success).toBe(true);
   });
 
   it('should refuse to drop while a modal state is pending', async () => {
@@ -830,7 +834,7 @@ describe.skipIf(!fs.existsSync(chromium.executablePath()))('browser_drop in a re
       refLocator: async () => page.locator('#zone'),
       waitForCompletion: async (callback: () => Promise<void>) => await callback(),
     };
-    const response = { setIncludeSnapshot: vi.fn(), addCode: vi.fn(), addResult: vi.fn(), addError: vi.fn() };
+    const response = dropResponse();
     try {
       await dropTool.handle({ currentTabOrDie: () => tab } as any, { element: 'Dropzone', ref: 'e1', ...params } as any, response as any);
       return { dropped: await page.evaluate(() => (window as any).dropped), code: response.addCode.mock.calls.map(call => call[0]).join('\n') };


### PR DESCRIPTION
Implements the three items tracked in #116, plus review fixes and a cleanup pass.

## 1. `browser_network_request` (new) — headers & bodies

`browser_network_requests` had an empty input schema and rendered only `[METHOD] url => [status] statusText`, so there was no way to reach response headers or bodies.

- `browser_network_requests` now numbers its lines (`[1] [GET] … => [200] OK`) and points at the detail tool.
- New `browser_network_request { index }` returns request headers, request body, response status, response headers and response body.
- **Credential headers are redacted.** `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key` and `x-auth-token` render as `<redacted, N characters>` — presence and size stay debuggable, the secret never reaches the transcript.
- **Binary bodies are summarised**, not dumped, for both request and response. `text/*`, `+json`/`+xml` and known textual types are text; `image/`, `audio/`, `video/`, `font/`, `model/` and known binary types are binary; anything unrecognised (`multipart/form-data`, custom types, a missing type) is decided by sniffing the bytes.
- **Bodies are decoded with the declared charset**, so a `windows-1252` or `shift_jis` page is not turned into replacement characters.
- **Bodies are fenced.** They are page-controlled and could otherwise forge the report's own `####` sections; the fence grows past any backtick run inside.
- Textual bodies are capped at 20000 characters (per body), and only the first `4 × cap` bytes are ever decoded, so a huge response cannot allocate a string twice its size.
- **Every blocking read is bounded** by the tab's page-state timeout. `Response.body()` and `allHeaders()` have no timeout of their own, so an SSE or long-poll response would otherwise hang the call until the page closed. A read that fails reports in place (`<headers unavailable: …>`, `<body unavailable: …>`) instead of discarding the rest of the report.
- A request that failed *after* its response arrived reports both the status and the failure, rather than a clean 200.
- Bodies, request bodies and header values all go through `truncateDataUrls`, so the new output paths cannot leak untruncated `data:` payloads.

The issue left open whether to mirror the option-flags shape or the newer index-based detail tool. Upstream source was not reachable from this environment (`raw.githubusercontent.com` 404s, `api.github.com`/`playwright.dev` 403 through the proxy, and `microsoft/playwright` cannot be attached to this session), so this implements the **index-based detail tool** the issue describes as current upstream.

## 2. `browser_evaluate` — accept plain expressions

`function` now accepts a bare expression as well as a function form: `document.title` behaves like `() => document.title`, and `element.textContent` becomes `(element) => (…)` when `element` and `ref` are both given.

The decision is made from the **source form**, never from the runtime type of the result — so `window.open` is returned, not invoked. (Deciding by `typeof` at runtime was suggested during review and deliberately rejected: it reintroduces exactly that bug, which this repo's review checklist already records.)

Detection handles function literals inside grouping parens (`(() => x)`, `(function () {})`), comments after `async`, comments/regex literals/nested template substitutions inside a parameter list, and non-ASCII parameter names. Where the scanner still cannot find the end of a parameter list it treats the source as a function — passing one through is the behaviour that predates expression support and fails loudly, whereas wrapping one fails silently.

`element` and `ref` are now paired by the schema (mirroring `browser_take_screenshot`), so a lone `ref` no longer silently evaluates against the page.

## 3. `browser_drop` (new)

`Locator.drop` turned out to be for simulating an **external** drag-and-drop of files or clipboard-like data onto an element — not for completing a drag started elsewhere, as the issue tentatively described. It covers the case `browser_drag` cannot: a drop zone where no drag ever starts inside the page.

- Parameters: `element`, `ref`, `paths` (file paths) and/or `data` (mime type → value map); at least one of `paths`/`data` is required by the schema.
- Generated code uses `JSON.stringify` so non-identifier keys like `'text/plain'` stay quoted. This deviates from the house `codegen.formatObject` on purpose — that helper emits bare `text/plain:` keys, which is the exact defect recorded in the findings catalog.
- `paths` are read on the **server host**, exactly as `browser_file_upload` does, and unlike that tool no file chooser needs to be open. The README says so plainly. Confining one tool while the other stays open would be security theatre, so that is flagged for a maintainer decision rather than patched here.

## On #134

No code changes — #134 is already fully implemented on `main` by `af891d3`: `timeouts.settle`, `--timeout-settle`, `PLAYWRIGHT_MCP_TIMEOUT_SETTLE`, `waitForCompletion` reading the configured value, README docs and tests. The open question there (keep the 1000 ms fork default or adopt upstream's 500 ms) was resolved as 500 ms. It looks safe to close.

## Structure

The last commit is a cleanup pass with no behaviour change: the general JS lexer moved out of `evaluate.ts` (259 → 98 lines) into `src/utils/jsSource.ts`; `network.ts` separates blocking reads (in `handle`, which owns the tab) from rendering (pure, plain data), so `Tab` left three signatures; and the tests lost ~300 lines of repeated setup to one helper and a table.

## Testing

- `npm run lint` (oxlint --type-aware + tsc) and `npm run build` clean.
- `npm test`: **678 pass**. The 23 failures in `tools-auditScreenReader.test.ts` are pre-existing and environmental — that file calls `chromium.launch()` with no availability guard and this sandbox has an older Chromium than the pinned build. Verified identical on a clean checkout of `main`.
- `npm run test:mcp` (real server, real browser, end-to-end): **30/31 pass**, `browser_install` skipped as usual. The harness covers `browser_network_request` (real headers, a real binary PNG body, out-of-range index, and a real session cookie proven redacted), `browser_drop` (real data and file drops, plus empty-payload rejection) and `browser_evaluate` bare expressions on both page and element. A local run needs `--executable-path` to reach the sandbox's Chromium; that scaffolding is not part of the diff.

Closes #116