### PR TITLE
Add end-to-end latency benchmarking and optimize axe scanning

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -237,7 +237,8 @@
         "tests/tools-axe.test.ts",
         "tests/tools-scanPageMatrix.test.ts",
         "tests/tools-auditKeyboard.test.ts",
-        "tests/tools-auditSite.integration.test.ts"
+        "tests/tools-auditSite.integration.test.ts",
+        "bench/**"
       ],
       "rules": {
         "notice/notice": "off"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Test: `npm test`
 - Coverage: `npm run test:coverage`
 - Docker smoke test: `npm run test:docker`
+- Tool latency benchmark: `npm run bench` (see the Benchmarking section of `README.md`; build first, and compare revisions with `npm run bench:compare`)
 - TypeScript config is driven by `tsconfig.json` and `tsconfig.all.json`.
 - Accessibility behavior centers around Axe + Playwright integrations in `src/tools/axe.ts`, `src/tools/auditSite.ts`, `src/tools/auditKeyboard.ts`, and related helpers.
 - Keep output and report paths compatible with the current README and CLI expectations.

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Create a `config.json` file with the following options:
 - `browser.contextOptions.storageState`: Start each session from a recorded Playwright storage state; applied in every mode except `--extension` (fresh contexts receive it at creation, reused contexts via `setStorageState()`). Sessions that share one reused context (non-isolated CDP modes) get the state applied once per context — a session joining a live context inherits its current state, not a fresh copy of the file; see [Auditing pages behind a login](#auditing-pages-behind-a-login)
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
-- `timeouts.settle`: How long to wait after an action that started network work or navigated, for that work to settle before responding (default: `500`). An action that issued no request and navigated nowhere has nothing in flight and does not wait at all.
+- `timeouts.settle`: How long to wait after an action that started network work or navigated, for that work to settle before responding (default: `500`). An action that finishes quietly is watched for up to 100ms (or the settle delay, whichever is shorter) in case it scheduled work rather than starting it; if nothing appears in that window, the response goes out without the settle delay.
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies only after actions that actually started something: a click that fired a request or navigated waits it out, a click that only changed local DOM state responds immediately.
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after actions that actually started something: a click that fires a request or navigates waits it out, while a click that only changed local DOM state responds without it. Work the action scheduled on a timer still counts — a short window after the action catches it before the response is built.
 
 #### HTTP Heartbeat
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ In `audit_site`, selectors apply to every crawled page, so an `includeSelectors`
 **Incomplete ("needs review") results:**
 Axe returns `incomplete` for checks it cannot decide on its own -- contrast over a background image or gradient, ambiguous labels, elements it could not fully evaluate. `scan_page`, `audit_site`, and `scan_page_matrix` report these in a section separate from violations so you can resolve them by inspecting the page (screenshot, snapshot, `browser_evaluate`). Set `includeIncomplete: false` to suppress them.
 
+**Frames that could not be scanned:**
+Axe is installed into every frame of the page before the scan runs. A frame that navigates mid-injection, or whose renderer does not answer within a second, is left out -- and its contents then contribute no findings. Rather than let that pass as a clean result, all three scan tools print a `WARNING: Axe could not be installed in N frame(s)` block listing the frame URLs, and `audit_site` and `scan_page_matrix` also record them per page and per variant in their JSON reports (`unscannedFrames`) and in `structuredContent`. A frame that was still loading usually succeeds on a re-run; one that fails consistently has to be audited on its own.
+
 ### Audit Tools
 
 #### `audit_site`

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Runs Axe scans on the same page across viewport/media/zoom variants and compares
 - Default variants: baseline, mobile, desktop, forced-colors, reduced-motion, zoom-200
 - Supports custom variants and optional reload between variants
 - Always writes a JSON report (default filename: `scan-matrix-{timestamp}.json`)
+- JSON report schema `v2` sets `diffFromBaseline` to `null` when either scan left frames unscanned, because their coverage is not comparable
 
 **Example flow:**
 ```text

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Create a `config.json` file with the following options:
 - `browser.contextOptions.storageState`: Start each session from a recorded Playwright storage state; applied in every mode except `--extension` (fresh contexts receive it at creation, reused contexts via `setStorageState()`). Sessions that share one reused context (non-isolated CDP modes) get the state applied once per context — a session joining a live context inherits its current state, not a fresh copy of the file; see [Auditing pages behind a login](#auditing-pages-behind-a-login)
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
-- `timeouts.settle`: How long to wait after each action for triggered work to settle before responding (default: `500`)
+- `timeouts.settle`: How long to wait after an action that started network work or navigated, for that work to settle before responding (default: `500`). An action that issued no request and navigated nowhere has nothing in flight and does not wait at all.
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay.
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies only after actions that actually started something: a click that fired a request or navigated waits it out, a click that only changed local DOM state responds immediately.
 
 #### HTTP Heartbeat
 
@@ -692,6 +692,30 @@ Clone and set up the project:
 git clone https://github.com/JustasMonkev/mcp-accessibility-scanner.git
 cd mcp-accessibility-scanner
 npm install
+```
+
+### Benchmarking tool latency
+
+`bench/mcp-bench.mjs` measures what a client actually waits for: it serves a fixed
+synthetic site, speaks MCP to the built server over stdio, and times real
+`tools/call` round trips for navigation, interaction, snapshots and every audit
+tool. Build first — it runs the compiled server from `lib/`.
+
+```bash
+npm run build
+npm run bench -- --out after.json --label after
+```
+
+Useful flags: `--iterations <n>` and `--warmups <n>` (defaults 5 and 1),
+`--browser`/`--executable-path` when the browser lives outside Playwright's own
+download directory, and `--server <path/to/cli.js>` plus `--lib <path/to/lib>` to
+point at a different build — that is how a revision is compared with another:
+
+```bash
+git worktree add /tmp/baseline main && (cd /tmp/baseline && npm install && npm run build)
+npm run bench -- --server /tmp/baseline/cli.js --lib /tmp/baseline/lib --out before.json --label before
+npm run bench -- --out after.json --label after
+npm run bench:compare -- before.json after.json
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -726,6 +726,9 @@ npm run bench -- --out after.json --label after
 npm run bench:compare -- before.json after.json
 ```
 
+The comparison total uses only end-to-end scenarios present in both reports,
+so adding or removing a scenario does not distort the reported speedup.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Create a `config.json` file with the following options:
 - `browser.contextOptions.storageState`: Start each session from a recorded Playwright storage state; applied in every mode except `--extension` (fresh contexts receive it at creation, reused contexts via `setStorageState()`). Sessions that share one reused context (non-isolated CDP modes) get the state applied once per context — a session joining a live context inherits its current state, not a fresh copy of the file; see [Auditing pages behind a login](#auditing-pages-behind-a-login)
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
-- `timeouts.settle`: How long to wait after an action that started network work or navigated, for that work to settle before responding (default: `500`). An action that finishes quietly is watched for up to 100ms (or the settle delay, whichever is shorter) in case it scheduled work rather than starting it; if nothing appears in that window, the response goes out without the settle delay.
+- `timeouts.settle`: How long to wait after every action before responding (default: `500`). An action that finishes quietly is first watched for up to 100ms (or the settle delay, whichever is shorter) so scheduled network work can still be awaited before the settle delay.
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after actions that actually started something: a click that fires a request or navigates — including one that only swaps an iframe's document, which a `srcdoc` or `data:` URL does without touching the network — waits it out, while a click that only changed local DOM state responds without it. Work the action scheduled on a timer still counts — a short window after the action catches it before the response is built.
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after every action so delayed DOM-only updates are included in the response; a short observation window also catches scheduled requests and waits for them before that delay.
 
 #### HTTP Heartbeat
 
@@ -388,7 +388,7 @@ Runs Axe scans on the same page across viewport/media/zoom variants and compares
 - Default variants: baseline, mobile, desktop, forced-colors, reduced-motion, zoom-200
 - Supports custom variants and optional reload between variants
 - Always writes a JSON report (default filename: `scan-matrix-{timestamp}.json`)
-- JSON report schema `v2` sets `diffFromBaseline` to `null` when either scan left frames unscanned, because their coverage is not comparable
+- JSON report and structured result schema `v2` set baseline deltas to `null` when either scan left frames unscanned, because their coverage is not comparable
 
 **Example flow:**
 ```text

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Axe returns `incomplete` for checks it cannot decide on its own -- contrast over
 **Frames that could not be scanned:**
 Axe is installed into every frame of the page before the scan runs. A frame that navigates mid-injection, or whose renderer does not answer within a second, is left out -- and its contents then contribute no findings. Rather than let that pass as a clean result, all three scan tools print a `WARNING: Axe could not be installed in N frame(s)` block listing the frame URLs, and `audit_site` and `scan_page_matrix` also record them per page and per variant in their JSON reports (`unscannedFrames`) and in `structuredContent`. A frame that was still loading usually succeeds on a re-run; one that fails consistently has to be audited on its own.
 
+A frame you scoped out yourself is not reported: with `excludeSelectors: ["iframe.intercom-frame"]` that widget failing to load is the outcome you asked for, not a gap. Scope is resolved through the whole frame chain, so an `includeSelectors` entry naming an ancestor still covers frames nested several levels below it, and excluding an outer frame silences everything inside it. Anything the check cannot resolve is reported rather than hidden.
+
 ### Audit Tools
 
 #### `audit_site`

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Create a `config.json` file with the following options:
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after actions that actually started something: a click that fires a request or navigates waits it out, while a click that only changed local DOM state responds without it. Work the action scheduled on a timer still counts — a short window after the action catches it before the response is built.
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after actions that actually started something: a click that fires a request or navigates — including one that only swaps an iframe's document, which a `srcdoc` or `data:` URL does without touching the network — waits it out, while a click that only changed local DOM state responds without it. Work the action scheduled on a timer still counts — a short window after the action catches it before the response is built.
 
 #### HTTP Heartbeat
 
@@ -363,7 +363,9 @@ Axe returns `incomplete` for checks it cannot decide on its own -- contrast over
 **Frames that could not be scanned:**
 Axe is installed into every frame of the page before the scan runs. A frame that navigates mid-injection, or whose renderer does not answer within a second, is left out -- and its contents then contribute no findings. Rather than let that pass as a clean result, all three scan tools print a `WARNING: Axe could not be installed in N frame(s)` block listing the frame URLs, and `audit_site` and `scan_page_matrix` also record them per page and per variant in their JSON reports (`unscannedFrames`) and in `structuredContent`. A frame that was still loading usually succeeds on a re-run; one that fails consistently has to be audited on its own.
 
-A frame you scoped out yourself is not reported: with `excludeSelectors: ["iframe.intercom-frame"]` that widget failing to load is the outcome you asked for, not a gap. Scope is resolved through the whole frame chain, so an `includeSelectors` entry naming an ancestor still covers frames nested several levels below it, and excluding an outer frame silences everything inside it. Anything the check cannot resolve is reported rather than hidden.
+A nested frame is reported when any frame above it went unscanned, even if its own injection succeeded: Axe reaches a nested document only by relaying through the frames above it, so an outer frame without Axe takes everything below it out of the scan.
+
+A frame you scoped out yourself is not reported: with `excludeSelectors: ["iframe.intercom-frame"]` that widget failing to load is the outcome you asked for, not a gap. Scope is resolved through the whole frame chain and across shadow boundaries, so an `includeSelectors` entry naming an ancestor still covers frames nested several levels below it or inside a shadow root, and excluding an outer frame or a shadow host silences everything inside it. Anything the check cannot resolve is reported rather than hidden.
 
 ### Audit Tools
 

--- a/README.md
+++ b/README.md
@@ -716,8 +716,8 @@ npm run bench -- --out after.json --label after
 
 Useful flags: `--iterations <n>` and `--warmups <n>` (defaults 5 and 1),
 `--browser`/`--executable-path` when the browser lives outside Playwright's own
-download directory, and `--server <path/to/cli.js>` plus `--lib <path/to/lib>` to
-point at a different build — that is how a revision is compared with another:
+download directory, and `--server <path/to/cli.js>` plus `--lib <path/to/lib>`
+(supplied together) to point at a different build — that is how revisions compare:
 
 ```bash
 git worktree add /tmp/baseline main && (cd /tmp/baseline && npm install && npm run build)

--- a/SKILL.md
+++ b/SKILL.md
@@ -93,7 +93,7 @@ Scan the current page for accessibility violations using Axe.
 {"violationsTag": ["wcag2aa", "wcag21aa", "wcag22aa"]}
 ```
 
-For Electron CDP targets, `scan_page` may currently fail with `Target.createTarget: Not supported`. If that happens, keep using the CLI session, select the live app tab with `browser_tabs`, and run Axe through `browser_evaluate` by injecting the local `node_modules/axe-core/axe.min.js` bundle.
+The scan injects Axe into the frames that are already open and runs it there; it no longer opens a helper page, which is what used to fail on Electron CDP targets with `Target.createTarget: Not supported`. If a scan still fails on such a target, keep using the CLI session, select the live app tab with `browser_tabs`, and run Axe through `browser_evaluate` by injecting the local `node_modules/axe-core/axe.min.js` bundle.
 
 ### audit_site
 
@@ -311,7 +311,7 @@ Typical REPL flow:
 > browser_evaluate {"function":"() => document.querySelector('SELECTOR_FOR_NEXT_STEP')?.click()"}
 ```
 
-If `scan_page {}` fails on the Electron target, use this Axe fallback from the same REPL session:
+If `scan_page {}` still fails on the Electron target, use this Axe fallback from the same REPL session:
 
 ```json
 {

--- a/bench/fixture.mjs
+++ b/bench/fixture.mjs
@@ -18,10 +18,15 @@ function heavyPage() {
     // A mix of named and unnamed controls so axe finds real violations and the
     // aria snapshot has interactive refs to click.
     const missingAlt = random() < 0.2;
+    // Every fifth button is genuinely unnamed - no label, and an aria-hidden
+    // glyph for its only content - so the scan really does report button-name.
+    const unnamed = index % 5 === 0;
     rows.push([
       '<li class="row">',
       `<a href="/page-${index % 12}.html">${label} link</a>`,
-      `<button id="btn-${index}" ${index % 5 === 0 ? '' : `aria-label="Action ${index}"`}>Go ${index}</button>`,
+      unnamed
+        ? `<button id="btn-${index}"><span aria-hidden="true">&#9654;</span></button>`
+        : `<button id="btn-${index}" aria-label="Action ${index}">Go ${index}</button>`,
       `<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" ${missingAlt ? '' : `alt="Thumb ${index}"`}>`,
       `<span class="muted" style="color:#bbb;background:#fff">Low contrast text ${index}</span>`,
       '</li>',
@@ -53,7 +58,7 @@ function smallPage(index) {
     `<a href="/page-${(index + 1) % 12}.html">Next page</a>`,
     `<a href="/page-${(index + 2) % 12}.html">Skip ahead</a>`,
     `<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">`,
-    '<button>Unlabelled</button>',
+    '<button><span aria-hidden="true">&#9654;</span></button>',
     '</main></body></html>',
   ].join('');
 }

--- a/bench/fixture.mjs
+++ b/bench/fixture.mjs
@@ -1,0 +1,91 @@
+/**
+ * Deterministic pages served to the benchmarked MCP server.
+ *
+ * The markup is generated from a fixed seed so every run - and every revision
+ * compared against another - scans exactly the same DOM.
+ */
+
+const seededRandom = seed => () => {
+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+  return seed / 0x7fffffff;
+};
+
+function heavyPage() {
+  const random = seededRandom(42);
+  const rows = [];
+  for (let index = 0; index < 220; index++) {
+    const label = `Item ${index}`;
+    // A mix of named and unnamed controls so axe finds real violations and the
+    // aria snapshot has interactive refs to click.
+    const missingAlt = random() < 0.2;
+    rows.push([
+      '<li class="row">',
+      `<a href="/page-${index % 12}.html">${label} link</a>`,
+      `<button id="btn-${index}" ${index % 5 === 0 ? '' : `aria-label="Action ${index}"`}>Go ${index}</button>`,
+      `<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" ${missingAlt ? '' : `alt="Thumb ${index}"`}>`,
+      `<span class="muted" style="color:#bbb;background:#fff">Low contrast text ${index}</span>`,
+      '</li>',
+    ].join(''));
+  }
+  return [
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">',
+    '<title>Benchmark heavy page</title>',
+    '<style>.row{display:flex;gap:4px;align-items:center}.muted{font-size:12px}',
+    'button{min-width:12px;min-height:12px}img{width:16px;height:16px}</style>',
+    '</head><body>',
+    '<a href="#main" class="skip">Skip to main content</a>',
+    '<header><nav><a href="/page-1.html">Home</a><a href="/page-2.html">Docs</a></nav></header>',
+    '<main id="main"><h1>Benchmark heavy page</h1>',
+    '<form><label>Search <input aria-label="Search" name="q"></label>',
+    '<select aria-label="Sort"><option>Newest</option><option>Oldest</option></select>',
+    '<button type="button" id="submit" aria-label="Submit search">Submit</button></form>',
+    `<ul>${rows.join('')}</ul>`,
+    '</main></body></html>',
+  ].join('');
+}
+
+function smallPage(index) {
+  return [
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">',
+    `<title>Benchmark page ${index}</title></head><body>`,
+    `<main><h1>Page ${index}</h1>`,
+    `<p>Body copy for page ${index}.</p>`,
+    `<a href="/page-${(index + 1) % 12}.html">Next page</a>`,
+    `<a href="/page-${(index + 2) % 12}.html">Skip ahead</a>`,
+    `<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">`,
+    '<button>Unlabelled</button>',
+    '</main></body></html>',
+  ].join('');
+}
+
+export const pages = new Map([
+  ['/', heavyPage()],
+  ['/heavy.html', heavyPage()],
+  ...Array.from({ length: 12 }, (_, index) => [`/page-${index}.html`, smallPage(index)]),
+]);
+
+/** A string with many embedded data URLs, for the string-processing micro benchmark. */
+export function dataUrlHeavyText(repeat = 400) {
+  const payload = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'.repeat(4);
+  const lines = [];
+  for (let index = 0; index < repeat; index++) {
+    lines.push(`- img "Thumb ${index}" [ref=e${index}]:`);
+    lines.push(`  - /url: data:image/gif;base64,${payload}`);
+    lines.push(`- text: plain aria node ${index} with no url at all`);
+    lines.push(`- link "Item ${index}" [ref=e${index}b]:`);
+    lines.push(`  - /url: https://example.com/page-${index}`);
+  }
+  return lines.join('\n');
+}
+
+/** A large aria snapshot with no data URLs at all - the common case. */
+export function plainSnapshotText(repeat = 2000) {
+  const lines = [];
+  for (let index = 0; index < repeat; index++) {
+    lines.push(`- listitem [ref=e${index}]:`);
+    lines.push(`  - link "Item ${index} link" [ref=e${index}a]: /page-${index % 12}.html`);
+    lines.push(`  - button "Action ${index}" [ref=e${index}b]`);
+    lines.push(`  - text: Low contrast text ${index}`);
+  }
+  return lines.join('\n');
+}

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -323,7 +323,7 @@ function parseArgs(argv) {
   // silently skipped report after a full benchmark run.
   const value = (index, flag) => {
     const next = argv[index];
-    if (next === undefined || next.startsWith('--'))
+    if (next === undefined || next.startsWith('--') || !next.trim())
       throw new Error(`${flag} needs a value, got: ${next ?? '(nothing)'}`);
     return next;
   };

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -273,10 +273,16 @@ function compare(beforePath, afterPath) {
   const after = JSON.parse(fs.readFileSync(afterPath, 'utf-8'));
   const byName = new Map(before.scenarios.map(entry => [entry.name, entry]));
   const rows = [['Scenario', `${before.label} (ms)`, `${after.label} (ms)`, 'Change', 'Speedup']];
+  let beforeTotal = 0;
+  let afterTotal = 0;
   for (const entry of after.scenarios) {
     const baseline = byName.get(entry.name);
     if (!baseline)
       continue;
+    if (!entry.micro && !baseline.micro) {
+      beforeTotal += baseline.median;
+      afterTotal += entry.median;
+    }
     const change = (entry.median - baseline.median) / baseline.median * 100;
     rows.push([
       entry.name,
@@ -286,13 +292,15 @@ function compare(beforePath, afterPath) {
       `${(baseline.median / entry.median).toFixed(2)}x`,
     ]);
   }
-  const totalChange = (after.totalMedianMs - before.totalMedianMs) / before.totalMedianMs * 100;
+  if (!beforeTotal)
+    throw new Error('The reports have no end-to-end scenarios in common.');
+  const totalChange = (afterTotal - beforeTotal) / beforeTotal * 100;
   rows.push([
     'TOTAL (end-to-end tool calls)',
-    format(before.totalMedianMs),
-    format(after.totalMedianMs),
+    format(beforeTotal),
+    format(afterTotal),
     `${totalChange >= 0 ? '+' : ''}${totalChange.toFixed(1)}%`,
-    `${(before.totalMedianMs / after.totalMedianMs).toFixed(2)}x`,
+    `${(beforeTotal / afterTotal).toFixed(2)}x`,
   ]);
   const widths = rows[0].map((_, column) => Math.max(...rows.map(row => row[column].length)));
   rows.forEach((row, index) => {

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -145,27 +145,32 @@ const scenarios = [
 ];
 
 const results = [];
-for (const scenario of scenarios) {
-  const samples = [];
-  let state;
-  for (let index = 0; index < warmups + iterations; index++) {
-    state = scenario.setup ? await scenario.setup() : undefined;
-    const startedAt = performance.now();
-    await scenario.run(state);
-    const elapsed = performance.now() - startedAt;
-    if (index >= warmups)
-      samples.push(elapsed);
+try {
+  for (const scenario of scenarios) {
+    const samples = [];
+    let state;
+    for (let index = 0; index < warmups + iterations; index++) {
+      state = scenario.setup ? await scenario.setup() : undefined;
+      const startedAt = performance.now();
+      await scenario.run(state);
+      const elapsed = performance.now() - startedAt;
+      if (index >= warmups)
+        samples.push(elapsed);
+    }
+    const stats = summarize(samples);
+    results.push({ name: scenario.name, ...stats });
+    process.stderr.write(`${scenario.name.padEnd(34)} median ${stats.median.toFixed(1).padStart(9)} ms   mean ${stats.mean.toFixed(1).padStart(9)} ms\n`);
   }
-  const stats = summarize(samples);
-  results.push({ name: scenario.name, ...stats });
-  process.stderr.write(`${scenario.name.padEnd(34)} median ${stats.median.toFixed(1).padStart(9)} ms   mean ${stats.mean.toFixed(1).padStart(9)} ms\n`);
+
+  results.push(...await runMicroBenchmarks());
+} finally {
+  // A scenario that throws must not leave the server process, the browser it
+  // launched, or the temporary report directory behind: a few failed runs would
+  // otherwise pile up orphaned Chromiums.
+  await client.close().catch(() => {});
+  await new Promise(resolve => server.close(resolve));
+  fs.rmSync(outputDir, { recursive: true, force: true });
 }
-
-results.push(...await runMicroBenchmarks());
-
-await client.close().catch(() => {});
-await new Promise(resolve => server.close(resolve));
-fs.rmSync(outputDir, { recursive: true, force: true });
 
 const report = {
   label: options.label ?? 'run',

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -84,7 +84,9 @@ const scenarios = [
     run: state => call('browser_click', { element: 'Submit search button', ref: state.ref }),
   },
   {
-    name: 'browser_type (ref + snapshot)',
+    // browser_type only asks for a snapshot on its `slowly` and `submit` paths,
+    // so a plain fill is what this measures: ref resolution plus the settle.
+    name: 'browser_type (ref, fill only)',
     setup: async () => {
       const snapshot = await call('browser_navigate', { url: `${origin}/heavy.html` });
       return { ref: refFor(snapshot, 'Search') };
@@ -311,11 +313,21 @@ function parseArgs(argv) {
     else if (arg === '--executable-path')
       parsed.executablePath = argv[++index];
     else if (arg === '--iterations')
-      parsed.iterations = Number(argv[++index]);
+      parsed.iterations = wholeNumber(argv[++index], arg, 1);
     else if (arg === '--warmups')
-      parsed.warmups = Number(argv[++index]);
+      parsed.warmups = wholeNumber(argv[++index], arg, 0);
     else
       throw new Error(`Unknown argument: ${arg}`);
   }
+  return parsed;
+}
+
+// A missing or non-numeric count would otherwise reach the sampling loop as NaN,
+// collect no samples, and crash while formatting undefined statistics - after
+// the fixture server and the browser have already started.
+function wholeNumber(value, flag, minimum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum)
+    throw new Error(`${flag} needs an integer >= ${minimum}, got: ${value ?? '(nothing)'}`);
   return parsed;
 }

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+/**
+ * End-to-end latency benchmark for the MCP tool surface.
+ *
+ * Every scenario is a real `tools/call` against a real browser driven by the
+ * built server, so the numbers include the MCP round trip, Playwright IPC and
+ * the page work - the latency a client actually waits for.
+ *
+ * Usage:
+ *   node bench/mcp-bench.mjs --out results.json [--label name] [--iterations 5]
+ *   node bench/mcp-bench.mjs --server /path/to/other/cli.js --lib /path/to/other/lib
+ *   node bench/mcp-bench.mjs --compare before.json after.json
+ */
+
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { dataUrlHeavyText, pages, plainSnapshotText } from './fixture.mjs';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const options = parseArgs(process.argv.slice(2));
+
+if (options.compare) {
+  compare(options.compare[0], options.compare[1]);
+  process.exit(0);
+}
+
+const serverEntry = options.server ? path.resolve(options.server) : path.join(projectRoot, 'cli.js');
+const libRoot = options.lib ? path.resolve(options.lib) : path.join(projectRoot, 'lib');
+const iterations = options.iterations ?? 5;
+const warmups = options.warmups ?? 1;
+
+const server = await startFixtureServer();
+const origin = `http://127.0.0.1:${server.address().port}`;
+const outputDir = fs.mkdtempSync(path.join(process.env.TMPDIR ?? '/tmp', 'mcp-bench-'));
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [
+    serverEntry,
+    '--headless',
+    '--no-sandbox',
+    '--isolated',
+    '--browser', options.browser ?? 'chromium',
+    '--output-dir', outputDir,
+    // Sandboxes and CI images often ship a browser outside Playwright's own
+    // download directory; point at it explicitly when asked.
+    ...(options.executablePath ? ['--executable-path', options.executablePath] : []),
+  ],
+  cwd: projectRoot,
+});
+const client = new Client({ name: 'mcp-bench', version: '1.0.0' });
+await client.connect(transport);
+
+/**
+ * Scenarios run in declaration order; `setup` is excluded from the timing so a
+ * scenario measures one tool call and nothing else.
+ */
+const scenarios = [
+  {
+    name: 'tools/list',
+    run: () => client.listTools(),
+  },
+  {
+    name: 'browser_navigate (heavy page)',
+    run: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+  },
+  {
+    name: 'browser_snapshot (heavy page)',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('browser_snapshot', {}),
+  },
+  {
+    name: 'browser_click (ref + snapshot)',
+    setup: async () => {
+      const snapshot = await call('browser_navigate', { url: `${origin}/heavy.html` });
+      return { ref: refFor(snapshot, 'Submit search') };
+    },
+    run: state => call('browser_click', { element: 'Submit search button', ref: state.ref }),
+  },
+  {
+    name: 'browser_type (ref + snapshot)',
+    setup: async () => {
+      const snapshot = await call('browser_navigate', { url: `${origin}/heavy.html` });
+      return { ref: refFor(snapshot, 'Search') };
+    },
+    run: state => call('browser_type', { element: 'Search box', ref: state.ref, text: 'benchmark' }),
+  },
+  {
+    name: 'browser_hover (ref + snapshot)',
+    setup: async () => {
+      const snapshot = await call('browser_navigate', { url: `${origin}/heavy.html` });
+      return { ref: refFor(snapshot, 'Home') };
+    },
+    run: state => call('browser_hover', { element: 'Home link', ref: state.ref }),
+  },
+  {
+    name: 'browser_press_key',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('browser_press_key', { key: 'Tab' }),
+  },
+  {
+    name: 'browser_find',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('browser_find', { text: 'Item 200 link' }),
+  },
+  {
+    name: 'scan_page (axe)',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('scan_page', {}),
+  },
+  {
+    name: 'audit_keyboard (12 tabs)',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('audit_keyboard', { maxTabs: 12 }),
+  },
+  {
+    name: 'scan_page_matrix (3 variants)',
+    setup: () => call('browser_navigate', { url: `${origin}/heavy.html` }),
+    run: () => call('scan_page_matrix', {
+      variants: [
+        { name: 'baseline' },
+        { name: 'mobile', viewport: { width: 375, height: 812 } },
+        { name: 'zoom-200', zoomPercent: 200 },
+      ],
+    }),
+  },
+  {
+    name: 'audit_site (6 pages)',
+    setup: () => call('browser_navigate', { url: `${origin}/page-0.html` }),
+    run: () => call('audit_site', { startUrl: `${origin}/page-0.html`, maxPages: 6, maxDepth: 2 }),
+  },
+  {
+    name: 'audit_screen_reader',
+    setup: () => call('browser_navigate', { url: `${origin}/page-0.html` }),
+    run: () => call('audit_screen_reader', {}),
+  },
+];
+
+const results = [];
+for (const scenario of scenarios) {
+  const samples = [];
+  let state;
+  for (let index = 0; index < warmups + iterations; index++) {
+    state = scenario.setup ? await scenario.setup() : undefined;
+    const startedAt = performance.now();
+    await scenario.run(state);
+    const elapsed = performance.now() - startedAt;
+    if (index >= warmups)
+      samples.push(elapsed);
+  }
+  const stats = summarize(samples);
+  results.push({ name: scenario.name, ...stats });
+  process.stderr.write(`${scenario.name.padEnd(34)} median ${stats.median.toFixed(1).padStart(9)} ms   mean ${stats.mean.toFixed(1).padStart(9)} ms\n`);
+}
+
+results.push(...await runMicroBenchmarks());
+
+await client.close().catch(() => {});
+await new Promise(resolve => server.close(resolve));
+fs.rmSync(outputDir, { recursive: true, force: true });
+
+const report = {
+  label: options.label ?? 'run',
+  server: serverEntry,
+  node: process.version,
+  iterations,
+  scenarios: results,
+  totalMedianMs: results.filter(entry => !entry.micro).reduce((sum, entry) => sum + entry.median, 0),
+};
+
+if (options.out) {
+  fs.writeFileSync(path.resolve(options.out), `${JSON.stringify(report, null, 2)}\n`);
+  process.stderr.write(`\nWrote ${options.out}\n`);
+}
+process.stderr.write(`\nTotal median tool latency: ${report.totalMedianMs.toFixed(1)} ms\n`);
+
+// --- helpers -------------------------------------------------------------
+
+async function runMicroBenchmarks() {
+  const { truncateDataUrls } = await import(pathToFileURL(path.join(libRoot, 'utils/dataUrl.js')));
+  const { toMcpTool } = await import(pathToFileURL(path.join(libRoot, 'mcp/tool.js')));
+  const { allTools } = await import(pathToFileURL(path.join(libRoot, 'tools.js')));
+
+  const plain = plainSnapshotText();
+  const withDataUrls = dataUrlHeavyText();
+  const micro = [
+    ['micro: truncateDataUrls (no data urls, 240 KB)', () => truncateDataUrls(plain)],
+    ['micro: truncateDataUrls (data url heavy)', () => truncateDataUrls(withDataUrls)],
+    ['micro: tool schema -> JSON schema (all tools)', () => allTools.map(tool => toMcpTool(tool.schema))],
+  ];
+
+  const out = [];
+  for (const [name, run] of micro) {
+    const samples = [];
+    for (let index = 0; index < 25; index++) {
+      const startedAt = performance.now();
+      run();
+      const elapsed = performance.now() - startedAt;
+      if (index >= 5)
+        samples.push(elapsed);
+    }
+    const stats = summarize(samples);
+    out.push({ name, micro: true, ...stats });
+    process.stderr.write(`${name.padEnd(34)} median ${stats.median.toFixed(3).padStart(9)} ms\n`);
+  }
+  return out;
+}
+
+function summarize(samples) {
+  const sorted = [...samples].sort((first, second) => first - second);
+  return {
+    samples: samples.length,
+    median: sorted[Math.floor((sorted.length - 1) / 2)],
+    mean: samples.reduce((sum, value) => sum + value, 0) / samples.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+async function call(name, args) {
+  const result = await client.callTool({ name, arguments: args });
+  if (result.isError)
+    throw new Error(`${name} failed: ${textOf(result).slice(0, 400)}`);
+  return result;
+}
+
+function textOf(result) {
+  return (result.content ?? []).filter(entry => entry.type === 'text').map(entry => entry.text).join('\n');
+}
+
+function refFor(result, needle) {
+  const line = textOf(result).split('\n').find(entry => entry.includes(needle) && entry.includes('[ref='));
+  const ref = line && /\[ref=([^\]]+)\]/.exec(line);
+  if (!ref)
+    throw new Error(`No ref found for "${needle}"`);
+  return ref[1];
+}
+
+function startFixtureServer() {
+  const httpServer = http.createServer((request, response) => {
+    const body = pages.get(new URL(request.url, 'http://localhost').pathname);
+    if (body === undefined) {
+      response.writeHead(404, { 'content-type': 'text/plain' }).end('not found');
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' }).end(body);
+  });
+  return new Promise(resolve => httpServer.listen(0, '127.0.0.1', () => resolve(httpServer)));
+}
+
+function compare(beforePath, afterPath) {
+  const before = JSON.parse(fs.readFileSync(beforePath, 'utf-8'));
+  const after = JSON.parse(fs.readFileSync(afterPath, 'utf-8'));
+  const byName = new Map(before.scenarios.map(entry => [entry.name, entry]));
+  const rows = [['Scenario', `${before.label} (ms)`, `${after.label} (ms)`, 'Change', 'Speedup']];
+  for (const entry of after.scenarios) {
+    const baseline = byName.get(entry.name);
+    if (!baseline)
+      continue;
+    const change = (entry.median - baseline.median) / baseline.median * 100;
+    rows.push([
+      entry.name,
+      format(baseline.median),
+      format(entry.median),
+      `${change >= 0 ? '+' : ''}${change.toFixed(1)}%`,
+      `${(baseline.median / entry.median).toFixed(2)}x`,
+    ]);
+  }
+  const totalChange = (after.totalMedianMs - before.totalMedianMs) / before.totalMedianMs * 100;
+  rows.push([
+    'TOTAL (end-to-end tool calls)',
+    format(before.totalMedianMs),
+    format(after.totalMedianMs),
+    `${totalChange >= 0 ? '+' : ''}${totalChange.toFixed(1)}%`,
+    `${(before.totalMedianMs / after.totalMedianMs).toFixed(2)}x`,
+  ]);
+  const widths = rows[0].map((_, column) => Math.max(...rows.map(row => row[column].length)));
+  rows.forEach((row, index) => {
+    process.stdout.write(`| ${row.map((cell, column) => cell.padEnd(widths[column])).join(' | ')} |\n`);
+    if (index === 0)
+      process.stdout.write(`|${widths.map(width => '-'.repeat(width + 2)).join('|')}|\n`);
+  });
+}
+
+function format(value) {
+  return value >= 10 ? value.toFixed(1) : value.toFixed(3);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--compare')
+      parsed.compare = [argv[++index], argv[++index]];
+    else if (arg === '--out')
+      parsed.out = argv[++index];
+    else if (arg === '--label')
+      parsed.label = argv[++index];
+    else if (arg === '--server')
+      parsed.server = argv[++index];
+    else if (arg === '--lib')
+      parsed.lib = argv[++index];
+    else if (arg === '--browser')
+      parsed.browser = argv[++index];
+    else if (arg === '--executable-path')
+      parsed.executablePath = argv[++index];
+    else if (arg === '--iterations')
+      parsed.iterations = Number(argv[++index]);
+    else if (arg === '--warmups')
+      parsed.warmups = Number(argv[++index]);
+    else
+      throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -55,7 +55,6 @@ const transport = new StdioClientTransport({
   cwd: projectRoot,
 });
 const client = new Client({ name: 'mcp-bench', version: '1.0.0' });
-await client.connect(transport);
 
 /**
  * Scenarios run in declaration order; `setup` is excluded from the timing so a
@@ -146,6 +145,10 @@ const scenarios = [
 
 const results = [];
 try {
+  // Inside the guard: a missing or unbuilt --server rejects here, and the temp
+  // output directory has already been created.
+  await client.connect(transport);
+
   for (const scenario of scenarios) {
     const samples = [];
     let state;
@@ -301,26 +304,34 @@ function format(value) {
 
 function parseArgs(argv) {
   const parsed = {};
+  // Every flag takes a value, and a missing one must fail here rather than as a
+  // silently skipped report after a full benchmark run.
+  const value = (index, flag) => {
+    const next = argv[index];
+    if (next === undefined || next.startsWith('--'))
+      throw new Error(`${flag} needs a value, got: ${next ?? '(nothing)'}`);
+    return next;
+  };
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
     if (arg === '--compare')
-      parsed.compare = [argv[++index], argv[++index]];
+      parsed.compare = [value(++index, arg), value(++index, arg)];
     else if (arg === '--out')
-      parsed.out = argv[++index];
+      parsed.out = value(++index, arg);
     else if (arg === '--label')
-      parsed.label = argv[++index];
+      parsed.label = value(++index, arg);
     else if (arg === '--server')
-      parsed.server = argv[++index];
+      parsed.server = value(++index, arg);
     else if (arg === '--lib')
-      parsed.lib = argv[++index];
+      parsed.lib = value(++index, arg);
     else if (arg === '--browser')
-      parsed.browser = argv[++index];
+      parsed.browser = value(++index, arg);
     else if (arg === '--executable-path')
-      parsed.executablePath = argv[++index];
+      parsed.executablePath = value(++index, arg);
     else if (arg === '--iterations')
-      parsed.iterations = wholeNumber(argv[++index], arg, 1);
+      parsed.iterations = wholeNumber(value(++index, arg), arg, 1);
     else if (arg === '--warmups')
-      parsed.warmups = wholeNumber(argv[++index], arg, 0);
+      parsed.warmups = wholeNumber(value(++index, arg), arg, 0);
     else
       throw new Error(`Unknown argument: ${arg}`);
   }

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -33,6 +33,8 @@ if (options.compare) {
   await new Promise(resolve => process.stdout.write('', resolve));
   process.exit(0);
 }
+if (!!options.server !== !!options.lib)
+  throw new Error('--server and --lib must be provided together.');
 
 const serverEntry = options.server ? path.resolve(options.server) : path.join(projectRoot, 'cli.js');
 const libRoot = options.lib ? path.resolve(options.lib) : path.join(projectRoot, 'lib');

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -230,9 +230,10 @@ async function runMicroBenchmarks() {
 
 function summarize(samples) {
   const sorted = [...samples].sort((first, second) => first - second);
+  const middle = Math.floor(sorted.length / 2);
   return {
     samples: samples.length,
-    median: sorted[Math.floor((sorted.length - 1) / 2)],
+    median: sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2,
     mean: samples.reduce((sum, value) => sum + value, 0) / samples.length,
     min: sorted[0],
     max: sorted[sorted.length - 1],

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -27,6 +27,10 @@ const options = parseArgs(process.argv.slice(2));
 
 if (options.compare) {
   compare(options.compare[0], options.compare[1]);
+  // process.exit() drops whatever is still buffered, and stdout is only
+  // synchronous on a TTY - piped into anything that applies backpressure, the
+  // tail of the table is simply lost. Wait for the writes to drain first.
+  await new Promise(resolve => process.stdout.write('', resolve));
   process.exit(0);
 }
 

--- a/bench/mcp-bench.mjs
+++ b/bench/mcp-bench.mjs
@@ -38,6 +38,7 @@ if (!!options.server !== !!options.lib)
 
 const serverEntry = options.server ? path.resolve(options.server) : path.join(projectRoot, 'cli.js');
 const libRoot = options.lib ? path.resolve(options.lib) : path.join(projectRoot, 'lib');
+const reportPath = options.out ? writableReportPath(options.out) : undefined;
 const iterations = options.iterations ?? 5;
 const warmups = options.warmups ?? 1;
 
@@ -190,8 +191,8 @@ const report = {
   totalMedianMs: results.filter(entry => !entry.micro).reduce((sum, entry) => sum + entry.median, 0),
 };
 
-if (options.out) {
-  fs.writeFileSync(path.resolve(options.out), `${JSON.stringify(report, null, 2)}\n`);
+if (reportPath) {
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   process.stderr.write(`\nWrote ${options.out}\n`);
 }
 process.stderr.write(`\nTotal median tool latency: ${report.totalMedianMs.toFixed(1)} ms\n`);
@@ -361,4 +362,18 @@ function wholeNumber(value, flag, minimum) {
   if (!Number.isInteger(parsed) || parsed < minimum)
     throw new Error(`${flag} needs an integer >= ${minimum}, got: ${value ?? '(nothing)'}`);
   return parsed;
+}
+
+function writableReportPath(value) {
+  const resolved = path.resolve(value);
+  const parent = path.dirname(resolved);
+  if (!fs.statSync(parent).isDirectory())
+    throw new Error(`--out parent must be a directory: ${parent}`);
+  fs.accessSync(parent, fs.constants.W_OK);
+  if (fs.existsSync(resolved)) {
+    if (!fs.statSync(resolved).isFile())
+      throw new Error(`--out must name a file: ${resolved}`);
+    fs.accessSync(resolved, fs.constants.W_OK);
+  }
+  return resolved;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@axe-core/playwright": "4.12.1",
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"axe-core": "4.12.1",
@@ -45,18 +44,6 @@
 			},
 			"engines": {
 				"node": ">=24.0.0"
-			}
-		},
-		"node_modules/@axe-core/playwright": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
-			"integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
-			"license": "MPL-2.0",
-			"dependencies": {
-				"axe-core": "~4.12.1"
-			},
-			"peerDependencies": {
-				"playwright-core": ">= 1.0.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
 		"test:docker": "bash ./tests/docker-smoke.sh",
 		"test:mcp": "node .claude/run-mcp-direct-harness.mjs",
 		"test:mcp:install": "node .claude/run-mcp-direct-harness.mjs --include-install",
+		"bench": "node bench/mcp-bench.mjs",
+		"bench:compare": "node bench/mcp-bench.mjs --compare",
 		"test:watch": "vitest",
 		"test:ui": "vitest --ui",
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@axe-core/playwright": "4.12.1",
 		"@cfworker/json-schema": "^4.1.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"axe-core": "4.12.1",

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -32,6 +32,10 @@ import type { ServerBackend } from './mcp/server.js';
 
 export class BrowserServerBackend implements ServerBackend {
   private _tools: Tool[];
+  private _toolsByName: Map<string, Tool>;
+  // Converting the zod schemas to JSON schema costs a few milliseconds for the
+  // whole set and never changes, so it is done once per server.
+  private _mcpTools: mcpServer.Tool[] | undefined;
   private _context: Context | undefined;
   private _sessionLog: SessionLog | undefined;
   private _config: FullConfig;
@@ -41,6 +45,7 @@ export class BrowserServerBackend implements ServerBackend {
     this._config = config;
     this._browserContextFactory = factory;
     this._tools = filteredTools(config);
+    this._toolsByName = new Map(this._tools.map(tool => [tool.schema.name, tool]));
   }
 
   async initialize(_context: mcpServer.ServerBackendContext, clientVersion: mcpServer.ClientVersion, roots: mcpServer.Root[]): Promise<void> {
@@ -61,11 +66,12 @@ export class BrowserServerBackend implements ServerBackend {
   }
 
   async listTools(): Promise<mcpServer.Tool[]> {
-    return this._tools.map(tool => toMcpTool(tool.schema));
+    this._mcpTools ??= this._tools.map(tool => toMcpTool(tool.schema));
+    return this._mcpTools;
   }
 
   async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'], requestContext?: mcpServer.CallToolRequestContext) {
-    const tool = this._tools.find(tool => tool.schema.name === name);
+    const tool = this._toolsByName.get(name);
     if (!tool)
       throw new McpError(ErrorCode.InvalidParams, `Tool "${name}" not found`);
     let parsedArguments: Record<string, any>;

--- a/src/response.ts
+++ b/src/response.ts
@@ -157,13 +157,17 @@ export class Response {
     // All the async snapshotting post-action is happening here.
     // Everything below should race against modal states.
     const currentTab = this._context.currentTab();
-    if (this._includeSnapshot && currentTab)
-      this._tabSnapshot = await currentTab.captureSnapshot();
-
+    // The snapshot of the current tab and the titles of the others are
+    // independent page reads, so they go out together rather than one after the
+    // other. Only the current tab's snapshot also refreshes its title.
     const tabsToUpdate = this._includeTabs
       ? this._context.tabs().filter(tab => !this._includeSnapshot || tab !== currentTab)
       : currentTab && !this._includeSnapshot ? [currentTab] : [];
-    await Promise.allSettled(tabsToUpdate.map(tab => tab.updateTitle()));
+    const [snapshot] = await Promise.all([
+      this._includeSnapshot && currentTab ? currentTab.captureSnapshot() : undefined,
+      Promise.allSettled(tabsToUpdate.map(tab => tab.updateTitle())),
+    ]);
+    this._tabSnapshot = snapshot;
   }
 
   tabSnapshot(): TabSnapshot | undefined {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -42,6 +42,8 @@ export type TabSnapshot = {
   downloads: { download: playwright.Download, finished: boolean, outputFile: string }[];
 };
 
+class StaleAriaSnapshotError extends Error {}
+
 export class Tab extends EventEmitter<TabEventsInterface> {
   readonly context: Context;
   readonly page: playwright.Page;
@@ -58,6 +60,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   // next tool call will name. Cleared whenever the page it described is gone.
   private _lastAriaSnapshot: string | undefined;
   private _ariaSnapshotGeneration = 0;
+  private _pageGeneration = 0;
 
   private _pageListeners: { event: string, listener: (...args: any[]) => void }[] = [];
 
@@ -80,8 +83,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     // a ref resolved against the page the user has left would target the wrong
     // document.
     listen('framenavigated', (frame: playwright.Frame) => {
-      if (!frame.parentFrame())
+      if (!frame.parentFrame()) {
+        ++this._pageGeneration;
         this._invalidateAriaSnapshot();
+      }
     });
     listen('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     listen('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
@@ -165,6 +170,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._recentConsoleMessages.length = 0;
     this._requests.clear();
     this._mainDocumentStatus = undefined;
+    ++this._pageGeneration;
     this._invalidateAriaSnapshot();
   }
 
@@ -272,16 +278,22 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   async captureSnapshot(): Promise<TabSnapshot> {
     let tabSnapshot: TabSnapshot | undefined;
+    const capture = { valid: true };
+    const snapshotGeneration = this._ariaSnapshotGeneration;
     const modalStates = await this._raceAgainstModalStates(async () => {
       const [snapshot, title] = await Promise.all([
         this._withPageStateTimeout(
-            this._captureAriaSnapshot(),
+            this._captureAriaSnapshot(capture),
             'capturing page accessibility snapshot',
         ).catch(error => {
-          logUnhandledError(error);
           // Nothing describes the page any more, and the refs of an older
           // snapshot must not be trusted against it.
-          this._invalidateAriaSnapshot();
+          if (!(error instanceof StaleAriaSnapshotError)) {
+            capture.valid = false;
+            logUnhandledError(error);
+            if (snapshotGeneration === this._ariaSnapshotGeneration)
+              this._invalidateAriaSnapshot();
+          }
           return `# Page snapshot unavailable: ${formatPageStateError(error)}`;
         }),
         this._withPageStateTimeout(
@@ -308,8 +320,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot.consoleMessages = this._recentConsoleMessages;
       this._recentConsoleMessages = [];
     }
-    if (!tabSnapshot)
+    if (!tabSnapshot) {
+      capture.valid = false;
       this._invalidateAriaSnapshot();
+    }
     return tabSnapshot ?? {
       url: this.page.url(),
       title: '',
@@ -406,11 +420,13 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     return matches.every(Boolean);
   }
 
-  private async _captureAriaSnapshot(): Promise<string> {
-    const generation = this._ariaSnapshotGeneration;
+  private async _captureAriaSnapshot(capture = { valid: true }): Promise<string> {
+    const pageGeneration = this._pageGeneration;
     const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
-    if (generation === this._ariaSnapshotGeneration)
-      this._lastAriaSnapshot = snapshot;
+    if (!capture.valid || pageGeneration !== this._pageGeneration)
+      throw new StaleAriaSnapshotError('Page changed while capturing accessibility snapshot.');
+    ++this._ariaSnapshotGeneration;
+    this._lastAriaSnapshot = snapshot;
     return snapshot;
   }
 

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -54,6 +54,9 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _modalStates: ModalState[] = [];
   private _downloads: { download: playwright.Download, finished: boolean, outputFile: string }[] = [];
   private _defaultTimeout: number;
+  // The aria snapshot last handed to the caller; the refs in it are the refs the
+  // next tool call will name. Cleared whenever the page it described is gone.
+  private _lastAriaSnapshot: string | undefined;
 
   private _pageListeners: { event: string, listener: (...args: any[]) => void }[] = [];
 
@@ -152,6 +155,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._recentConsoleMessages.length = 0;
     this._requests.clear();
     this._mainDocumentStatus = undefined;
+    this._lastAriaSnapshot = undefined;
   }
 
   private _handleConsoleMessage(message: ConsoleMessage) {
@@ -256,10 +260,13 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     const modalStates = await this._raceAgainstModalStates(async () => {
       const [snapshot, title] = await Promise.all([
         this._withPageStateTimeout(
-            this.page.ariaSnapshot({ mode: 'ai' }),
+            this._captureAriaSnapshot(),
             'capturing page accessibility snapshot',
         ).catch(error => {
           logUnhandledError(error);
+          // Nothing describes the page any more, and the refs of an older
+          // snapshot must not be trusted against it.
+          this._lastAriaSnapshot = undefined;
           return `# Page snapshot unavailable: ${formatPageStateError(error)}`;
         }),
         this._withPageStateTimeout(
@@ -348,12 +355,25 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   async refLocators(params: { element: string, ref: string }[]): Promise<playwright.Locator[]> {
-    const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
+    // The refs a caller passes come from the snapshot the last tool call
+    // returned, which is the one cached here — so the common case needs no page
+    // round trip at all. A ref that is missing from it still costs one fresh
+    // capture, both to catch a ref that appeared since and to keep the "capture
+    // a new snapshot" error accurate.
+    let snapshot = this._lastAriaSnapshot;
+    if (!snapshot || params.some(param => !snapshot!.includes(`[ref=${param.ref}]`)))
+      snapshot = await this._captureAriaSnapshot();
     return params.map(param => {
       if (!snapshot.includes(`[ref=${param.ref}]`))
         throw new Error(`Ref ${param.ref} not found in the current page snapshot. Try capturing new snapshot.`);
       return this.page.locator(`aria-ref=${param.ref}`).describe(param.element);
     });
+  }
+
+  private async _captureAriaSnapshot(): Promise<string> {
+    const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
+    this._lastAriaSnapshot = snapshot;
+    return snapshot;
   }
 
   async waitForTimeout(time: number) {
@@ -406,7 +426,7 @@ export function renderModalStates(context: Context, modalStates: ModalState[]): 
   if (modalStates.length === 0)
     result.push('- There is no modal state present');
   for (const state of modalStates) {
-    const tool = context.tools.filter(tool => 'clearsModalState' in tool).find(tool => tool.clearsModalState === state.type);
+    const tool = context.tools.find(tool => tool.clearsModalState === state.type);
     result.push(`- [${truncateDataUrls(state.description)}]: can be handled by the "${tool?.schema.name}" tool`);
   }
   return result;

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -386,9 +386,17 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   // Whether every ref still resolves to a live element. A ref whose element was
   // removed or replaced resolves to nothing, which sends the caller down the
   // fresh-capture path instead of handing back a locator that cannot match.
+  //
+  // Bounded like every other page-state read here: `count()` uses Playwright's
+  // no-timeout query path, so an unresponsive renderer would hang the tool call
+  // on what is meant to be a cheap check. A check that cannot answer in time
+  // counts as unresolved and falls through to a fresh capture.
   private async _refsResolve(params: { ref: string }[]): Promise<boolean> {
     const counts = await Promise.all(params.map(param =>
-      callOnPageNoTrace(this.page, page => page.locator(`aria-ref=${param.ref}`).count()).catch(() => 0)));
+      this._withPageStateTimeout(
+          callOnPageNoTrace(this.page, page => page.locator(`aria-ref=${param.ref}`).count()),
+          'resolving element references',
+      ).catch(() => 0)));
     return counts.every(count => count > 0);
   }
 

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -73,6 +73,15 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       page.on(event as any, listener);
       this._pageListeners.push({ event, listener });
     };
+    // Every document swap invalidates the cached snapshot, whoever caused it:
+    // goBack(), page.reload() from scan_page_matrix, a meta refresh, or the page
+    // assigning location itself. Tab.navigate() is only one of those routes, and
+    // a ref resolved against the page the user has left would target the wrong
+    // document.
+    listen('framenavigated', (frame: playwright.Frame) => {
+      if (!frame.parentFrame())
+        this._lastAriaSnapshot = undefined;
+    });
     listen('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     listen('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
     listen('request', request => this._requests.set(request, null));

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -57,7 +57,6 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   // The aria snapshot last handed to the caller; the refs in it are the refs the
   // next tool call will name. Cleared whenever the page it described is gone.
   private _lastAriaSnapshot: string | undefined;
-  private _omittedRefNames = new Map<string, string>();
 
   private _pageListeners: { event: string, listener: (...args: any[]) => void }[] = [];
 
@@ -383,42 +382,24 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private async _refsMatchSnapshot(params: { ref: string }[], snapshot: string): Promise<boolean> {
+    const lines = snapshot.split('\n');
+    const timeout = Math.min(this._pageStateTimeoutMs(), 1000);
     const matches = await Promise.all(params.map(async param => {
-      const cached = snapshot.split('\n').find(line => line.includes(`[ref=${param.ref}]`));
+      const cached = lines.find(line => line.includes(`[ref=${param.ref}]`));
       if (!cached)
         return false;
-      let line = cached.trim();
-      const quoted = /^- '((?:[^']|'')*)'(.*)$/.exec(line);
-      if (quoted)
-        line = `- ${quoted[1].replace(/''/g, "'")}${quoted[2]}`;
-      const match = line.match(/^-?\s*([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?/);
-      if (!match)
-        return false;
-      const role = match[1];
-      const name = this._omittedRefNames.get(param.ref) ?? (match[2] ? JSON.parse(`"${match[2]}"`) : '');
-      const locator = this.page.locator(`aria-ref=${param.ref}`) as playwright.Locator & {
-        _expect(expression: string, options: object): Promise<{ matches: boolean, received?: { value?: unknown } }>;
-      };
-      const expectedText = (string: string, normalizeWhiteSpace = false) => [{ string, normalizeWhiteSpace }];
-      const timeout = Math.min(this._pageStateTimeoutMs(), 1000);
-      const [roleResult, nameResult] = await Promise.all([
-        locator._expect('to.have.role', { expectedText: expectedText(role), isNot: false, timeout }),
-        locator._expect('to.have.accessible.name', { expectedText: expectedText(name, true), isNot: false, timeout }),
-      ]).catch(() => [{ matches: false, received: undefined }, { matches: false, received: undefined }]);
-      const syntheticRoleMatches = (role === 'generic' || role === 'iframe') && roleResult.received?.value === '';
-      if (!match[2] && typeof nameResult.received?.value === 'string' && nameResult.received.value.length > 900)
-        this._omittedRefNames.set(param.ref, nameResult.received.value);
-      return (roleResult.matches || syntheticRoleMatches) && nameResult.matches;
+      const current = await this.page.locator(`aria-ref=${param.ref}`)
+          .ariaSnapshot({ mode: 'ai', depth: 1, timeout })
+          .catch(() => '');
+      // Refs are assigned from the full role and name before long names are
+      // omitted from rendering, so a semantic change still changes this line.
+      return current.split('\n', 1)[0]?.trim() === cached.trim();
     }));
     return matches.every(Boolean);
   }
 
   private async _captureAriaSnapshot(): Promise<string> {
     const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
-    for (const ref of this._omittedRefNames.keys()) {
-      if (!snapshot.includes(`[ref=${ref}]`))
-        this._omittedRefNames.delete(ref);
-    }
     this._lastAriaSnapshot = snapshot;
     return snapshot;
   }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -404,6 +404,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private async _refsMatchSnapshot(params: { ref: string }[], snapshot: string): Promise<boolean> {
+    const pageGeneration = this._pageGeneration;
     const lines = snapshot.split('\n');
     const timeout = Math.min(this._pageStateTimeoutMs(), 1000);
     const matches = await Promise.all(params.map(async param => {
@@ -417,7 +418,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       // omitted from rendering, so a semantic change still changes this line.
       return current.split('\n', 1)[0]?.trim() === cached.trim();
     }));
-    return matches.every(Boolean);
+    return pageGeneration === this._pageGeneration && matches.every(Boolean);
   }
 
   private async _captureAriaSnapshot(capture = { valid: true }): Promise<string> {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -57,6 +57,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   // The aria snapshot last handed to the caller; the refs in it are the refs the
   // next tool call will name. Cleared whenever the page it described is gone.
   private _lastAriaSnapshot: string | undefined;
+  private _omittedRefNames = new Map<string, string>();
 
   private _pageListeners: { event: string, listener: (...args: any[]) => void }[] = [];
 
@@ -366,14 +367,12 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async refLocators(params: { element: string, ref: string }[]): Promise<playwright.Locator[]> {
     // The refs a caller passes come from the snapshot the last tool call
     // returned, which is the one cached here, so the common case needs no fresh
-    // capture. Playwright keeps a ref bound to the element it was issued for -
-    // a DOM change never moves it to a different one - so the only thing the
-    // cached text cannot tell us is whether that element is still in the page.
-    // A resolve check answers that for ~1.5ms against ~37ms for a snapshot, and
-    // keeps a stale ref failing fast with the message below rather than as an
-    // action timeout.
+    // capture. Playwright keeps a ref bound to the element it was issued for,
+    // but that element can change its accessible role or name while staying
+    // connected. Re-checking only the referenced nodes is still cheaper than a
+    // full-page snapshot and prevents an old ref from targeting repurposed UI.
     const cached = this._lastAriaSnapshot;
-    const snapshot = cached && params.every(param => cached.includes(`[ref=${param.ref}]`)) && await this._refsResolve(params)
+    const snapshot = cached && await this._refsMatchSnapshot(params, cached)
       ? cached
       : await this._captureAriaSnapshot();
     return params.map(param => {
@@ -383,25 +382,43 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     });
   }
 
-  // Whether every ref still resolves to a live element. A ref whose element was
-  // removed or replaced resolves to nothing, which sends the caller down the
-  // fresh-capture path instead of handing back a locator that cannot match.
-  //
-  // Bounded like every other page-state read here: `count()` uses Playwright's
-  // no-timeout query path, so an unresponsive renderer would hang the tool call
-  // on what is meant to be a cheap check. A check that cannot answer in time
-  // counts as unresolved and falls through to a fresh capture.
-  private async _refsResolve(params: { ref: string }[]): Promise<boolean> {
-    const counts = await Promise.all(params.map(param =>
-      this._withPageStateTimeout(
-          callOnPageNoTrace(this.page, page => page.locator(`aria-ref=${param.ref}`).count()),
-          'resolving element references',
-      ).catch(() => 0)));
-    return counts.every(count => count > 0);
+  private async _refsMatchSnapshot(params: { ref: string }[], snapshot: string): Promise<boolean> {
+    const matches = await Promise.all(params.map(async param => {
+      const cached = snapshot.split('\n').find(line => line.includes(`[ref=${param.ref}]`));
+      if (!cached)
+        return false;
+      let line = cached.trim();
+      const quoted = /^- '((?:[^']|'')*)'(.*)$/.exec(line);
+      if (quoted)
+        line = `- ${quoted[1].replace(/''/g, "'")}${quoted[2]}`;
+      const match = line.match(/^-?\s*([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?/);
+      if (!match)
+        return false;
+      const role = match[1];
+      const name = this._omittedRefNames.get(param.ref) ?? (match[2] ? JSON.parse(`"${match[2]}"`) : '');
+      const locator = this.page.locator(`aria-ref=${param.ref}`) as playwright.Locator & {
+        _expect(expression: string, options: object): Promise<{ matches: boolean, received?: { value?: unknown } }>;
+      };
+      const expectedText = (string: string, normalizeWhiteSpace = false) => [{ string, normalizeWhiteSpace }];
+      const timeout = Math.min(this._pageStateTimeoutMs(), 1000);
+      const [roleResult, nameResult] = await Promise.all([
+        locator._expect('to.have.role', { expectedText: expectedText(role), isNot: false, timeout }),
+        locator._expect('to.have.accessible.name', { expectedText: expectedText(name, true), isNot: false, timeout }),
+      ]).catch(() => [{ matches: false, received: undefined }, { matches: false, received: undefined }]);
+      const syntheticRoleMatches = (role === 'generic' || role === 'iframe') && roleResult.received?.value === '';
+      if (!match[2] && typeof nameResult.received?.value === 'string' && nameResult.received.value.length > 900)
+        this._omittedRefNames.set(param.ref, nameResult.received.value);
+      return (roleResult.matches || syntheticRoleMatches) && nameResult.matches;
+    }));
+    return matches.every(Boolean);
   }
 
   private async _captureAriaSnapshot(): Promise<string> {
     const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
+    for (const ref of this._omittedRefNames.keys()) {
+      if (!snapshot.includes(`[ref=${ref}]`))
+        this._omittedRefNames.delete(ref);
+    }
     this._lastAriaSnapshot = snapshot;
     return snapshot;
   }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -365,18 +365,31 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   async refLocators(params: { element: string, ref: string }[]): Promise<playwright.Locator[]> {
     // The refs a caller passes come from the snapshot the last tool call
-    // returned, which is the one cached here — so the common case needs no page
-    // round trip at all. A ref that is missing from it still costs one fresh
-    // capture, both to catch a ref that appeared since and to keep the "capture
-    // a new snapshot" error accurate.
-    let snapshot = this._lastAriaSnapshot;
-    if (!snapshot || params.some(param => !snapshot!.includes(`[ref=${param.ref}]`)))
-      snapshot = await this._captureAriaSnapshot();
+    // returned, which is the one cached here, so the common case needs no fresh
+    // capture. Playwright keeps a ref bound to the element it was issued for -
+    // a DOM change never moves it to a different one - so the only thing the
+    // cached text cannot tell us is whether that element is still in the page.
+    // A resolve check answers that for ~1.5ms against ~37ms for a snapshot, and
+    // keeps a stale ref failing fast with the message below rather than as an
+    // action timeout.
+    const cached = this._lastAriaSnapshot;
+    const snapshot = cached && params.every(param => cached.includes(`[ref=${param.ref}]`)) && await this._refsResolve(params)
+      ? cached
+      : await this._captureAriaSnapshot();
     return params.map(param => {
       if (!snapshot.includes(`[ref=${param.ref}]`))
         throw new Error(`Ref ${param.ref} not found in the current page snapshot. Try capturing new snapshot.`);
       return this.page.locator(`aria-ref=${param.ref}`).describe(param.element);
     });
+  }
+
+  // Whether every ref still resolves to a live element. A ref whose element was
+  // removed or replaced resolves to nothing, which sends the caller down the
+  // fresh-capture path instead of handing back a locator that cannot match.
+  private async _refsResolve(params: { ref: string }[]): Promise<boolean> {
+    const counts = await Promise.all(params.map(param =>
+      callOnPageNoTrace(this.page, page => page.locator(`aria-ref=${param.ref}`).count()).catch(() => 0)));
+    return counts.every(count => count > 0);
   }
 
   private async _captureAriaSnapshot(): Promise<string> {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -57,6 +57,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   // The aria snapshot last handed to the caller; the refs in it are the refs the
   // next tool call will name. Cleared whenever the page it described is gone.
   private _lastAriaSnapshot: string | undefined;
+  private _ariaSnapshotGeneration = 0;
 
   private _pageListeners: { event: string, listener: (...args: any[]) => void }[] = [];
 
@@ -80,7 +81,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     // document.
     listen('framenavigated', (frame: playwright.Frame) => {
       if (!frame.parentFrame())
-        this._lastAriaSnapshot = undefined;
+        this._invalidateAriaSnapshot();
     });
     listen('console', event => this._handleConsoleMessage(messageToConsoleMessage(event)));
     listen('pageerror', error => this._handleConsoleMessage(pageErrorToConsoleMessage(error)));
@@ -164,6 +165,11 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._recentConsoleMessages.length = 0;
     this._requests.clear();
     this._mainDocumentStatus = undefined;
+    this._invalidateAriaSnapshot();
+  }
+
+  private _invalidateAriaSnapshot() {
+    ++this._ariaSnapshotGeneration;
     this._lastAriaSnapshot = undefined;
   }
 
@@ -275,7 +281,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
           logUnhandledError(error);
           // Nothing describes the page any more, and the refs of an older
           // snapshot must not be trusted against it.
-          this._lastAriaSnapshot = undefined;
+          this._invalidateAriaSnapshot();
           return `# Page snapshot unavailable: ${formatPageStateError(error)}`;
         }),
         this._withPageStateTimeout(
@@ -302,6 +308,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       tabSnapshot.consoleMessages = this._recentConsoleMessages;
       this._recentConsoleMessages = [];
     }
+    if (!tabSnapshot)
+      this._invalidateAriaSnapshot();
     return tabSnapshot ?? {
       url: this.page.url(),
       title: '',
@@ -399,8 +407,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private async _captureAriaSnapshot(): Promise<string> {
+    const generation = this._ariaSnapshotGeneration;
     const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
-    this._lastAriaSnapshot = snapshot;
+    if (generation === this._ariaSnapshotGeneration)
+      this._lastAriaSnapshot = snapshot;
     return snapshot;
   }
 

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -14,7 +14,6 @@ import {
   summarizeAxeViolations,
   type AxeTag,
   type AxeViolation,
-  type TrimmedAxeViolation
 } from './axe.js';
 
 type CrawlStrategy = 'links' | 'nav' | 'sitemap' | 'provided';
@@ -36,8 +35,8 @@ type PageReport = {
   status: PageScanStatus;
   error: string | null;
   summary: ReturnType<typeof summarizeAxeViolations> | null;
-  violations: TrimmedAxeViolation[];
-  incomplete: TrimmedAxeViolation[];
+  violations: AxeViolation[];
+  incomplete: AxeViolation[];
 };
 
 type SummaryViolation = {
@@ -295,22 +294,25 @@ async function findCookieLoss(
   };
 }
 
-async function extractLinks(page: import('playwright').Page): Promise<string[]> {
-  return await page.evaluate(() => {
-    return Array.from(document.querySelectorAll('a[href]'))
-        .map(anchor => (anchor as HTMLAnchorElement).href)
-        .filter(Boolean);
-  });
+/**
+ * Title and outgoing links in one round trip: both are wanted for every crawled
+ * page, and a second evaluate per page is pure latency on a 200-page crawl.
+ * `linkSelector` is empty when this page contributes no links (depth exhausted,
+ * or a strategy that only reads the entry page).
+ */
+async function readPage(page: import('playwright').Page, linkSelector: string): Promise<{ title: string, links: string[] }> {
+  return await page.evaluate(selector => ({
+    title: document.title,
+    links: selector
+      ? Array.from(document.querySelectorAll(selector))
+          .map(anchor => (anchor as HTMLAnchorElement).href)
+          .filter(Boolean)
+      : [],
+  }), linkSelector);
 }
 
-async function extractNavLinks(page: import('playwright').Page): Promise<string[]> {
-  return await page.evaluate(() => {
-    const selectors = 'nav a[href], header a[href], [role="navigation"] a[href]';
-    return Array.from(document.querySelectorAll(selectors))
-        .map(anchor => (anchor as HTMLAnchorElement).href)
-        .filter(Boolean);
-  });
-}
+const allLinksSelector = 'a[href]';
+const navLinksSelector = 'nav a[href], header a[href], [role="navigation"] a[href]';
 
 async function extractSitemapUrls(page: import('playwright').Page, sitemapUrl: string): Promise<string[]> {
   const response = await page.request.get(sitemapUrl, { timeout: 15000 });
@@ -569,22 +571,20 @@ const auditSite = defineTabTool({
         try {
           await crawlTab.navigate(item.url);
           await crawlTab.waitForTimeout(params.waitAfterNavigationMs);
-          pageReport.title = await crawlTab.page.title();
 
           // Discover before scanning. A scoped scan throws when an
           // includeSelectors entry is absent from this page, and that must not
           // silently drop every descendant reachable only through it.
-          if (params.strategy === 'links' && item.depth < params.maxDepth) {
-            const links = await extractLinks(crawlTab.page);
-            for (const link of links)
-              enqueueUrl(link, item.depth + 1, item.url);
-          }
+          let linkSelector = '';
+          if (params.strategy === 'links' && item.depth < params.maxDepth)
+            linkSelector = allLinksSelector;
+          else if (params.strategy === 'nav' && item.depth === 0)
+            linkSelector = navLinksSelector;
 
-          if (params.strategy === 'nav' && item.depth === 0) {
-            const links = await extractNavLinks(crawlTab.page);
-            for (const link of links)
-              enqueueUrl(link, item.depth + 1, item.url);
-          }
+          const { title, links } = await readPage(crawlTab.page, linkSelector);
+          pageReport.title = title;
+          for (const link of links)
+            enqueueUrl(link, item.depth + 1, item.url);
 
           const axeResult = await runAxeScan(crawlTab.page, {
             tags: params.violationsTag as AxeTag[],

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -37,6 +37,9 @@ type PageReport = {
   summary: ReturnType<typeof summarizeAxeViolations> | null;
   violations: AxeViolation[];
   incomplete: AxeViolation[];
+  // Frames Axe never reached on this page, so a page with no violations is
+  // distinguishable from a page that was only partly scanned.
+  unscannedFrames: string[];
 };
 
 type SummaryViolation = {
@@ -543,6 +546,7 @@ const auditSite = defineTabTool({
           summary: null,
           violations: [],
           incomplete: [],
+          unscannedFrames: [],
         };
         pages.push(pageReport);
 
@@ -596,6 +600,7 @@ const auditSite = defineTabTool({
           const violations = prepareAxeResults(axeResult.violations, params.maxNodesPerViolation);
 
           pageReport.status = 'scanned';
+          pageReport.unscannedFrames = axeResult.unscannedFrames;
           pageReport.violations = violations.trimmed;
           pageReport.summary = summarizeAxeViolations(violations.trimmed);
           aggregateIntoSummary(summaryByViolation, violations.deduped, item.url);
@@ -652,6 +657,9 @@ const auditSite = defineTabTool({
     const summaryViolations = toSortedSummaryViolations(summaryByViolation);
     const summaryIncomplete = toSortedSummaryViolations(summaryByIncomplete);
 
+    // A partly-scanned page reports fewer violations, and a reader counting them
+    // must know which pages those numbers are incomplete for.
+    const pagesWithUnscannedFrames = pages.filter(page => page.unscannedFrames.length);
     const scannedPagesByViolations = sortScannedPagesByViolations(pages);
     const summary: SummaryReport = {
       totals: {
@@ -724,6 +732,10 @@ const auditSite = defineTabTool({
       },
       totals: summary.totals,
       sessionLosses,
+      pagesWithUnscannedFrames: pagesWithUnscannedFrames.map(page => ({
+        url: page.url,
+        unscannedFrames: page.unscannedFrames,
+      })),
       topViolations: summaryViolations.slice(0, 5).map(violation => ({
         id: violation.id,
         impact: violation.impact ?? null,
@@ -751,6 +763,11 @@ const auditSite = defineTabTool({
     const topViolations = summarizeTopViolations(summaryViolations, 10);
     const topIncomplete = summarizeTopViolations(summaryIncomplete, 10);
     const topPages = summarizeTopPages(scannedPagesByViolations, 20);
+    const frameWarning = pagesWithUnscannedFrames.length ? [
+      `WARNING: Axe could not be installed in frames on ${pagesWithUnscannedFrames.length} page(s); their contents were not scanned and contribute no findings below.`,
+      ...pagesWithUnscannedFrames.slice(0, 10).map(page => `- ${page.url}: ${page.unscannedFrames.join(', ')}`),
+      '',
+    ] : [];
     const sessionWarning = sessionLosses.length ? [
       ...sessionLosses.map(loss => `WARNING: cookie(s) ${loss.cookies.join(', ')} present when the crawl started disappeared while loading ${loss.url}.`),
       'If one of these was a session cookie, pages scanned after the URL that dropped it were audited as a signed-out user. Add that URL to excludePathPatterns, sign in again, and re-run.',
@@ -758,6 +775,7 @@ const auditSite = defineTabTool({
     ] : [];
     response.addCode('// Crawled pages in a temporary tab and aggregated Axe violations.');
     response.addResult([
+      ...frameWarning,
       ...sessionWarning,
       `Scanned pages: ${summary.totals.scannedPages}`,
       `Errored pages: ${summary.totals.erroredPages}`,

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,7 +1,7 @@
 import axe from 'axe-core';
 import { z } from 'zod';
 
-import { truncateDataUrl, truncateDataUrls } from '../utils/dataUrl.js';
+import { truncateDataUrls } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
 
@@ -257,7 +257,7 @@ const maxFrameNameLength = 80;
 // too, and this string ends up in tool text, structured content and JSON
 // reports alike.
 function describeFrame(frame: playwright.Frame): string {
-  const url = truncateDataUrl(frame.url()) || 'about:blank';
+  const url = truncateDataUrls(frame.url()) || 'about:blank';
   const name = truncateDataUrls(frame.name().replace(/\s+/g, ' ').trim()).slice(0, maxFrameNameLength);
   return name ? `${url} (name="${name}")` : url;
 }
@@ -292,8 +292,6 @@ async function isFrameInScope(
   include: readonly string[],
   exclude: readonly string[]
 ): Promise<boolean> {
-  if (!include.length && !exclude.length)
-    return true;
   let includeMatched = !include.length;
   for (let current = frame; current.parentFrame(); current = current.parentFrame()!) {
     // Bounded like every other child-frame read: `frameElement()` takes no
@@ -306,7 +304,7 @@ async function isFrameInScope(
       void elementPromise.then(late => late?.dispose().catch(() => {}));
       return true;
     }
-    let matches: { included: boolean, excluded: boolean } | null;
+    let matches: { included: boolean, excluded: boolean, hidden: boolean } | null;
     try {
       matches = await withFrameTimeout(element.evaluate((node, scope) => {
         const matchesAny = (selectors: string[]) => selectors.some(selector => {
@@ -326,13 +324,30 @@ async function isFrameInScope(
             return false;
           }
         });
-        return { included: matchesAny(scope.include), excluded: matchesAny(scope.exclude) };
+        let hidden = false;
+        for (let current: Element | null = node as Element; current;) {
+          const ariaHidden = current.getAttribute('aria-hidden')?.trim().toLowerCase() === 'true';
+          const displayNone = getComputedStyle(current).display === 'none';
+          if (ariaHidden || displayNone || (current as HTMLElement).hidden) {
+            hidden = true;
+            break;
+          }
+          const root = current.getRootNode();
+          current = current.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+        }
+        const visibility = getComputedStyle(node as Element).visibility;
+        hidden ||= visibility === 'hidden' || visibility === 'collapse';
+        return { included: matchesAny(scope.include), excluded: matchesAny(scope.exclude), hidden };
       }, { include: [...include], exclude: [...exclude] }), null);
     } finally {
       await element.dispose().catch(() => {});
     }
     if (!matches)
       return true;
+    // Axe does not traverse a frame hidden from the accessibility tree, so a
+    // failed injection there is not missing coverage.
+    if (matches.hidden)
+      return false;
     // Exclude wins wherever it matches: it drops the whole subtree under it.
     if (matches.excluded)
       return false;

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,7 +1,7 @@
 import axe from 'axe-core';
 import { z } from 'zod';
 
-import { truncateDataUrl } from '../utils/dataUrl.js';
+import { truncateDataUrl, truncateDataUrls } from '../utils/dataUrl.js';
 
 import type * as playwright from 'playwright';
 
@@ -173,10 +173,21 @@ async function assertScopeSelectorsResolve(
     throw new Error(`No elements matched includeSelectors: ${unmatched.join(', ')}. The scan would have silently covered less of the page than requested.`);
 }
 
+// Set by the configure step below, and the only thing the coverage check
+// trusts. A frame that navigated to a document carrying its own axe of the same
+// version would answer a bare version probe while lacking the allowedOrigins
+// configuration the top-level run needs - and so would go unscanned while
+// looking covered.
+//
+// Ceiling: any in-page marker can be forged by the page itself. The name is
+// distinctive enough that an accidental collision does not happen; a page
+// deliberately evading its own audit is out of scope.
+const axeReadyMarker = '__mcpAccessibilityScannerAxeReady';
+
 // Axe's frame support needs its own copy in every frame, and the copy talks to
 // the top-level run over postMessage. `<unsafe_all_origins>` is what lets a
 // cross-origin frame answer; without it those frames go unscanned.
-const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } });`;
+const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } }); window['${axeReadyMarker}'] = axe.version;`;
 
 // Injected fresh for every scan rather than reused when `window.axe` already
 // looks right: that global belongs to the page, which may have installed its own
@@ -192,21 +203,51 @@ async function injectAxe(frame: playwright.Frame): Promise<void> {
 // violations, and an unreported one turns into a clean-looking report.
 const childFrameInjectionTimeoutMs = 1000;
 
+// Every read from a child frame is bounded by it, not just the injection: an
+// unresponsive renderer answers neither, and `frame.evaluate` has no timeout of
+// its own, so an unbounded probe would hang the whole scan rather than produce
+// the partial-coverage warning it exists to produce.
+async function withFrameTimeout<T>(work: Promise<T>, fallback: T): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Both branches resolve: a rejected loser of the race would surface as an
+    // unhandled rejection once the winner has already been awaited.
+    return await Promise.race([
+      work.catch(() => fallback),
+      new Promise<T>(resolve => {
+        timeoutId = setTimeout(() => resolve(fallback), childFrameInjectionTimeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// A frame name is author-controlled and unbounded, so it is normalized and
+// capped before going anywhere near a report.
+const maxFrameNameLength = 80;
+
 // Identifies a frame for the coverage warning. The URL alone is not enough for
 // a srcdoc or scripted about:blank frame - both report "about:blank" while
 // holding a whole document - so the frame's name comes along when it has one.
-// The URL is truncated: a data: frame's URL is the document, and this string
-// ends up in tool text, structured content and JSON reports alike.
+// Both are truncated: a data: frame's URL is its document, a name can carry one
+// too, and this string ends up in tool text, structured content and JSON
+// reports alike.
 function describeFrame(frame: playwright.Frame): string {
   const url = truncateDataUrl(frame.url()) || 'about:blank';
-  const name = frame.name();
+  const name = truncateDataUrls(frame.name().replace(/\s+/g, ' ').trim()).slice(0, maxFrameNameLength);
   return name ? `${url} (name="${name}")` : url;
 }
 
-// Whether this frame currently holds the Axe build about to be run. A frame that
-// navigated after its injection - or that appeared since - answers no.
+// Whether this frame currently holds the Axe this server injected and
+// configured. A frame that navigated after its injection - or that appeared
+// since, or that carries only the page's own axe - answers no.
 async function hasAxe(frame: playwright.Frame): Promise<boolean> {
-  return await frame.evaluate(() => (window as any).axe?.version).catch(() => undefined) === axe.version;
+  const ready = await withFrameTimeout(
+      frame.evaluate(marker => (window as any)[marker], axeReadyMarker),
+      undefined,
+  );
+  return ready === axe.version;
 }
 
 // Returns an identifier for every child frame Axe could not be installed in, so
@@ -223,15 +264,7 @@ async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
       await injectAxe(frame);
       return;
     }
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    // Both branches resolve: a rejected loser of the race would surface as an
-    // unhandled rejection once the winner has already been awaited.
-    await Promise.race([
-      injectAxe(frame).catch(() => {}),
-      new Promise<void>(resolve => {
-        timeoutId = setTimeout(resolve, childFrameInjectionTimeoutMs);
-      }),
-    ]).finally(() => clearTimeout(timeoutId));
+    await withFrameTimeout(injectAxe(frame), undefined);
   }));
 
   // Coverage is decided here rather than from the injection results: a frame

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -172,12 +172,11 @@ async function assertScopeSelectorsResolve(
 // cross-origin frame answer; without it those frames go unscanned.
 const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } });`;
 
-// Injection is ~70ms of parsing per frame, so a frame that already holds this
-// exact build is left alone: matrix scans and repeat scans of one page reuse it.
+// Injected fresh for every scan rather than reused when `window.axe` already
+// looks right: that global belongs to the page, which may have installed its own
+// axe or reconfigured ours since, and a scan must run this server's build and
+// configuration. Re-injection costs ~70ms per frame against a multi-second scan.
 async function injectAxe(frame: playwright.Frame): Promise<void> {
-  const injected = await frame.evaluate(() => (window as any).axe?.version).catch(() => undefined);
-  if (injected === axe.version)
-    return;
   await frame.evaluate(axe.source);
   await frame.evaluate(axeConfigureSource);
 }

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -324,11 +324,33 @@ async function isFrameInScope(
             return false;
           }
         });
-        let hidden = false;
+        const roots: (Document | ShadowRoot)[] = [document];
+        const modals: Element[] = [];
+        for (const root of roots) {
+          modals.push(...root.querySelectorAll('dialog:modal'));
+          for (const element of root.querySelectorAll('*')) {
+            if (element.shadowRoot)
+              roots.push(element.shadowRoot);
+          }
+        }
+        const insideModal = modals.some(modal => {
+          for (let current: Element | null = node as Element; current;) {
+            if (current === modal)
+              return true;
+            const root = current.getRootNode();
+            current = current.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+          }
+          return false;
+        });
+        let hidden = !!modals.length && !insideModal;
         for (let current: Element | null = node as Element; current;) {
+          const parent = current.parentElement;
+          const style = getComputedStyle(current);
           const ariaHidden = current.getAttribute('aria-hidden')?.trim().toLowerCase() === 'true';
-          const displayNone = getComputedStyle(current).display === 'none';
-          if (ariaHidden || displayNone || (current as HTMLElement).hidden) {
+          const closedDetails = parent?.localName === 'details' && !parent.hasAttribute('open') &&
+            (current.localName !== 'summary' || [...parent.children].find(child => child.localName === 'summary') !== current);
+          const contentHidden = current !== node && style.getPropertyValue('content-visibility') === 'hidden';
+          if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden || (current as HTMLElement).hidden) {
             hidden = true;
             break;
           }

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -256,10 +256,14 @@ async function hasAxe(frame: playwright.Frame): Promise<boolean> {
 // documented recipe for dropping a flaky third-party widget - does not produce a
 // warning about the very frame it removed.
 //
+// The whole ancestor chain is walked, not just the immediate parent document,
+// because `closest()` stops at a frame boundary while an Axe context does not:
+// `includeSelectors: ["#main"]` covers an iframe nested inside an iframe inside
+// `#main`, and an exclude naming an outer frame drops everything below it.
+//
 // Only a positive determination suppresses the warning. An unreachable frame
-// element, an unresolvable selector or a nested frame whose exclusion lives in a
-// grandparent document all fall through to reporting, so no genuine gap is
-// hidden by a check that could not answer.
+// element or a probe that cannot answer in time falls through to reporting, so
+// no genuine gap is hidden by a check that failed to resolve.
 async function isFrameInScope(
   frame: playwright.Frame,
   include: readonly string[],
@@ -267,25 +271,34 @@ async function isFrameInScope(
 ): Promise<boolean> {
   if (!include.length && !exclude.length)
     return true;
-  const element = await frame.frameElement().catch(() => null);
-  if (!element)
-    return true;
-  try {
-    return await withFrameTimeout(element.evaluate((node, scope) => {
-      const matchesAny = (selectors: string[]) => selectors.some(selector => {
-        try {
-          return !!(node as Element).closest(selector);
-        } catch {
-          return false;
-        }
-      });
-      if (scope.exclude.length && matchesAny(scope.exclude))
-        return false;
-      return scope.include.length ? matchesAny(scope.include) : true;
-    }, { include: [...include], exclude: [...exclude] }), true);
-  } finally {
-    await element.dispose().catch(() => {});
+  let includeMatched = !include.length;
+  for (let current = frame; current.parentFrame(); current = current.parentFrame()!) {
+    const element = await current.frameElement().catch(() => null);
+    if (!element)
+      return true;
+    let matches: { included: boolean, excluded: boolean } | null;
+    try {
+      matches = await withFrameTimeout(element.evaluate((node, scope) => {
+        const matchesAny = (selectors: string[]) => selectors.some(selector => {
+          try {
+            return !!(node as Element).closest(selector);
+          } catch {
+            return false;
+          }
+        });
+        return { included: matchesAny(scope.include), excluded: matchesAny(scope.exclude) };
+      }, { include: [...include], exclude: [...exclude] }), null);
+    } finally {
+      await element.dispose().catch(() => {});
+    }
+    if (!matches)
+      return true;
+    // Exclude wins wherever it matches: it drops the whole subtree under it.
+    if (matches.excluded)
+      return false;
+    includeMatched ||= matches.included;
   }
+  return includeMatched;
 }
 
 // Returns an identifier for every child frame Axe could not be installed in, so

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -223,6 +223,29 @@ async function withFrameTimeout<T>(work: Promise<T>, fallback: T): Promise<T> {
   }
 }
 
+// Injections run a few at a time rather than all at once. Frames sharing a
+// renderer run their evaluations on one thread, so launching every injection
+// together starts every timeout clock together too, and a frame still queued
+// behind its siblings is timed out for being slow before it has had a turn -
+// the budget is meant to catch an unresponsive renderer, not a busy one.
+//
+// A pool fixes that because a frame's clock starts when a slot frees, never
+// while it waits. Measured on a page of 48 same-origin frames: launching them
+// all at once reported 28 healthy frames as unscanned and 96 frames reported
+// every one of them; through the pool, none, at every size tried.
+const frameInjectionConcurrency = 4;
+
+async function withConcurrency<T>(items: readonly T[], run: (item: T) => Promise<unknown>): Promise<void> {
+  let next = 0;
+  await Promise.all(Array.from(
+      { length: Math.min(frameInjectionConcurrency, items.length) },
+      async () => {
+        while (next < items.length)
+          await run(items[next++]);
+      },
+  ));
+}
+
 // A frame name is author-controlled and unbounded, so it is normalized and
 // capped before going anywhere near a report.
 const maxFrameNameLength = 80;
@@ -331,13 +354,11 @@ async function injectAxeIntoFrames(
   exclude: readonly string[]
 ): Promise<string[]> {
   const mainFrame = page.mainFrame();
-  await Promise.all(page.frames().map(async frame => {
-    if (frame === mainFrame) {
-      await injectAxe(frame);
-      return;
-    }
-    await withFrameTimeout(injectAxe(frame), undefined);
-  }));
+  await injectAxe(mainFrame);
+  await withConcurrency(
+      page.frames().filter(frame => frame !== mainFrame),
+      frame => withFrameTimeout(injectAxe(frame), undefined),
+  );
 
   // Coverage is decided here rather than from the injection results: a frame
   // that navigated while a slower sibling was still injecting has a new document

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -294,6 +294,7 @@ async function hasAxe(frame: playwright.Frame, token: string): Promise<boolean> 
 // no genuine gap is hidden by a check that failed to resolve.
 async function isFrameInScope(
   frame: playwright.Frame,
+  mainFrame: playwright.Frame,
   include: readonly string[],
   exclude: readonly string[]
 ): Promise<boolean> {
@@ -314,7 +315,11 @@ async function isFrameInScope(
       matches = await withFrameTimeout(element.evaluate((node, scope) => {
         const composedParent = (element: Element) => {
           const root = element.getRootNode();
-          return element.assignedSlot ?? element.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+          if (element.assignedSlot) {
+            const slotRoot = element.assignedSlot.getRootNode();
+            return element.assignedSlot.parentElement ?? (slotRoot instanceof ShadowRoot ? slotRoot.host : null);
+          }
+          return element.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
         };
         const matchesAny = (selectors: string[]) => selectors.some(selector => {
           try {
@@ -331,7 +336,15 @@ async function isFrameInScope(
         const roots: (Document | ShadowRoot)[] = [document];
         const modals: Element[] = [];
         for (const root of roots) {
-          modals.push(...root.querySelectorAll('dialog:modal'));
+          modals.push(...[...root.querySelectorAll('dialog:modal')].filter(modal => {
+            const style = getComputedStyle(modal);
+            const rect = modal.getBoundingClientRect();
+            const visible = modal.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true }) ??
+              (style.display !== 'none' && !['hidden', 'collapse'].includes(style.visibility) && style.opacity !== '0');
+            return visible &&
+              rect.width > 0 && rect.height > 0 &&
+              (modal.getRootNode() as Document | ShadowRoot).elementsFromPoint(rect.left + 1, rect.top + 1).includes(modal);
+          }));
           for (const element of root.querySelectorAll('*')) {
             if (element.shadowRoot)
               roots.push(element.shadowRoot);
@@ -347,11 +360,17 @@ async function isFrameInScope(
         });
         let hidden = !!modals.length && !insideModal;
         for (let current: Element | null = node as Element; current;) {
-          const parent = current.parentElement;
+          const parent = current.assignedSlot?.parentElement ?? current.parentElement;
           const style = getComputedStyle(current);
           const ariaHidden = current.getAttribute('aria-hidden') === 'true';
+          const flattenedChildren = parent ? [...parent.children].flatMap(child => {
+            if (child.localName !== 'slot')
+              return [child];
+            const assigned = (child as HTMLSlotElement).assignedElements({ flatten: true });
+            return assigned.length ? assigned : [...child.children];
+          }) : [];
           const closedDetails = parent?.localName === 'details' && !parent.hasAttribute('open') &&
-            (current.localName !== 'summary' || [...parent.children].find(child => child.localName === 'summary') !== current);
+            (current.localName !== 'summary' || flattenedChildren.find(child => child.localName === 'summary') !== current);
           const contentHidden = current !== node && style.getPropertyValue('content-visibility') === 'hidden';
           if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden) {
             hidden = true;
@@ -362,7 +381,9 @@ async function isFrameInScope(
         const visibility = getComputedStyle(node as Element).visibility;
         hidden ||= visibility === 'hidden' || visibility === 'collapse';
         return { included: matchesAny(scope.include), excluded: matchesAny(scope.exclude), hidden };
-      }, { include: [...include], exclude: [...exclude] }), null);
+      }, current.parentFrame() === mainFrame
+        ? { include: [...include], exclude: [...exclude] }
+        : { include: [], exclude: [] }), null);
     } finally {
       await element.dispose().catch(() => {});
     }
@@ -432,7 +453,7 @@ async function injectAxeIntoFrames(
       }
       return false;
     });
-    const matches = await withConcurrency(missed, frame => isFrameInScope(frame, include, exclude));
+    const matches = await withConcurrency(missed, frame => isFrameInScope(frame, mainFrame, include, exclude));
     const inScope = new Map(missed.map((frame, index) => [frame, matches[index]]));
     const latest = page.frames().filter(frame => frame !== mainFrame);
     const attached = new Set(latest);

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -190,9 +190,19 @@ async function injectAxe(frame: playwright.Frame): Promise<void> {
 // violations, and an unreported one turns into a clean-looking report.
 const childFrameInjectionTimeoutMs = 1000;
 
-// Returns the URLs of the child frames Axe could not be installed in, so the
-// caller can say what the scan did not cover. Frames without an http(s) URL are
-// left out: about:blank and friends hold nothing a scan would have reported.
+// Identifies a frame for the coverage warning. The URL alone is not enough for
+// a srcdoc or scripted about:blank frame - both report "about:blank" while
+// holding a whole document - so the frame's name comes along when it has one.
+function describeFrame(frame: playwright.Frame): string {
+  const url = frame.url() || 'about:blank';
+  const name = frame.name();
+  return name ? `${url} (name="${name}")` : url;
+}
+
+// Returns an identifier for every child frame Axe could not be installed in, so
+// the caller can say what the scan did not cover. Every failure is reported
+// whatever the URL scheme: injection into an empty about:blank frame succeeds,
+// so a frame that reaches here failed for a reason worth knowing about.
 async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
   const mainFrame = page.mainFrame();
   const results = await Promise.all(page.frames().map(async frame => {
@@ -209,12 +219,9 @@ async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
         timeoutId = setTimeout(() => resolve(false), childFrameInjectionTimeoutMs);
       }),
     ]).finally(() => clearTimeout(timeoutId));
-    if (injected)
-      return null;
-    const url = frame.url();
-    return /^https?:/i.test(url) ? url : null;
+    return injected ? null : describeFrame(frame);
   }));
-  return [...new Set(results.filter((url): url is string => url !== null))];
+  return [...new Set(results.filter((frame): frame is string => frame !== null))];
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -273,9 +273,16 @@ async function isFrameInScope(
     return true;
   let includeMatched = !include.length;
   for (let current = frame; current.parentFrame(); current = current.parentFrame()!) {
-    const element = await current.frameElement().catch(() => null);
-    if (!element)
+    // Bounded like every other child-frame read: `frameElement()` takes no
+    // timeout of its own, so an unresponsive parent renderer would hang the
+    // scan here - on the very check that exists to report unresponsive frames.
+    const elementPromise = current.frameElement().catch(() => null);
+    const element = await withFrameTimeout(elementPromise, null);
+    if (!element) {
+      // The lookup may still land after the bound; do not leak that handle.
+      void elementPromise.then(late => late?.dispose().catch(() => {}));
       return true;
+    }
     let matches: { included: boolean, excluded: boolean } | null;
     try {
       matches = await withFrameTimeout(element.evaluate((node, scope) => {

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,6 +1,8 @@
 import axe from 'axe-core';
 import { z } from 'zod';
 
+import { truncateDataUrl } from '../utils/dataUrl.js';
+
 import type * as playwright from 'playwright';
 
 export const axeTagValues = [
@@ -193,35 +195,57 @@ const childFrameInjectionTimeoutMs = 1000;
 // Identifies a frame for the coverage warning. The URL alone is not enough for
 // a srcdoc or scripted about:blank frame - both report "about:blank" while
 // holding a whole document - so the frame's name comes along when it has one.
+// The URL is truncated: a data: frame's URL is the document, and this string
+// ends up in tool text, structured content and JSON reports alike.
 function describeFrame(frame: playwright.Frame): string {
-  const url = frame.url() || 'about:blank';
+  const url = truncateDataUrl(frame.url()) || 'about:blank';
   const name = frame.name();
   return name ? `${url} (name="${name}")` : url;
+}
+
+// Whether this frame currently holds the Axe build about to be run. A frame that
+// navigated after its injection - or that appeared since - answers no.
+async function hasAxe(frame: playwright.Frame): Promise<boolean> {
+  return await frame.evaluate(() => (window as any).axe?.version).catch(() => undefined) === axe.version;
 }
 
 // Returns an identifier for every child frame Axe could not be installed in, so
 // the caller can say what the scan did not cover. Every failure is reported
 // whatever the URL scheme: injection into an empty about:blank frame succeeds,
 // so a frame that reaches here failed for a reason worth knowing about.
+//
+// Duplicates are kept: two unnamed about:blank frames that both fail are two
+// documents that went unscanned, and collapsing them would under-count.
 async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
   const mainFrame = page.mainFrame();
-  const results = await Promise.all(page.frames().map(async frame => {
+  await Promise.all(page.frames().map(async frame => {
     if (frame === mainFrame) {
       await injectAxe(frame);
-      return null;
+      return;
     }
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     // Both branches resolve: a rejected loser of the race would surface as an
     // unhandled rejection once the winner has already been awaited.
-    const injected = await Promise.race([
-      injectAxe(frame).then(() => true, () => false),
-      new Promise<boolean>(resolve => {
-        timeoutId = setTimeout(() => resolve(false), childFrameInjectionTimeoutMs);
+    await Promise.race([
+      injectAxe(frame).catch(() => {}),
+      new Promise<void>(resolve => {
+        timeoutId = setTimeout(resolve, childFrameInjectionTimeoutMs);
       }),
     ]).finally(() => clearTimeout(timeoutId));
-    return injected ? null : describeFrame(frame);
   }));
-  return [...new Set(results.filter((frame): frame is string => frame !== null))];
+
+  // Coverage is decided here rather than from the injection results: a frame
+  // that navigated while a slower sibling was still injecting has a new document
+  // without Axe, and one that appeared since was never injected at all. Both
+  // would otherwise contribute nothing to a report that still looked complete.
+  // The frame list is re-read for the same reason.
+  //
+  // Ceiling: a frame that navigates between this check and the run below is
+  // still missed. The window is microseconds rather than the length of the
+  // slowest injection, but it cannot be closed from outside the page.
+  const children = page.frames().filter(frame => frame !== mainFrame);
+  const covered = await Promise.all(children.map(hasAxe));
+  return children.filter((_, index) => !covered[index]).map(describeFrame);
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -237,15 +237,19 @@ async function withFrameTimeout<T>(work: Promise<T>, fallback: T): Promise<T> {
 // every one of them; through the pool, none, at every size tried.
 const frameInjectionConcurrency = 4;
 
-async function withConcurrency<T>(items: readonly T[], run: (item: T) => Promise<unknown>): Promise<void> {
+async function withConcurrency<T, R>(items: readonly T[], run: (item: T) => Promise<R>): Promise<R[]> {
   let next = 0;
+  const results: R[] = [];
   await Promise.all(Array.from(
       { length: Math.min(frameInjectionConcurrency, items.length) },
       async () => {
-        while (next < items.length)
-          await run(items[next++]);
+        while (next < items.length) {
+          const index = next++;
+          results[index] = await run(items[index]);
+        }
       },
   ));
+  return results;
 }
 
 // A frame name is author-controlled and unbounded, so it is normalized and
@@ -349,8 +353,7 @@ async function isFrameInScope(
           const closedDetails = parent?.localName === 'details' && !parent.hasAttribute('open') &&
             (current.localName !== 'summary' || [...parent.children].find(child => child.localName === 'summary') !== current);
           const contentHidden = current !== node && style.getPropertyValue('content-visibility') === 'hidden';
-          const hiddenAttribute = current.hasAttribute('hidden') && current.getAttribute('hidden')?.trim().toLowerCase() !== 'until-found';
-          if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden || hiddenAttribute) {
+          if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden) {
             hidden = true;
             break;
           }
@@ -407,25 +410,48 @@ async function injectAxeIntoFrames(
   // Ceiling: a frame that navigates between this check and the run below is
   // still missed. The window is microseconds rather than the length of the
   // slowest injection, but it cannot be closed from outside the page.
-  const children = page.frames().filter(frame => frame !== mainFrame);
-  const covered = await Promise.all(children.map(frame => hasReachableAxe(frame, token)));
-  const withoutAxe = new Set(children.filter((_, index) => !covered[index]));
+  const frameIds = new Map<playwright.Frame, number>();
+  const frameId = (frame: playwright.Frame) => {
+    if (!frameIds.has(frame))
+      frameIds.set(frame, frameIds.size);
+    return frameIds.get(frame)!;
+  };
+  let previousSignature: string | undefined;
+  for (let round = 0; round < 4; round++) {
+    const children = page.frames().filter(frame => frame !== mainFrame);
+    const covered = await withConcurrency(children, frame => hasReachableAxe(frame, token));
+    const withoutAxe = new Set(children.filter((_, index) => !covered[index]));
 
-  // A frame whose own injection succeeded is still unreachable when an ancestor
-  // has no Axe: the top-level run reaches a nested document only by relaying
-  // through the frames above it, and a frame without Axe relays nothing. Both
-  // documents go unscanned, so both are reported rather than only the outer one.
-  const missed = children.filter(frame => {
-    for (let current: playwright.Frame | null = frame; current && current !== mainFrame; current = current.parentFrame()) {
-      if (withoutAxe.has(current))
-        return true;
+    // A frame whose own injection succeeded is still unreachable when an ancestor
+    // has no Axe: the top-level run reaches a nested document only by relaying
+    // through the frames above it, and a frame without Axe relays nothing.
+    const missed = children.filter(frame => {
+      for (let current: playwright.Frame | null = frame; current && current !== mainFrame; current = current.parentFrame()) {
+        if (withoutAxe.has(current))
+          return true;
+      }
+      return false;
+    });
+    const matches = await withConcurrency(missed, frame => isFrameInScope(frame, include, exclude));
+    const inScope = new Map(missed.map((frame, index) => [frame, matches[index]]));
+    const latest = page.frames().filter(frame => frame !== mainFrame);
+    const attached = new Set(latest);
+    const signature = `${children.map((frame, index) => `${frameId(frame)}:${covered[index] ? 1 : 0}:${inScope.get(frame) ? 1 : 0}`).join(',')}>${latest.map(frameId).join(',')}`;
+    const reported = missed.filter(frame => attached.has(frame) && inScope.get(frame)).map(describeFrame);
+
+    const unchanged = children.length === latest.length && children.every((frame, index) => frame === latest[index]);
+    if (!unchanged) {
+      previousSignature = undefined;
+      continue;
     }
-    return false;
-  });
-  // Runs only for frames that failed, which is normally none, so a scoped scan
-  // of a healthy page pays nothing for this.
-  const inScope = await Promise.all(missed.map(frame => isFrameInScope(frame, include, exclude)));
-  return missed.filter((_, index) => inScope[index]).map(describeFrame);
+    // A healthy, unchanged frame tree had no slow scope probes to race with.
+    if (!missed.length)
+      return [];
+    if (signature === previousSignature)
+      return reported;
+    previousSignature = signature;
+  }
+  throw new Error('The frame tree kept changing while Axe coverage was checked. Retry the scan once the page settles.');
 }
 
 async function hasReachableAxe(frame: playwright.Frame, token: string): Promise<boolean> {
@@ -437,8 +463,9 @@ async function hasReachableAxe(frame: playwright.Frame, token: string): Promise<
     void elementPromise.then(late => late?.dispose().catch(() => {}));
     return false;
   }
+  let reachable: boolean;
   try {
-    return await withFrameTimeout(element.evaluate(node => {
+    reachable = await withFrameTimeout(element.evaluate(node => {
       for (let current = node as Element; ;) {
         const root = current.getRootNode();
         if (!(root instanceof ShadowRoot))
@@ -451,6 +478,7 @@ async function hasReachableAxe(frame: playwright.Frame, token: string): Promise<
   } finally {
     await element.dispose().catch(() => {});
   }
+  return reachable && await hasAxe(frame, token);
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -62,6 +62,10 @@ export type AxeScanResult = {
   // Only the rule count of these is ever reported, so only the ids survive.
   passes: { id: string }[];
   inapplicable: { id: string }[];
+  // Child frames Axe could not be installed in, and whose contents therefore
+  // contributed nothing to the results above. Empty on a scan that covered
+  // everything, so an empty violation list means something only when this is.
+  unscannedFrames: string[];
 };
 
 export type AxeScanOptions = {
@@ -181,25 +185,36 @@ async function injectAxe(frame: playwright.Frame): Promise<void> {
   await frame.evaluate(axeConfigureSource);
 }
 
-// A child frame that never answers must not hang the scan: it goes unscanned
-// instead, which is what a failed injection has always meant here.
+// A child frame that never answers must not hang the scan. It goes unscanned
+// instead - but not silently: a frame Axe never reached contributes no
+// violations, and an unreported one turns into a clean-looking report.
 const childFrameInjectionTimeoutMs = 1000;
 
-function injectAxeIntoFrames(page: playwright.Page): Promise<unknown> {
+// Returns the URLs of the child frames Axe could not be installed in, so the
+// caller can say what the scan did not cover. Frames without an http(s) URL are
+// left out: about:blank and friends hold nothing a scan would have reported.
+async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
   const mainFrame = page.mainFrame();
-  return Promise.all(page.frames().map(frame => {
-    if (frame === mainFrame)
-      return injectAxe(frame);
+  const results = await Promise.all(page.frames().map(async frame => {
+    if (frame === mainFrame) {
+      await injectAxe(frame);
+      return null;
+    }
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     // Both branches resolve: a rejected loser of the race would surface as an
     // unhandled rejection once the winner has already been awaited.
-    return Promise.race([
-      injectAxe(frame).catch(() => {}),
-      new Promise<void>(resolve => {
-        timeoutId = setTimeout(resolve, childFrameInjectionTimeoutMs);
+    const injected = await Promise.race([
+      injectAxe(frame).then(() => true, () => false),
+      new Promise<boolean>(resolve => {
+        timeoutId = setTimeout(() => resolve(false), childFrameInjectionTimeoutMs);
       }),
     ]).finally(() => clearTimeout(timeoutId));
+    if (injected)
+      return null;
+    const url = frame.url();
+    return /^https?:/i.test(url) ? url : null;
   }));
+  return [...new Set(results.filter((url): url is string => url !== null))];
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:
@@ -248,8 +263,22 @@ export async function runAxeScan(page: playwright.Page, options: AxeScanOptions 
   // this component minus the widget" needs.
   const context = include.length || exclude.length ? { include: [...include], exclude: [...exclude] } : null;
 
-  await injectAxeIntoFrames(page);
-  return await page.evaluate(runAxeInPage, { context, options: axeOptions }) as AxeScanResult;
+  const unscannedFrames = await injectAxeIntoFrames(page);
+  const results = await page.evaluate(runAxeInPage, { context, options: axeOptions }) as AxeScanResult;
+  return { ...results, unscannedFrames };
+}
+
+// A scan that could not reach a frame covered less than it looks like it did,
+// so every tool that reports results says so in the same words.
+export function unscannedFrameLines(unscannedFrames: string[]): string[] {
+  if (!unscannedFrames.length)
+    return [];
+  return [
+    '',
+    `WARNING: Axe could not be installed in ${unscannedFrames.length} frame(s), whose contents were not scanned and contribute no findings above:`,
+    ...unscannedFrames.map(url => `- ${url}`),
+    'A frame that is still loading may succeed on a re-run; one that consistently fails must be audited on its own.',
+  ];
 }
 
 export function dedupeAxeNodes(nodes: AxeNode[]): AxeNode[] {

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -281,7 +281,17 @@ async function isFrameInScope(
       matches = await withFrameTimeout(element.evaluate((node, scope) => {
         const matchesAny = (selectors: string[]) => selectors.some(selector => {
           try {
-            return !!(node as Element).closest(selector);
+            // `closest()` stops at a shadow boundary as well as a frame one, so
+            // the walk steps onto the host and carries on: an iframe inside a
+            // shadow root is still inside whatever contains that host, and Axe
+            // descends into shadow content just the same.
+            for (let current: Element | null = node as Element; current;) {
+              if (current.closest(selector))
+                return true;
+              const root = current.getRootNode();
+              current = root instanceof ShadowRoot ? root.host : null;
+            }
+            return false;
           } catch {
             return false;
           }
@@ -333,7 +343,19 @@ async function injectAxeIntoFrames(
   // slowest injection, but it cannot be closed from outside the page.
   const children = page.frames().filter(frame => frame !== mainFrame);
   const covered = await Promise.all(children.map(hasAxe));
-  const missed = children.filter((_, index) => !covered[index]);
+  const withoutAxe = new Set(children.filter((_, index) => !covered[index]));
+
+  // A frame whose own injection succeeded is still unreachable when an ancestor
+  // has no Axe: the top-level run reaches a nested document only by relaying
+  // through the frames above it, and a frame without Axe relays nothing. Both
+  // documents go unscanned, so both are reported rather than only the outer one.
+  const missed = children.filter(frame => {
+    for (let current: playwright.Frame | null = frame; current && current !== mainFrame; current = current.parentFrame()) {
+      if (withoutAxe.has(current))
+        return true;
+    }
+    return false;
+  });
   // Runs only for frames that failed, which is normally none, so a scoped scan
   // of a healthy page pays nothing for this.
   const inScope = await Promise.all(missed.map(frame => isFrameInScope(frame, include, exclude)));

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -183,19 +183,19 @@ async function assertScopeSelectorsResolve(
 // distinctive enough that an accidental collision does not happen; a page
 // deliberately evading its own audit is out of scope.
 const axeReadyMarker = '__mcpAccessibilityScannerAxeReady';
+let axeReadySequence = 0;
 
 // Axe's frame support needs its own copy in every frame, and the copy talks to
 // the top-level run over postMessage. `<unsafe_all_origins>` is what lets a
 // cross-origin frame answer; without it those frames go unscanned.
-const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } }); window['${axeReadyMarker}'] = axe.version;`;
+const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } });`;
 
 // Injected fresh for every scan rather than reused when `window.axe` already
 // looks right: that global belongs to the page, which may have installed its own
 // axe or reconfigured ours since, and a scan must run this server's build and
 // configuration. Re-injection costs ~70ms per frame against a multi-second scan.
-async function injectAxe(frame: playwright.Frame): Promise<void> {
-  await frame.evaluate(axe.source);
-  await frame.evaluate(axeConfigureSource);
+async function injectAxe(frame: playwright.Frame, source: string): Promise<void> {
+  await frame.evaluate(source);
 }
 
 // A child frame that never answers must not hang the scan. It goes unscanned
@@ -265,12 +265,11 @@ function describeFrame(frame: playwright.Frame): string {
 // Whether this frame currently holds the Axe this server injected and
 // configured. A frame that navigated after its injection - or that appeared
 // since, or that carries only the page's own axe - answers no.
-async function hasAxe(frame: playwright.Frame): Promise<boolean> {
-  const ready = await withFrameTimeout(
-      frame.evaluate(marker => (window as any)[marker], axeReadyMarker),
-      undefined,
+async function hasAxe(frame: playwright.Frame, token: string): Promise<boolean> {
+  return withFrameTimeout(
+      frame.evaluate(({ marker, token }) => (window as any)[marker] === token, { marker: axeReadyMarker, token }),
+      false,
   );
-  return ready === axe.version;
 }
 
 // A frame the caller scoped out of the scan is not a coverage gap: its contents
@@ -390,11 +389,13 @@ async function injectAxeIntoFrames(
   include: readonly string[],
   exclude: readonly string[]
 ): Promise<string[]> {
+  const token = `${axe.version}:${++axeReadySequence}`;
+  const source = `${axe.source}${axeConfigureSource}window[${JSON.stringify(axeReadyMarker)}]=${JSON.stringify(token)};`;
   const mainFrame = page.mainFrame();
-  await injectAxe(mainFrame);
+  await injectAxe(mainFrame, source);
   await withConcurrency(
       page.frames().filter(frame => frame !== mainFrame),
-      frame => withFrameTimeout(injectAxe(frame), undefined),
+      frame => withFrameTimeout(injectAxe(frame, source), undefined),
   );
 
   // Coverage is decided here rather than from the injection results: a frame
@@ -407,7 +408,7 @@ async function injectAxeIntoFrames(
   // still missed. The window is microseconds rather than the length of the
   // slowest injection, but it cannot be closed from outside the page.
   const children = page.frames().filter(frame => frame !== mainFrame);
-  const covered = await Promise.all(children.map(hasAxe));
+  const covered = await Promise.all(children.map(frame => hasAxe(frame, token)));
   const withoutAxe = new Set(children.filter((_, index) => !covered[index]));
 
   // A frame whose own injection succeeded is still unreachable when an ancestor

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -255,6 +255,7 @@ async function withConcurrency<T, R>(items: readonly T[], run: (item: T) => Prom
 // A frame name is author-controlled and unbounded, so it is normalized and
 // capped before going anywhere near a report.
 const maxFrameNameLength = 80;
+const maxFrameUrlLength = 2048;
 
 // Identifies a frame for the coverage warning. The URL alone is not enough for
 // a srcdoc or scripted about:blank frame - both report "about:blank" while
@@ -263,7 +264,8 @@ const maxFrameNameLength = 80;
 // too, and this string ends up in tool text, structured content and JSON
 // reports alike.
 function describeFrame(frame: playwright.Frame): string {
-  const url = truncateDataUrls(frame.url()) || 'about:blank';
+  const rawUrl = truncateDataUrls(frame.url()) || 'about:blank';
+  const url = rawUrl.length > maxFrameUrlLength ? `${rawUrl.slice(0, maxFrameUrlLength - 3)}...` : rawUrl;
   const name = truncateDataUrls(frame.name().replace(/\s+/g, ' ').trim()).slice(0, maxFrameNameLength);
   return name ? `${url} (name="${name}")` : url;
 }

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -250,6 +250,44 @@ async function hasAxe(frame: playwright.Frame): Promise<boolean> {
   return ready === axe.version;
 }
 
+// A frame the caller scoped out of the scan is not a coverage gap: its contents
+// were never going to be reported. Answered from the iframe element in its
+// parent document, so an `excludeSelectors: ["iframe.chat-widget"]` entry - the
+// documented recipe for dropping a flaky third-party widget - does not produce a
+// warning about the very frame it removed.
+//
+// Only a positive determination suppresses the warning. An unreachable frame
+// element, an unresolvable selector or a nested frame whose exclusion lives in a
+// grandparent document all fall through to reporting, so no genuine gap is
+// hidden by a check that could not answer.
+async function isFrameInScope(
+  frame: playwright.Frame,
+  include: readonly string[],
+  exclude: readonly string[]
+): Promise<boolean> {
+  if (!include.length && !exclude.length)
+    return true;
+  const element = await frame.frameElement().catch(() => null);
+  if (!element)
+    return true;
+  try {
+    return await withFrameTimeout(element.evaluate((node, scope) => {
+      const matchesAny = (selectors: string[]) => selectors.some(selector => {
+        try {
+          return !!(node as Element).closest(selector);
+        } catch {
+          return false;
+        }
+      });
+      if (scope.exclude.length && matchesAny(scope.exclude))
+        return false;
+      return scope.include.length ? matchesAny(scope.include) : true;
+    }, { include: [...include], exclude: [...exclude] }), true);
+  } finally {
+    await element.dispose().catch(() => {});
+  }
+}
+
 // Returns an identifier for every child frame Axe could not be installed in, so
 // the caller can say what the scan did not cover. Every failure is reported
 // whatever the URL scheme: injection into an empty about:blank frame succeeds,
@@ -257,7 +295,11 @@ async function hasAxe(frame: playwright.Frame): Promise<boolean> {
 //
 // Duplicates are kept: two unnamed about:blank frames that both fail are two
 // documents that went unscanned, and collapsing them would under-count.
-async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
+async function injectAxeIntoFrames(
+  page: playwright.Page,
+  include: readonly string[],
+  exclude: readonly string[]
+): Promise<string[]> {
   const mainFrame = page.mainFrame();
   await Promise.all(page.frames().map(async frame => {
     if (frame === mainFrame) {
@@ -278,7 +320,11 @@ async function injectAxeIntoFrames(page: playwright.Page): Promise<string[]> {
   // slowest injection, but it cannot be closed from outside the page.
   const children = page.frames().filter(frame => frame !== mainFrame);
   const covered = await Promise.all(children.map(hasAxe));
-  return children.filter((_, index) => !covered[index]).map(describeFrame);
+  const missed = children.filter((_, index) => !covered[index]);
+  // Runs only for frames that failed, which is normally none, so a scoped scan
+  // of a healthy page pays nothing for this.
+  const inScope = await Promise.all(missed.map(frame => isFrameInScope(frame, include, exclude)));
+  return missed.filter((_, index) => inScope[index]).map(describeFrame);
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:
@@ -327,7 +373,7 @@ export async function runAxeScan(page: playwright.Page, options: AxeScanOptions 
   // this component minus the widget" needs.
   const context = include.length || exclude.length ? { include: [...include], exclude: [...exclude] } : null;
 
-  const unscannedFrames = await injectAxeIntoFrames(page);
+  const unscannedFrames = await injectAxeIntoFrames(page, include, exclude);
   const results = await page.evaluate(runAxeInPage, { context, options: axeOptions }) as AxeScanResult;
   return { ...results, unscannedFrames };
 }

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,6 +1,4 @@
-import { AxeBuilder } from '@axe-core/playwright';
 import axe from 'axe-core';
-import type { AxeResults } from 'axe-core';
 import { z } from 'zod';
 
 import type * as playwright from 'playwright';
@@ -36,24 +34,34 @@ export type AxeTag = (typeof axeTagValues)[number];
 export const defaultAxeTags: readonly AxeTag[] = axeTagValues.filter(
     tag => tag.startsWith('wcag') || tag === 'section508'
 );
-export type AxeScanResult = AxeResults;
-export type AxeViolation = AxeScanResult['violations'][number];
-export type AxeNode = AxeViolation['nodes'][number];
-
-export type TrimmedAxeNode = {
-  target: AxeNode['target'];
+// The scan result carries only what the reporting tools read. Axe's own result
+// object additionally holds the per-node check arrays and the full node list of
+// every passing rule, which together are ~85% of a content-heavy page's result
+// and are dropped inside the page rather than serialized across the CDP
+// connection and thrown away here.
+export type AxeNode = {
+  target: axe.NodeResult['target'];
   html: string;
   failureSummary: string | null;
 };
 
-export type TrimmedAxeViolation = {
+export type AxeViolation = {
   id: string;
-  impact: AxeViolation['impact'];
+  impact: axe.ImpactValue | null | undefined;
   tags: string[];
   help: string;
   helpUrl: string;
   description: string;
-  nodes: TrimmedAxeNode[];
+  nodes: AxeNode[];
+};
+
+export type AxeScanResult = {
+  url: string;
+  violations: AxeViolation[];
+  incomplete: AxeViolation[];
+  // Only the rule count of these is ever reported, so only the ids survive.
+  passes: { id: string }[];
+  inapplicable: { id: string }[];
 };
 
 export type AxeScanOptions = {
@@ -76,13 +84,9 @@ export const axeRuleSchemaShape = {
   disableRules: z.array(z.string().min(1)).optional().describe('Axe rule ids to skip, e.g. ["color-contrast"]. Unlike withRules this narrows whatever is already selected, so it applies to violationsTag and withRules alike. Disabling every rule in withRules is an error, not an empty scan. Unknown rule ids are rejected rather than silently skipped.'),
 };
 
-// The rule catalogue comes from the same axe-core build that AxeBuilder injects
-// into the page (it ships `axe.source`), so ids can never drift from what the
-// scan actually supports and no extra injection is needed to check them.
-// package.json pins axe-core AND @axe-core/playwright to the same exact
-// release: a ranged wrapper could resolve to a newer version on a clean
-// install and nest its own newer axe-core, so validation would use one rule
-// catalogue while AxeBuilder injects another.
+// The rule catalogue comes from the very axe-core build injected into the page
+// (`axe.source` below), so ids can never drift from what the scan supports and
+// no extra injection is needed to check them.
 // Axe does reject unknown ids itself, but only from inside the page after
 // injection, surfacing as an opaque `frame.evaluate` failure; checking up front
 // names the bad id and costs nothing.
@@ -131,56 +135,122 @@ export function assertRuleOptionsValid(options: Pick<AxeScanOptions, 'rules' | '
 // quietly covers less than asked is worse than one that fails loudly.
 async function assertScopeSelectorsResolve(
   page: playwright.Page,
-  selectors: readonly string[],
-  label: 'includeSelectors' | 'excludeSelectors'
+  include: readonly string[],
+  exclude: readonly string[]
 ) {
-  if (!selectors.length)
+  if (!include.length && !exclude.length)
     return;
+  // One round trip for both lists: the includes come first, so the counts split
+  // back apart at `include.length`.
+  const selectors = [...include, ...exclude];
   const counts = await page.evaluate(list => list.map(selector => {
     try {
       return document.querySelectorAll(selector).length;
     } catch {
       return -1;
     }
-  }), [...selectors]);
+  }), selectors);
 
-  const invalid = selectors.filter((_, index) => counts[index] === -1);
-  if (invalid.length)
-    throw new Error(`Invalid CSS in ${label}: ${invalid.join(', ')}`);
+  for (const [label, list, offset] of [
+    ['includeSelectors', include, 0],
+    ['excludeSelectors', exclude, include.length],
+  ] as const) {
+    const invalid = list.filter((_, index) => counts[offset + index] === -1);
+    if (invalid.length)
+      throw new Error(`Invalid CSS in ${label}: ${invalid.join(', ')}`);
+  }
 
   // An unmatched exclude only leaves extra content in scope, and a crawl may
   // legitimately hit pages without the excluded widget, so it is not an error.
-  if (label === 'excludeSelectors')
-    return;
-  const unmatched = selectors.filter((_, index) => counts[index] === 0);
+  const unmatched = include.filter((_, index) => counts[index] === 0);
   if (unmatched.length)
-    throw new Error(`No elements matched ${label}: ${unmatched.join(', ')}. The scan would have silently covered less of the page than requested.`);
+    throw new Error(`No elements matched includeSelectors: ${unmatched.join(', ')}. The scan would have silently covered less of the page than requested.`);
+}
+
+// Axe's frame support needs its own copy in every frame, and the copy talks to
+// the top-level run over postMessage. `<unsafe_all_origins>` is what lets a
+// cross-origin frame answer; without it those frames go unscanned.
+const axeConfigureSource = `;axe.configure({ allowedOrigins: ['<unsafe_all_origins>'], branding: { application: 'playwright' } });`;
+
+// Injection is ~70ms of parsing per frame, so a frame that already holds this
+// exact build is left alone: matrix scans and repeat scans of one page reuse it.
+async function injectAxe(frame: playwright.Frame): Promise<void> {
+  const injected = await frame.evaluate(() => (window as any).axe?.version).catch(() => undefined);
+  if (injected === axe.version)
+    return;
+  await frame.evaluate(axe.source);
+  await frame.evaluate(axeConfigureSource);
+}
+
+// A child frame that never answers must not hang the scan: it goes unscanned
+// instead, which is what a failed injection has always meant here.
+const childFrameInjectionTimeoutMs = 1000;
+
+function injectAxeIntoFrames(page: playwright.Page): Promise<unknown> {
+  const mainFrame = page.mainFrame();
+  return Promise.all(page.frames().map(frame => {
+    if (frame === mainFrame)
+      return injectAxe(frame);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    // Both branches resolve: a rejected loser of the race would surface as an
+    // unhandled rejection once the winner has already been awaited.
+    return Promise.race([
+      injectAxe(frame).catch(() => {}),
+      new Promise<void>(resolve => {
+        timeoutId = setTimeout(resolve, childFrameInjectionTimeoutMs);
+      }),
+    ]).finally(() => clearTimeout(timeoutId));
+  }));
+}
+
+// Runs in the page. Keeps axe's own result shape minus the parts nothing reads:
+// per-node check arrays, and the node lists of passing/inapplicable rules.
+async function runAxeInPage({ context, options }: { context: unknown, options: unknown }) {
+  const results = await (window as any).axe.run(context ?? document, options);
+  const findings = (rules: any[]) => rules.map(rule => ({
+    id: rule.id,
+    impact: rule.impact,
+    tags: rule.tags,
+    help: rule.help,
+    helpUrl: rule.helpUrl,
+    description: rule.description,
+    nodes: rule.nodes.map((node: any) => ({
+      target: node.target,
+      html: node.html,
+      failureSummary: node.failureSummary ?? null,
+    })),
+  }));
+  return {
+    url: results.url,
+    violations: findings(results.violations),
+    incomplete: findings(results.incomplete),
+    passes: results.passes.map((rule: any) => ({ id: rule.id })),
+    inapplicable: results.inapplicable.map((rule: any) => ({ id: rule.id })),
+  };
 }
 
 export async function runAxeScan(page: playwright.Page, options: AxeScanOptions = {}): Promise<AxeScanResult> {
   const rules = assertRuleOptionsValid(options);
-  await assertScopeSelectorsResolve(page, options.include ?? [], 'includeSelectors');
-  await assertScopeSelectorsResolve(page, options.exclude ?? [], 'excludeSelectors');
+  const include = options.include ?? [];
+  const exclude = options.exclude ?? [];
+  await assertScopeSelectorsResolve(page, include, exclude);
 
-  const builder = new AxeBuilder({ page });
-  // withRules and withTags both overwrite axe's single `runOnly` slot, so only
-  // one may be called. Explicit rule ids are the more specific request, so they
-  // win over tags.
-  if (rules.length) {
-    builder.withRules(rules);
-  } else {
-    builder.withTags([...(options.tags ?? defaultAxeTags)]);
-    if (options.disableRules?.length)
-      builder.disableRules([...options.disableRules]);
-  }
-  // include/exclude are cumulative in AxeBuilder; exclude wins over include for
-  // overlapping subtrees, which is what "scan this component minus the widget"
-  // needs.
-  for (const selector of options.include ?? [])
-    builder.include(selector);
-  for (const selector of options.exclude ?? [])
-    builder.exclude(selector);
-  return await builder.analyze();
+  // `runOnly` holds either a rule list or a tag list, never both. Explicit rule
+  // ids are the more specific request, so they win over tags — and the per-rule
+  // `enabled` flag disableRules would set is ignored on that branch, which is
+  // why assertRuleOptionsValid already subtracted them from the list.
+  const axeOptions: Record<string, unknown> = rules.length
+    ? { runOnly: { type: 'rule', values: rules } }
+    : { runOnly: { type: 'tag', values: [...(options.tags ?? defaultAxeTags)] } };
+  if (!rules.length && options.disableRules?.length)
+    axeOptions.rules = Object.fromEntries(options.disableRules.map(rule => [rule, { enabled: false }]));
+
+  // exclude wins over include for overlapping subtrees, which is what "scan
+  // this component minus the widget" needs.
+  const context = include.length || exclude.length ? { include: [...include], exclude: [...exclude] } : null;
+
+  await injectAxeIntoFrames(page);
+  return await page.evaluate(runAxeInPage, { context, options: axeOptions }) as AxeScanResult;
 }
 
 export function dedupeAxeNodes(nodes: AxeNode[]): AxeNode[] {
@@ -199,27 +269,14 @@ export function dedupeAxeNodes(nodes: AxeNode[]): AxeNode[] {
 export function trimAxeResults(
   violations: AxeViolation[],
   options: { maxNodesPerViolation: number; dedupe?: boolean }
-): TrimmedAxeViolation[] {
+): AxeViolation[] {
   // Callers that already deduped node lists can pass `dedupe: false` to skip a
   // redundant second dedup pass over potentially large node sets.
   const shouldDedupe = options.dedupe ?? true;
-  return violations.map(violation => {
-    const sourceNodes = shouldDedupe ? dedupeAxeNodes(violation.nodes) : violation.nodes;
-    const nodes = sourceNodes.slice(0, options.maxNodesPerViolation).map(node => ({
-      target: [...(node.target ?? [])],
-      html: node.html ?? '',
-      failureSummary: node.failureSummary ?? null,
-    }));
-    return {
-      id: violation.id,
-      impact: violation.impact,
-      tags: [...violation.tags],
-      help: violation.help,
-      helpUrl: violation.helpUrl,
-      description: violation.description,
-      nodes,
-    };
-  });
+  return violations.map(violation => ({
+    ...violation,
+    nodes: (shouldDedupe ? dedupeAxeNodes(violation.nodes) : violation.nodes).slice(0, options.maxNodesPerViolation),
+  }));
 }
 
 // Dedupe once and reuse: callers need the deduped nodes for per-rule counting
@@ -227,7 +284,7 @@ export function trimAxeResults(
 export function prepareAxeResults(
   violations: AxeViolation[],
   maxNodesPerViolation: number
-): { deduped: AxeViolation[]; trimmed: TrimmedAxeViolation[] } {
+): { deduped: AxeViolation[]; trimmed: AxeViolation[] } {
   const deduped = violations.map(violation => ({
     ...violation,
     nodes: dedupeAxeNodes(violation.nodes),
@@ -235,7 +292,7 @@ export function prepareAxeResults(
   return { deduped, trimmed: trimAxeResults(deduped, { maxNodesPerViolation, dedupe: false }) };
 }
 
-export function summarizeAxeViolations(violations: TrimmedAxeViolation[]) {
+export function summarizeAxeViolations(violations: AxeViolation[]) {
   const byImpact: Record<string, number> = {};
   const byRuleId: Record<string, number> = {};
   let totalNodes = 0;

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -1,4 +1,5 @@
 import axe from 'axe-core';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import { truncateDataUrls } from '../utils/dataUrl.js';
@@ -184,6 +185,7 @@ async function assertScopeSelectorsResolve(
 // deliberately evading its own audit is out of scope.
 const axeReadyMarker = '__mcpAccessibilityScannerAxeReady';
 let axeReadySequence = 0;
+const axeReadyNonce = randomUUID();
 
 // Axe's frame support needs its own copy in every frame, and the copy talks to
 // the top-level run over postMessage. `<unsafe_all_origins>` is what lets a
@@ -387,7 +389,7 @@ async function injectAxeIntoFrames(
   include: readonly string[],
   exclude: readonly string[]
 ): Promise<string[]> {
-  const token = `${axe.version}:${++axeReadySequence}`;
+  const token = `${axe.version}:${axeReadyNonce}:${++axeReadySequence}`;
   const source = `${axe.source}${axeConfigureSource}window[${JSON.stringify(axeReadyMarker)}]=${JSON.stringify(token)};`;
   const mainFrame = page.mainFrame();
   await injectAxe(mainFrame, source);

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -306,17 +306,16 @@ async function isFrameInScope(
     let matches: { included: boolean, excluded: boolean, hidden: boolean } | null;
     try {
       matches = await withFrameTimeout(element.evaluate((node, scope) => {
+        const composedParent = (element: Element) => {
+          const root = element.getRootNode();
+          return element.assignedSlot ?? element.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+        };
         const matchesAny = (selectors: string[]) => selectors.some(selector => {
           try {
-            // `closest()` stops at a shadow boundary as well as a frame one, so
-            // the walk steps onto the host and carries on: an iframe inside a
-            // shadow root is still inside whatever contains that host, and Axe
-            // descends into shadow content just the same.
             for (let current: Element | null = node as Element; current;) {
-              if (current.closest(selector))
+              if (current.matches(selector))
                 return true;
-              const root = current.getRootNode();
-              current = root instanceof ShadowRoot ? root.host : null;
+              current = composedParent(current);
             }
             return false;
           } catch {
@@ -336,8 +335,7 @@ async function isFrameInScope(
           for (let current: Element | null = node as Element; current;) {
             if (current === modal)
               return true;
-            const root = current.getRootNode();
-            current = current.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+            current = composedParent(current);
           }
           return false;
         });
@@ -349,12 +347,12 @@ async function isFrameInScope(
           const closedDetails = parent?.localName === 'details' && !parent.hasAttribute('open') &&
             (current.localName !== 'summary' || [...parent.children].find(child => child.localName === 'summary') !== current);
           const contentHidden = current !== node && style.getPropertyValue('content-visibility') === 'hidden';
-          if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden || (current as HTMLElement).hidden) {
+          const hiddenAttribute = current.hasAttribute('hidden') && current.getAttribute('hidden')?.trim().toLowerCase() !== 'until-found';
+          if (ariaHidden || style.display === 'none' || current.hasAttribute('inert') || closedDetails || contentHidden || hiddenAttribute) {
             hidden = true;
             break;
           }
-          const root = current.getRootNode();
-          current = current.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+          current = composedParent(current);
         }
         const visibility = getComputedStyle(node as Element).visibility;
         hidden ||= visibility === 'hidden' || visibility === 'collapse';
@@ -408,7 +406,7 @@ async function injectAxeIntoFrames(
   // still missed. The window is microseconds rather than the length of the
   // slowest injection, but it cannot be closed from outside the page.
   const children = page.frames().filter(frame => frame !== mainFrame);
-  const covered = await Promise.all(children.map(frame => hasAxe(frame, token)));
+  const covered = await Promise.all(children.map(frame => hasReachableAxe(frame, token)));
   const withoutAxe = new Set(children.filter((_, index) => !covered[index]));
 
   // A frame whose own injection succeeded is still unreachable when an ancestor
@@ -426,6 +424,31 @@ async function injectAxeIntoFrames(
   // of a healthy page pays nothing for this.
   const inScope = await Promise.all(missed.map(frame => isFrameInScope(frame, include, exclude)));
   return missed.filter((_, index) => inScope[index]).map(describeFrame);
+}
+
+async function hasReachableAxe(frame: playwright.Frame, token: string): Promise<boolean> {
+  if (!await hasAxe(frame, token))
+    return false;
+  const elementPromise = frame.frameElement().catch(() => null);
+  const element = await withFrameTimeout(elementPromise, null);
+  if (!element) {
+    void elementPromise.then(late => late?.dispose().catch(() => {}));
+    return false;
+  }
+  try {
+    return await withFrameTimeout(element.evaluate(node => {
+      for (let current = node as Element; ;) {
+        const root = current.getRootNode();
+        if (!(root instanceof ShadowRoot))
+          return true;
+        if (root.host.shadowRoot !== root)
+          return false;
+        current = root.host;
+      }
+    }), false);
+  } finally {
+    await element.dispose().catch(() => {});
+  }
 }
 
 // Runs in the page. Keeps axe's own result shape minus the parts nothing reads:

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -345,7 +345,7 @@ async function isFrameInScope(
         for (let current: Element | null = node as Element; current;) {
           const parent = current.parentElement;
           const style = getComputedStyle(current);
-          const ariaHidden = current.getAttribute('aria-hidden')?.trim().toLowerCase() === 'true';
+          const ariaHidden = current.getAttribute('aria-hidden') === 'true';
           const closedDetails = parent?.localName === 'details' && !parent.hasAttribute('open') &&
             (current.localName !== 'summary' || [...parent.children].find(child => child.localName === 'summary') !== current);
           const contentHidden = current !== node && style.getPropertyValue('content-visibility') === 'hidden';

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -295,6 +295,9 @@ const scanPageMatrix = defineTabTool({
         // includeIncomplete, so a 0 here is indistinguishable from a variant
         // with no needs-review findings. Matches the "-" in the markdown table.
         totalIncomplete: params.includeIncomplete ? result.incomplete.length : null,
+        // Without this a client reading only structured output cannot tell a
+        // partly-scanned variant from a clean one.
+        unscannedFrames: result.unscannedFrames,
         newViolationIds: result.diffFromBaseline.newViolationIds,
         resolvedViolationIds: result.diffFromBaseline.resolvedViolationIds,
         changedRuleIds: Object.keys(result.diffFromBaseline.changedCounts),

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -107,19 +107,6 @@ function safeIsoTimestampForFileName() {
   return sanitizeForFilePath(new Date().toISOString());
 }
 
-/**
- * Viewport, media and zoom are independent, so they are applied together rather
- * than in three sequential round trips. Every one of them is awaited even after
- * one fails, so a second failure cannot surface as an unhandled rejection once
- * the first has already propagated.
- */
-async function applyTogether(operations: Promise<unknown>[]): Promise<void> {
-  const results = await Promise.allSettled(operations);
-  const failure = results.find(result => result.status === 'rejected');
-  if (failure)
-    throw failure.reason;
-}
-
 function countNodesByRule(violations: { id: string; nodes: unknown[] }[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const violation of violations)
@@ -175,13 +162,15 @@ const scanPageMatrix = defineTabTool({
       for (const variant of variants) {
         // Apply each property once per variant: the variant value when set,
         // otherwise the original page state (undoing the previous variant).
-        await applyTogether([
-          tab.page.setViewportSize(variant.viewport ?? originalViewport),
-          tab.page.emulateMedia(normalizeMedia(variant.media)),
-          tab.page.evaluate(zoom => {
-            document.documentElement.style.zoom = zoom;
-          }, variant.zoomPercent !== undefined ? `${variant.zoomPercent}%` : originalZoom),
-        ]);
+        // Strictly in this order, not in parallel: a page that reacts to a
+        // viewport or media change by writing document.documentElement.style.zoom
+        // would overwrite a zoom applied alongside it, and the variant would be
+        // scanned - and reported - at a zoom it never actually had.
+        await tab.page.setViewportSize(variant.viewport ?? originalViewport);
+        await tab.page.emulateMedia(normalizeMedia(variant.media));
+        await tab.page.evaluate(zoom => {
+          document.documentElement.style.zoom = zoom;
+        }, variant.zoomPercent !== undefined ? `${variant.zoomPercent}%` : originalZoom);
 
         if (params.reloadBetweenVariants)
           await tab.page.reload({ waitUntil: 'domcontentloaded' });
@@ -230,18 +219,17 @@ const scanPageMatrix = defineTabTool({
       for (const result of variantResults)
         result.diffFromBaseline = computeDiffFromBaseline(baselineCounts, result.nodeCountByRuleId);
     } finally {
-      await applyTogether([
-        tab.page.setViewportSize(originalViewport),
-        tab.page.emulateMedia({
-          colorScheme: null,
-          forcedColors: null,
-          contrast: null,
-          reducedMotion: null,
-        }),
-        tab.page.evaluate(zoom => {
-          document.documentElement.style.zoom = zoom;
-        }, originalZoom),
-      ]);
+      // Same ordering as the apply path, and for the same reason.
+      await tab.page.setViewportSize(originalViewport);
+      await tab.page.emulateMedia({
+        colorScheme: null,
+        forcedColors: null,
+        contrast: null,
+        reducedMotion: null,
+      });
+      await tab.page.evaluate(zoom => {
+        document.documentElement.style.zoom = zoom;
+      }, originalZoom);
     }
 
     const report = {

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -203,7 +203,10 @@ const scanPageMatrix = defineTabTool({
         // would overwrite a zoom applied alongside it, and the variant would be
         // scanned - and reported - at a zoom it never actually had.
         await tab.page.setViewportSize(variant.viewport ?? originalViewport);
-        await tab.page.emulateMedia(normalizeMedia(variant.media, originalMedia));
+        // One value, applied and then reported, so `applied.media` cannot drift
+        // from what the variant was actually scanned under.
+        const media = normalizeMedia(variant.media, originalMedia);
+        await tab.page.emulateMedia(media);
 
         // Before the zoom, not after it. Viewport and media emulation survive a
         // reload, but the zoom is an inline style on documentElement and the new
@@ -232,7 +235,7 @@ const scanPageMatrix = defineTabTool({
           name: variant.name,
           applied: {
             viewport: variant.viewport ?? null,
-            media: normalizeMedia(variant.media, originalMedia),
+            media,
             zoomPercent: variant.zoomPercent ?? null,
           },
           summary: summarizeAxeViolations(violations.trimmed),
@@ -351,10 +354,12 @@ const scanPageMatrix = defineTabTool({
       '--- | --- | --- | --- | ---',
       ...variantResults.map(result => {
         // "n/a" rather than "-": "-" means "compared, nothing new", which is a
-        // claim a pair of scans with differing coverage cannot make.
+        // claim a pair of scans with differing coverage cannot make. The reason
+        // names neither side, because the gap may be in the baseline - in which
+        // case every other row is uncomparable through no fault of its own.
         const topNew = result.diffFromBaseline
           ? result.diffFromBaseline.newViolationIds.slice(0, 5).join(', ') || '-'
-          : 'n/a (partial scan)';
+          : 'n/a (coverage differs)';
         // "-" rather than 0: with collection off, 0 is indistinguishable from
         // "no needs-review findings". audit_site omits its section for the same
         // reason.

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -35,11 +35,14 @@ type VariantResult = {
   // distinguishable from one that was only partly scanned.
   unscannedFrames: string[];
   nodeCountByRuleId: Record<string, number>;
+  // null when this variant or the baseline left frames unscanned: the two runs
+  // then covered different documents, and a delta between them would report a
+  // coverage artefact as a fixed or newly introduced violation.
   diffFromBaseline: {
     newViolationIds: string[];
     resolvedViolationIds: string[];
     changedCounts: Record<string, { baseline: number; variant: number }>;
-  };
+  } | null;
 };
 
 const variantSchema = z.object({
@@ -107,7 +110,12 @@ async function readPageState(page: playwright.Page): Promise<{ zoom: string, med
   return await page.evaluate(() => ({
     zoom: document.documentElement.style.zoom || '',
     media: {
-      colorScheme: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' as const : 'light' as const,
+      // Neither query matching is a third state, not light. Pinning it to light
+      // would emulate a preference the page never had, so it is left
+      // un-emulated - the same treatment the unrepresentable contrast values get.
+      colorScheme: matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark' as const
+        : matchMedia('(prefers-color-scheme: light)').matches ? 'light' as const : null,
       forcedColors: matchMedia('(forced-colors: active)').matches ? 'active' as const : 'none' as const,
       reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduce' as const : 'no-preference' as const,
       // `less` and `custom` are values emulateMedia cannot express. Leaving the
@@ -234,11 +242,7 @@ const scanPageMatrix = defineTabTool({
             ? prepareAxeResults(axeResult.incomplete, params.maxNodesPerViolation).trimmed
             : [],
           nodeCountByRuleId,
-          diffFromBaseline: {
-            newViolationIds: [],
-            resolvedViolationIds: [],
-            changedCounts: {},
-          },
+          diffFromBaseline: null,
         });
 
         await response.reportProgress({
@@ -248,9 +252,20 @@ const scanPageMatrix = defineTabTool({
         });
       }
 
-      const baselineCounts = variantResults[0]?.nodeCountByRuleId ?? {};
-      for (const result of variantResults)
-        result.diffFromBaseline = computeDiffFromBaseline(baselineCounts, result.nodeCountByRuleId);
+      const baseline = variantResults[0];
+      const baselineCounts = baseline?.nodeCountByRuleId ?? {};
+      for (const result of variantResults) {
+        // Only comparable when both sides scanned the same documents. With a
+        // frame missed on either side, a rule absent from one run may simply
+        // live in the document that went unscanned, and calling that "resolved"
+        // - or its reappearance "new" - states an accessibility outcome the run
+        // cannot support. The warning already says coverage differs; the
+        // numbers must not quietly contradict it.
+        const comparable = !result.unscannedFrames.length && !baseline?.unscannedFrames.length;
+        result.diffFromBaseline = comparable
+          ? computeDiffFromBaseline(baselineCounts, result.nodeCountByRuleId)
+          : null;
+      }
     } finally {
       // Same ordering as the apply path, and for the same reason.
       await tab.page.setViewportSize(originalViewport);
@@ -314,9 +329,12 @@ const scanPageMatrix = defineTabTool({
         // Without this a client reading only structured output cannot tell a
         // partly-scanned variant from a clean one.
         unscannedFrames: result.unscannedFrames,
-        newViolationIds: result.diffFromBaseline.newViolationIds,
-        resolvedViolationIds: result.diffFromBaseline.resolvedViolationIds,
-        changedRuleIds: Object.keys(result.diffFromBaseline.changedCounts),
+        // null, not [], when the coverage differs from the baseline's: an empty
+        // list reads as "nothing changed", which is the one thing an incomplete
+        // pair of scans cannot establish.
+        newViolationIds: result.diffFromBaseline?.newViolationIds ?? null,
+        resolvedViolationIds: result.diffFromBaseline?.resolvedViolationIds ?? null,
+        changedRuleIds: result.diffFromBaseline ? Object.keys(result.diffFromBaseline.changedCounts) : null,
         reportUri: reportResourceLink.uri,
       })),
     });
@@ -326,12 +344,17 @@ const scanPageMatrix = defineTabTool({
       ...(variantsWithUnscannedFrames.length ? [
         `WARNING: Axe could not be installed in frames on ${variantsWithUnscannedFrames.length} variant(s); their contents were not scanned and contribute no findings below.`,
         ...variantsWithUnscannedFrames.map(result => `- ${result.name}: ${result.unscannedFrames.join(', ')}`),
+        'Baseline deltas are reported as "n/a" wherever the two scans did not cover the same documents.',
         '',
       ] : []),
       'Variant | Violations | Nodes | Incomplete | Top new vs baseline',
       '--- | --- | --- | --- | ---',
       ...variantResults.map(result => {
-        const topNew = result.diffFromBaseline.newViolationIds.slice(0, 5).join(', ') || '-';
+        // "n/a" rather than "-": "-" means "compared, nothing new", which is a
+        // claim a pair of scans with differing coverage cannot make.
+        const topNew = result.diffFromBaseline
+          ? result.diffFromBaseline.newViolationIds.slice(0, 5).join(', ') || '-'
+          : 'n/a (partial scan)';
         // "-" rather than 0: with collection off, 0 is indistinguishable from
         // "no needs-review findings". audit_site omits its section for the same
         // reason.

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { z } from 'zod';
+import type * as playwright from 'playwright';
 import { defineTabTool } from './tool.js';
 import { sanitizeForFilePath } from '../utils/fileUtils.js';
 import {
@@ -94,12 +95,39 @@ const scanPageMatrixSchema = z.object({
   ...axeRuleSchemaShape,
 });
 
-function normalizeMedia(variantMedia: z.output<typeof variantSchema>['media'] | undefined) {
+type MediaState = VariantResult['applied']['media'];
+
+// Playwright has no getter for a page's media emulation, and passing null to
+// emulateMedia resets a feature to the browser default rather than to whatever
+// the context was created with: a context made with `colorScheme: 'dark'` reads
+// light again after a null. So the effective state is measured from the page
+// before the first variant and used both as the per-variant fallback and to put
+// the page back afterwards - the same way the viewport and zoom already are.
+async function readPageState(page: playwright.Page): Promise<{ zoom: string, media: MediaState }> {
+  return await page.evaluate(() => ({
+    zoom: document.documentElement.style.zoom || '',
+    media: {
+      colorScheme: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' as const : 'light' as const,
+      forcedColors: matchMedia('(forced-colors: active)').matches ? 'active' as const : 'none' as const,
+      reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduce' as const : 'no-preference' as const,
+      // `less` and `custom` are values emulateMedia cannot express. Leaving the
+      // feature un-emulated reproduces them exactly, naming a value cannot.
+      contrast: matchMedia('(prefers-contrast: more)').matches
+        ? 'more' as const
+        : matchMedia('(prefers-contrast: no-preference)').matches ? 'no-preference' as const : null,
+    },
+  }));
+}
+
+// An unset property means "whatever this page had before the scan started", not
+// "the browser default" - undoing the previous variant must not also undo the
+// media emulation the session was configured with.
+function normalizeMedia(variantMedia: z.output<typeof variantSchema>['media'] | undefined, original: MediaState): MediaState {
   return {
-    colorScheme: variantMedia?.colorScheme ?? null,
-    forcedColors: variantMedia?.forcedColors ?? null,
-    contrast: variantMedia?.contrast ?? null,
-    reducedMotion: variantMedia?.reducedMotion ?? null,
+    colorScheme: variantMedia?.colorScheme ?? original.colorScheme,
+    forcedColors: variantMedia?.forcedColors ?? original.forcedColors,
+    contrast: variantMedia?.contrast ?? original.contrast,
+    reducedMotion: variantMedia?.reducedMotion ?? original.reducedMotion,
   };
 }
 
@@ -155,7 +183,7 @@ const scanPageMatrix = defineTabTool({
       width: window.innerWidth,
       height: window.innerHeight,
     }));
-    const originalZoom = await tab.page.evaluate(() => document.documentElement.style.zoom || '');
+    const { zoom: originalZoom, media: originalMedia } = await readPageState(tab.page);
 
     const variantResults: VariantResult[] = [];
     try {
@@ -167,13 +195,18 @@ const scanPageMatrix = defineTabTool({
         // would overwrite a zoom applied alongside it, and the variant would be
         // scanned - and reported - at a zoom it never actually had.
         await tab.page.setViewportSize(variant.viewport ?? originalViewport);
-        await tab.page.emulateMedia(normalizeMedia(variant.media));
+        await tab.page.emulateMedia(normalizeMedia(variant.media, originalMedia));
+
+        // Before the zoom, not after it. Viewport and media emulation survive a
+        // reload, but the zoom is an inline style on documentElement and the new
+        // document does not have it - applying it first would scan the variant
+        // unzoomed while `applied.zoomPercent` still claimed the requested zoom.
+        if (params.reloadBetweenVariants)
+          await tab.page.reload({ waitUntil: 'domcontentloaded' });
+
         await tab.page.evaluate(zoom => {
           document.documentElement.style.zoom = zoom;
         }, variant.zoomPercent !== undefined ? `${variant.zoomPercent}%` : originalZoom);
-
-        if (params.reloadBetweenVariants)
-          await tab.page.reload({ waitUntil: 'domcontentloaded' });
 
         await tab.waitForTimeout(params.waitAfterApplyMs);
 
@@ -191,7 +224,7 @@ const scanPageMatrix = defineTabTool({
           name: variant.name,
           applied: {
             viewport: variant.viewport ?? null,
-            media: normalizeMedia(variant.media),
+            media: normalizeMedia(variant.media, originalMedia),
             zoomPercent: variant.zoomPercent ?? null,
           },
           summary: summarizeAxeViolations(violations.trimmed),
@@ -221,12 +254,7 @@ const scanPageMatrix = defineTabTool({
     } finally {
       // Same ordering as the apply path, and for the same reason.
       await tab.page.setViewportSize(originalViewport);
-      await tab.page.emulateMedia({
-        colorScheme: null,
-        forcedColors: null,
-        contrast: null,
-        reducedMotion: null,
-      });
+      await tab.page.emulateMedia(originalMedia);
       await tab.page.evaluate(zoom => {
         document.documentElement.style.zoom = zoom;
       }, originalZoom);

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -30,6 +30,9 @@ type VariantResult = {
   summary: ReturnType<typeof summarizeAxeViolations>;
   violations: AxeViolation[];
   incomplete: AxeViolation[];
+  // Frames Axe never reached for this variant, so a variant that looks clean is
+  // distinguishable from one that was only partly scanned.
+  unscannedFrames: string[];
   nodeCountByRuleId: Record<string, number>;
   diffFromBaseline: {
     newViolationIds: string[];
@@ -203,6 +206,7 @@ const scanPageMatrix = defineTabTool({
             zoomPercent: variant.zoomPercent ?? null,
           },
           summary: summarizeAxeViolations(violations.trimmed),
+          unscannedFrames: axeResult.unscannedFrames,
           violations: violations.trimmed,
           incomplete: params.includeIncomplete
             ? prepareAxeResults(axeResult.incomplete, params.maxNodesPerViolation).trimmed
@@ -298,7 +302,13 @@ const scanPageMatrix = defineTabTool({
       })),
     });
 
+    const variantsWithUnscannedFrames = variantResults.filter(result => result.unscannedFrames.length);
     const lines = [
+      ...(variantsWithUnscannedFrames.length ? [
+        `WARNING: Axe could not be installed in frames on ${variantsWithUnscannedFrames.length} variant(s); their contents were not scanned and contribute no findings below.`,
+        ...variantsWithUnscannedFrames.map(result => `- ${result.name}: ${result.unscannedFrames.join(', ')}`),
+        '',
+      ] : []),
       'Variant | Violations | Nodes | Incomplete | Top new vs baseline',
       '--- | --- | --- | --- | ---',
       ...variantResults.map(result => {

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -12,7 +12,7 @@ import {
   runAxeScan,
   summarizeAxeViolations,
   type AxeTag,
-  type TrimmedAxeViolation
+  type AxeViolation,
 } from './axe.js';
 
 type VariantResult = {
@@ -28,8 +28,8 @@ type VariantResult = {
     zoomPercent: number | null;
   };
   summary: ReturnType<typeof summarizeAxeViolations>;
-  violations: TrimmedAxeViolation[];
-  incomplete: TrimmedAxeViolation[];
+  violations: AxeViolation[];
+  incomplete: AxeViolation[];
   nodeCountByRuleId: Record<string, number>;
   diffFromBaseline: {
     newViolationIds: string[];
@@ -104,6 +104,19 @@ function safeIsoTimestampForFileName() {
   return sanitizeForFilePath(new Date().toISOString());
 }
 
+/**
+ * Viewport, media and zoom are independent, so they are applied together rather
+ * than in three sequential round trips. Every one of them is awaited even after
+ * one fails, so a second failure cannot surface as an unhandled rejection once
+ * the first has already propagated.
+ */
+async function applyTogether(operations: Promise<unknown>[]): Promise<void> {
+  const results = await Promise.allSettled(operations);
+  const failure = results.find(result => result.status === 'rejected');
+  if (failure)
+    throw failure.reason;
+}
+
 function countNodesByRule(violations: { id: string; nodes: unknown[] }[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const violation of violations)
@@ -159,11 +172,13 @@ const scanPageMatrix = defineTabTool({
       for (const variant of variants) {
         // Apply each property once per variant: the variant value when set,
         // otherwise the original page state (undoing the previous variant).
-        await tab.page.setViewportSize(variant.viewport ?? originalViewport);
-        await tab.page.emulateMedia(normalizeMedia(variant.media));
-        await tab.page.evaluate(zoom => {
-          document.documentElement.style.zoom = zoom;
-        }, variant.zoomPercent !== undefined ? `${variant.zoomPercent}%` : originalZoom);
+        await applyTogether([
+          tab.page.setViewportSize(variant.viewport ?? originalViewport),
+          tab.page.emulateMedia(normalizeMedia(variant.media)),
+          tab.page.evaluate(zoom => {
+            document.documentElement.style.zoom = zoom;
+          }, variant.zoomPercent !== undefined ? `${variant.zoomPercent}%` : originalZoom),
+        ]);
 
         if (params.reloadBetweenVariants)
           await tab.page.reload({ waitUntil: 'domcontentloaded' });
@@ -211,16 +226,18 @@ const scanPageMatrix = defineTabTool({
       for (const result of variantResults)
         result.diffFromBaseline = computeDiffFromBaseline(baselineCounts, result.nodeCountByRuleId);
     } finally {
-      await tab.page.setViewportSize(originalViewport);
-      await tab.page.emulateMedia({
-        colorScheme: null,
-        forcedColors: null,
-        contrast: null,
-        reducedMotion: null,
-      });
-      await tab.page.evaluate(zoom => {
-        document.documentElement.style.zoom = zoom;
-      }, originalZoom);
+      await applyTogether([
+        tab.page.setViewportSize(originalViewport),
+        tab.page.emulateMedia({
+          colorScheme: null,
+          forcedColors: null,
+          contrast: null,
+          reducedMotion: null,
+        }),
+        tab.page.evaluate(zoom => {
+          document.documentElement.style.zoom = zoom;
+        }, originalZoom),
+      ]);
     }
 
     const report = {

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -279,7 +279,8 @@ const scanPageMatrix = defineTabTool({
     }
 
     const report = {
-      version: 'v1',
+      // v2 allows diffFromBaseline to be null when scan coverage differs.
+      version: 'v2',
       metadata: {
         url: tab.page.url(),
         baselineVariant: variantResults[0]?.name ?? 'baseline',

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -311,6 +311,7 @@ const scanPageMatrix = defineTabTool({
     });
     response.setStructuredContent({
       kind: 'scan_page_matrix',
+      version: 'v2',
       report: {
         path: reportPath,
         uri: reportResourceLink.uri,

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 import { defineTabTool, defineTool } from './tool.js';
 import * as javascript from '../utils/codegen.js';
 import { generateLocator } from './utils.js';
-import { axeRuleSchemaShape, axeScopeSchemaShape, axeTagValues, dedupeAxeNodes, defaultAxeTags, prepareAxeResults, runAxeScan } from './axe.js';
+import { axeRuleSchemaShape, axeScopeSchemaShape, axeTagValues, dedupeAxeNodes, defaultAxeTags, prepareAxeResults, runAxeScan, unscannedFrameLines } from './axe.js';
 import { truncateDataUrls } from '../utils/dataUrl.js';
 import { sanitizeForFilePath } from '../utils/fileUtils.js';
 
@@ -102,6 +102,7 @@ const scanPage = defineTool({
       `URL: ${results.url}`,
       '',
       `Violations: ${results.violations.length}, ${incompleteCount}Passes: ${results.passes.length}, Inapplicable: ${results.inapplicable.length}`,
+      ...unscannedFrameLines(results.unscannedFrames),
       ...annotationLines,
     ].join('\n'));
 

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -39,6 +39,9 @@ export type ModalState = FileUploadModalState | DialogModalState;
 export type Tool<Input extends z.Schema = z.Schema> = {
   capability: ToolCapability;
   schema: ToolSchema<Input>;
+  // Set by the tab tools that resolve a modal state, so a blocked tab can name
+  // the tool that unblocks it.
+  clearsModalState?: ModalState['type'];
   handle: (context: Context, params: z.output<Input>, response: Response) => Promise<void>;
 };
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -32,7 +32,6 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   const requests = new Set<playwright.Request>();
   let requestSeen = false;
   let frameNavigated = false;
-  let subframeNavigated = false;
   let waitCallback: () => void = () => {};
   const waitBarrier = new Promise<void>(f => { waitCallback = f; });
   // Resolves on the first sign of page work, whenever it arrives.
@@ -58,12 +57,8 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     signalCallback();
     if (frame.parentFrame()) {
       // A child frame swapping documents is page work too, and it can issue no
-      // request at all - a srcdoc or data: URL is served without touching the
-      // network. Skipping the settle would then capture the response while the
-      // replacement document is still initializing. It is tracked separately
-      // from a main-frame navigation because it must not gate the barrier on a
-      // top-level load state that this navigation will never produce.
-      subframeNavigated = true;
+      // request at all. It must not gate the barrier on a top-level load state
+      // that this navigation will never produce.
       return;
     }
     frameNavigated = true;
@@ -100,13 +95,18 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     if (!requests.size && !frameNavigated)
       waitCallback();
     await waitBarrier;
-    // The settle delay covers work the page reported and is still finishing -
-    // a response being rendered, a navigation still painting. An action that
-    // issued no request and navigated nowhere within the window above started
-    // none of that, so there is nothing left to wait out. Skipping it is worth
-    // ~500ms on every click, keypress and form fill.
-    if (requestSeen || frameNavigated || subframeNavigated)
-      await tab.waitForTimeout(settleMs);
+    // Timers can schedule DOM-only work without producing any observable page
+    // signal. Preserve the configured settle delay so the returned snapshot
+    // includes those updates too.
+    if (!tab.page.isClosed()) {
+      try {
+        await tab.waitForTimeout(settleMs);
+      } catch (error) {
+        const targetClosed = error instanceof Error && /Target (?:page, context or browser has been closed|page closed|closed)/i.test(error.message);
+        if (!tab.page.isClosed() || !targetClosed)
+          throw error;
+      }
+    }
     return result;
   } finally {
     dispose();

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -21,6 +21,12 @@ const { asLocator } = coreBundle.iso;
 import type * as playwright from 'playwright';
 import type { Tab } from '../tab.js';
 
+// How long an action that finished quietly is watched for work it scheduled
+// rather than started - a click handler whose fetch fires from a timer has
+// issued nothing by the time its own promise resolves. Capped by the settle
+// delay it defers to, so lowering that lowers this with it.
+const quietWindowMs = 100;
+
 export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>): Promise<R> {
   const settleMs = tab.context.config.timeouts.settle ?? 500;
   const requests = new Set<playwright.Request>();
@@ -28,10 +34,14 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   let frameNavigated = false;
   let waitCallback: () => void = () => {};
   const waitBarrier = new Promise<void>(f => { waitCallback = f; });
+  // Resolves on the first sign of page work, whenever it arrives.
+  let signalCallback: () => void = () => {};
+  const firstSignal = new Promise<void>(f => { signalCallback = f; });
 
   const requestListener = (request: playwright.Request) => {
     requestSeen = true;
     requests.add(request);
+    signalCallback();
   };
   const requestFinishedListener = (request: playwright.Request) => {
     requests.delete(request);
@@ -43,6 +53,7 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     if (frame.parentFrame())
       return;
     frameNavigated = true;
+    signalCallback();
     dispose();
     clearTimeout(timeout);
     void tab.waitForLoadState('load').then(waitCallback);
@@ -67,19 +78,39 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
 
   try {
     const result = await callback();
+    // Nothing has happened yet, which is not the same as nothing being about to:
+    // watch briefly for work the action scheduled instead of started.
+    if (!requestSeen && !frameNavigated)
+      await raceTimeout(firstSignal, Math.min(quietWindowMs, settleMs));
     if (!requests.size && !frameNavigated)
       waitCallback();
     await waitBarrier;
-    // The settle delay covers work the page kicked off and finished reporting -
-    // a response still being rendered, a navigation still painting. An action
-    // that issued no request and navigated nowhere started none of that, and its
-    // own promise has already resolved, so there is nothing left to wait out.
-    // Skipping it is worth ~500ms on every click, keypress and form fill.
+    // The settle delay covers work the page reported and is still finishing -
+    // a response being rendered, a navigation still painting. An action that
+    // issued no request and navigated nowhere within the window above started
+    // none of that, so there is nothing left to wait out. Skipping it is worth
+    // ~500ms on every click, keypress and form fill.
     if (requestSeen || frameNavigated)
       await tab.waitForTimeout(settleMs);
     return result;
   } finally {
     dispose();
+  }
+}
+
+// Resolves with `promise` or when the timeout elapses, whichever comes first.
+// Both branches resolve, so the losing one leaves nothing unhandled behind.
+async function raceTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<void>(resolve => {
+        timeoutId = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -32,6 +32,7 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   const requests = new Set<playwright.Request>();
   let requestSeen = false;
   let frameNavigated = false;
+  let subframeNavigated = false;
   let waitCallback: () => void = () => {};
   const waitBarrier = new Promise<void>(f => { waitCallback = f; });
   // Resolves on the first sign of page work, whenever it arrives.
@@ -54,10 +55,18 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   };
 
   const frameNavigateListener = (frame: playwright.Frame) => {
-    if (frame.parentFrame())
-      return;
-    frameNavigated = true;
     signalCallback();
+    if (frame.parentFrame()) {
+      // A child frame swapping documents is page work too, and it can issue no
+      // request at all - a srcdoc or data: URL is served without touching the
+      // network. Skipping the settle would then capture the response while the
+      // replacement document is still initializing. It is tracked separately
+      // from a main-frame navigation because it must not gate the barrier on a
+      // top-level load state that this navigation will never produce.
+      subframeNavigated = true;
+      return;
+    }
+    frameNavigated = true;
     dispose();
     clearTimeout(timeout);
     void tab.waitForLoadState('load').then(waitCallback);
@@ -96,7 +105,7 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     // issued no request and navigated nowhere within the window above started
     // none of that, so there is nothing left to wait out. Skipping it is worth
     // ~500ms on every click, keypress and form fill.
-    if (requestSeen || frameNavigated)
+    if (requestSeen || frameNavigated || subframeNavigated)
       await tab.waitForTimeout(settleMs);
     return result;
   } finally {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -43,7 +43,11 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     requests.add(request);
     signalCallback();
   };
-  const requestFinishedListener = (request: playwright.Request) => {
+  // A request that fails - offline, blocked by CORS, aborted - emits
+  // `requestfailed` and never `requestfinished`. Without the same removal path
+  // it would sit in the set until the 10s timeout below, turning a click that
+  // fired one doomed fetch into a ten-second tool call.
+  const requestSettledListener = (request: playwright.Request) => {
     requests.delete(request);
     if (!requests.size)
       waitCallback();
@@ -65,13 +69,15 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   };
 
   tab.page.on('request', requestListener);
-  tab.page.on('requestfinished', requestFinishedListener);
+  tab.page.on('requestfinished', requestSettledListener);
+  tab.page.on('requestfailed', requestSettledListener);
   tab.page.on('framenavigated', frameNavigateListener);
   const timeout = setTimeout(onTimeout, 10000);
 
   const dispose = () => {
     tab.page.off('request', requestListener);
-    tab.page.off('requestfinished', requestFinishedListener);
+    tab.page.off('requestfinished', requestSettledListener);
+    tab.page.off('requestfailed', requestSettledListener);
     tab.page.off('framenavigated', frameNavigateListener);
     clearTimeout(timeout);
   };

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -24,11 +24,15 @@ import type { Tab } from '../tab.js';
 export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>): Promise<R> {
   const settleMs = tab.context.config.timeouts.settle ?? 500;
   const requests = new Set<playwright.Request>();
+  let requestSeen = false;
   let frameNavigated = false;
   let waitCallback: () => void = () => {};
   const waitBarrier = new Promise<void>(f => { waitCallback = f; });
 
-  const requestListener = (request: playwright.Request) => requests.add(request);
+  const requestListener = (request: playwright.Request) => {
+    requestSeen = true;
+    requests.add(request);
+  };
   const requestFinishedListener = (request: playwright.Request) => {
     requests.delete(request);
     if (!requests.size)
@@ -66,7 +70,13 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     if (!requests.size && !frameNavigated)
       waitCallback();
     await waitBarrier;
-    await tab.waitForTimeout(settleMs);
+    // The settle delay covers work the page kicked off and finished reporting -
+    // a response still being rendered, a navigation still painting. An action
+    // that issued no request and navigated nowhere started none of that, and its
+    // own promise has already resolved, so there is nothing left to wait out.
+    // Skipping it is worth ~500ms on every click, keypress and form fill.
+    if (requestSeen || frameNavigated)
+      await tab.waitForTimeout(settleMs);
     return result;
   } finally {
     dispose();

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -29,17 +29,15 @@ export function truncateDataUrl(url: string): string {
 }
 
 export function truncateDataUrls(text: string): string {
+  // Snapshots are routinely hundreds of KB and usually hold no data URL at all,
+  // so nothing is copied or rebuilt until the first one is actually found.
+  let start = findDataUrlStart(text, 0);
+  if (start === -1)
+    return text;
+
   let result = '';
   let offset = 0;
-  const lowerText = text.toLowerCase();
-
-  while (offset < text.length) {
-    const start = findDataUrlStart(text, lowerText, offset);
-    if (start === -1) {
-      result += text.slice(offset);
-      break;
-    }
-
+  while (start !== -1) {
     result += text.slice(offset, start);
 
     const match = parseDataUrl(text, start);
@@ -47,15 +45,14 @@ export function truncateDataUrls(text: string): string {
       const prefixLength = dataUrlPrefixLengthAt(text, start);
       result += text.slice(start, start + prefixLength);
       offset = start + prefixLength;
-      continue;
+    } else {
+      result += `${match.displayPrefix}...`;
+      offset = findDataUrlEnd(text, match);
     }
-
-    const end = findDataUrlEnd(text, match);
-    result += `${match.displayPrefix}...`;
-    offset = end;
+    start = findDataUrlStart(text, offset);
   }
 
-  return result;
+  return result + text.slice(offset);
 }
 
 type DataUrlMatch = {
@@ -66,24 +63,17 @@ type DataUrlMatch = {
   quote: '"' | '\'' | undefined;
 };
 
-function findDataUrlStart(text: string, lowerText: string, offset: number): number {
-  let start = nextDataUrlPrefix(lowerText, offset);
-  while (start !== -1) {
-    if (isDataUrlStartBoundary(text, start))
-      return start;
-    start = nextDataUrlPrefix(lowerText, start + dataUrlPrefixLengthAt(lowerText, start));
+// Matches either prefix case-insensitively without lower-casing a copy of the
+// whole text, which on a large snapshot costs more than the scan itself.
+const dataUrlPrefixPattern = /data(?::|%3a)/gi;
+
+function findDataUrlStart(text: string, offset: number): number {
+  dataUrlPrefixPattern.lastIndex = offset;
+  for (let match = dataUrlPrefixPattern.exec(text); match; match = dataUrlPrefixPattern.exec(text)) {
+    if (isDataUrlStartBoundary(text, match.index))
+      return match.index;
   }
   return -1;
-}
-
-function nextDataUrlPrefix(lowerText: string, offset: number): number {
-  const literalStart = lowerText.indexOf(dataUrlPrefix, offset);
-  const encodedStart = lowerText.indexOf(encodedDataUrlPrefix, offset);
-  if (literalStart === -1)
-    return encodedStart;
-  if (encodedStart === -1)
-    return literalStart;
-  return Math.min(literalStart, encodedStart);
 }
 
 function dataUrlPrefixLengthAt(text: string, start: number): number {
@@ -204,8 +194,20 @@ function isLineBreak(char: string): boolean {
   return char === '\n' || char === '\r';
 }
 
+// Runs once per character of a base64 payload, which is the longest run in any
+// snapshot, so it stays a plain switch rather than a regex plus an array scan.
 function isBase64PayloadTerminator(char: string): boolean {
-  return /\s/.test(char) || ['"', '\'', '<', '>', ')', ']', '}', '`', ':'].includes(char);
+  switch (char) {
+    case '"': case '\'': case '<': case '>':
+    case ')': case ']': case '}': case '`': case ':':
+      return true;
+    default:
+      return isWhitespace(char);
+  }
+}
+
+function isWhitespace(char: string): boolean {
+  return /\s/.test(char);
 }
 
 function isQueryParamBoundary(text: string, match: DataUrlMatch, ampersand: number): boolean {
@@ -216,14 +218,14 @@ function isQueryParamBoundary(text: string, match: DataUrlMatch, ampersand: numb
 
 function isRawPayloadCompleteBefore(text: string, payloadStart: number, end: number): boolean {
   let position = end - 1;
-  while (position >= payloadStart && /\s/.test(text[position]))
+  while (position >= payloadStart && isWhitespace(text[position]))
     position--;
   return text[position] === '>' || (position >= payloadStart + 2 && startsWithIgnoreCase(text, position - 2, '%3e'));
 }
 
 function isRawPayloadSuffixBoundary(text: string, match: DataUrlMatch, position: number): boolean {
   const char = text[position];
-  if (/\s/.test(char))
+  if (isWhitespace(char))
     return !isRawMarkupPayload(text, match.payloadStart) || isRawPayloadCompleteBefore(text, match.payloadStart, position);
   if (isRawPayloadWrapperBoundary(text, match, position))
     return true;
@@ -250,7 +252,7 @@ function looksLikeSourceLocationSuffix(text: string, colon: number): boolean {
     return false;
   while (position < text.length && /\d/.test(text[position]))
     position++;
-  return position === text.length || isLineBreak(text[position]) || /\s/.test(text[position]);
+  return position === text.length || isLineBreak(text[position]) || isWhitespace(text[position]);
 }
 
 function looksLikeQueryParam(text: string, offset: number): boolean {
@@ -260,7 +262,7 @@ function looksLikeQueryParam(text: string, offset: number): boolean {
     const char = text[position];
     if (char === '=')
       return position > offset;
-    if (isLineBreak(char) || /\s/.test(char) || ['&', '#', '"', '\'', '<', '>', ')', '}', '`'].includes(char))
+    if (isLineBreak(char) || isWhitespace(char) || ['&', '#', '"', '\'', '<', '>', ')', '}', '`'].includes(char))
       return false;
   }
   return false;
@@ -292,7 +294,7 @@ function isRawPayloadBoundarySuffix(text: string, offset: number): boolean {
   if (offset >= text.length)
     return true;
   const char = text[offset];
-  return isLineBreak(char) || /\s/.test(char) || ['"', '\'', ')', ']', '}', '`'].includes(char) || (char === '&' && looksLikeQueryParam(text, offset + 1));
+  return isLineBreak(char) || isWhitespace(char) || ['"', '\'', ')', ']', '}', '`'].includes(char) || (char === '&' && looksLikeQueryParam(text, offset + 1));
 }
 
 function isEncodedPayloadTerminator(text: string, position: number): boolean {
@@ -310,6 +312,18 @@ function percentEncodedCharAt(text: string, position: number): string | undefine
   return String.fromCharCode(Number.parseInt(text.slice(position + 1, position + 3), 16));
 }
 
+// `value` is always lower-case ASCII here, so a char-code compare answers this
+// without allocating the slice these hot per-character scans would otherwise make.
 function startsWithIgnoreCase(text: string, position: number, value: string): boolean {
-  return text.slice(position, position + value.length).toLowerCase() === value;
+  if (position < 0 || position + value.length > text.length)
+    return false;
+  for (let index = 0; index < value.length; index++) {
+    const char = text.charCodeAt(position + index);
+    const expected = value.charCodeAt(index);
+    // Fold upper-case ASCII only; folding by bit would also equate control
+    // characters with punctuation.
+    if (char !== expected && !(char >= 65 && char <= 90 && char + 32 === expected))
+      return false;
+  }
+  return true;
 }

--- a/tests/bench.test.ts
+++ b/tests/bench.test.ts
@@ -86,3 +86,33 @@ it.each(['--out', '--server', '--lib'])('rejects a blank %s value', flag => {
   expect(result.status).not.toBe(0);
   expect(result.stderr).toContain('needs a value');
 });
+
+it('rejects an invalid report directory before starting the benchmark', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-bench-test-'));
+  temporaryDirectories.push(directory);
+  const result = spawnSync(process.execPath, [
+    'bench/mcp-bench.mjs', '--out', path.join(directory, 'missing', 'report.json'),
+  ], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('ENOENT');
+});
+
+it('rejects a report path whose parent is a file', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-bench-test-'));
+  temporaryDirectories.push(directory);
+  const parent = path.join(directory, 'file');
+  fs.writeFileSync(parent, 'not a directory');
+  const result = spawnSync(process.execPath, [
+    'bench/mcp-bench.mjs', '--out', path.join(parent, 'report.json'),
+  ], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('--out parent must be a directory');
+});

--- a/tests/bench.test.ts
+++ b/tests/bench.test.ts
@@ -17,7 +17,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { afterEach, expect, it } from 'vitest';
 
 const temporaryDirectories: string[] = [];
@@ -52,4 +52,14 @@ it('compares totals over only the shared end-to-end scenarios', () => {
   expect(output).toContain('| 20.0');
   expect(output).not.toContain('110.0');
   expect(output).not.toContain('1020.0');
+});
+
+it.each(['--server', '--lib'])('rejects an unpaired %s override', flag => {
+  const result = spawnSync(process.execPath, ['bench/mcp-bench.mjs', flag, '/tmp/revision'], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('--server and --lib must be provided together.');
 });

--- a/tests/bench.test.ts
+++ b/tests/bench.test.ts
@@ -35,12 +35,20 @@ it('compares totals over only the shared end-to-end scenarios', () => {
   fs.writeFileSync(before, JSON.stringify({
     label: 'before',
     totalMedianMs: 110,
-    scenarios: [{ name: 'shared', median: 10 }, { name: 'removed', median: 100 }],
+    scenarios: [
+      { name: 'shared', median: 10 },
+      { name: 'removed', median: 100 },
+      { name: 'micro-shared', median: 1000, micro: true },
+    ],
   }));
   fs.writeFileSync(after, JSON.stringify({
     label: 'after',
     totalMedianMs: 1020,
-    scenarios: [{ name: 'shared', median: 20 }, { name: 'added', median: 1000 }],
+    scenarios: [
+      { name: 'shared', median: 20 },
+      { name: 'added', median: 1000 },
+      { name: 'micro-shared', median: 2000, micro: true },
+    ],
   }));
 
   const output = execFileSync(process.execPath, ['bench/mcp-bench.mjs', '--compare', before, after], {
@@ -48,8 +56,13 @@ it('compares totals over only the shared end-to-end scenarios', () => {
     encoding: 'utf8',
   });
 
-  expect(output).toContain('| TOTAL (end-to-end tool calls) | 10.0');
-  expect(output).toContain('| 20.0');
+  const totalRow = output.split('\n').find(line => line.includes('TOTAL (end-to-end tool calls)'));
+  expect(totalRow?.split('|').map(cell => cell.trim())).toEqual([
+    '', 'TOTAL (end-to-end tool calls)', '10.0', '20.0', '+100.0%', '0.50x', '',
+  ]);
+  expect(output).toMatch(/^\| shared\s+\|/m);
+  expect(output).not.toMatch(/^\| added\s+\|/m);
+  expect(output).not.toMatch(/^\| removed\s+\|/m);
   expect(output).not.toContain('110.0');
   expect(output).not.toContain('1020.0');
 });

--- a/tests/bench.test.ts
+++ b/tests/bench.test.ts
@@ -76,3 +76,13 @@ it.each(['--server', '--lib'])('rejects an unpaired %s override', flag => {
   expect(result.status).not.toBe(0);
   expect(result.stderr).toContain('--server and --lib must be provided together.');
 });
+
+it.each(['--out', '--server', '--lib'])('rejects a blank %s value', flag => {
+  const result = spawnSync(process.execPath, ['bench/mcp-bench.mjs', flag, '  '], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('needs a value');
+});

--- a/tests/bench.test.ts
+++ b/tests/bench.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, expect, it } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+it('compares totals over only the shared end-to-end scenarios', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-bench-test-'));
+  temporaryDirectories.push(directory);
+  const before = path.join(directory, 'before.json');
+  const after = path.join(directory, 'after.json');
+  fs.writeFileSync(before, JSON.stringify({
+    label: 'before',
+    totalMedianMs: 110,
+    scenarios: [{ name: 'shared', median: 10 }, { name: 'removed', median: 100 }],
+  }));
+  fs.writeFileSync(after, JSON.stringify({
+    label: 'after',
+    totalMedianMs: 1020,
+    scenarios: [{ name: 'shared', median: 20 }, { name: 'added', median: 1000 }],
+  }));
+
+  const output = execFileSync(process.execPath, ['bench/mcp-bench.mjs', '--compare', before, after], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  expect(output).toContain('| TOTAL (end-to-end tool calls) | 10.0');
+  expect(output).toContain('| 20.0');
+  expect(output).not.toContain('110.0');
+  expect(output).not.toContain('1020.0');
+});

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -23,8 +23,7 @@ describe('Tab', () => {
   let mockContext: Context;
   let mockPage: any;
   let onPageClose: any;
-  let locatorRole: string | undefined;
-  let locatorName: string;
+  let locatorSnapshot: string | undefined;
 
   beforeEach(() => {
     mockPage = new EventEmitter();
@@ -37,16 +36,13 @@ describe('Tab', () => {
     mockPage.setDefaultTimeout = vi.fn();
     mockPage.goBack = vi.fn().mockResolvedValue(null);
     mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
-    locatorRole = 'button';
-    locatorName = 'Submit';
+    locatorSnapshot = 'button "Submit" [ref=1]';
     mockPage.locator = vi.fn().mockReturnValue({
       describe: vi.fn().mockReturnValue({}),
-      _expect: vi.fn(async (expression, options) => {
-        if (locatorRole === undefined)
+      ariaSnapshot: vi.fn(async () => {
+        if (locatorSnapshot === undefined)
           throw new Error('Element not found');
-        const expected = options.expectedText[0].string;
-        const value = expression === 'to.have.role' ? locatorRole : locatorName;
-        return { matches: expected === value, received: { value } };
+        return locatorSnapshot;
       }),
     });
 
@@ -463,7 +459,7 @@ describe('Tab', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
       await tab.captureSnapshot();
-      locatorRole = undefined;
+      locatorSnapshot = undefined;
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=2]');
 
       await expect(
@@ -475,7 +471,7 @@ describe('Tab', () => {
     it('re-captures when a cached ref has different accessible semantics', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       await tab.captureSnapshot();
-      locatorName = 'Delete';
+      locatorSnapshot = 'button "Delete" [ref=2]';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Delete" [ref=2]');
 
       await expect(
@@ -488,7 +484,7 @@ describe('Tab', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Save" [ref=1]');
       await tab.captureSnapshot();
-      locatorName = 'Save 2';
+      locatorSnapshot = 'button "Save 2" [ref=2]';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Save 2" [ref=2]');
 
       await expect(
@@ -499,7 +495,7 @@ describe('Tab', () => {
 
     it('revalidates YAML-quoted snapshot entries without a full-page capture', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
-      locatorName = 'Warning: Delete';
+      locatorSnapshot = `- 'button "Warning: Delete" [ref=1]'`;
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- 'button "Warning: Delete" [ref=1]'`);
       await tab.captureSnapshot();
 
@@ -510,8 +506,7 @@ describe('Tab', () => {
 
     it('accepts Playwright synthetic roles when the public ARIA role is empty', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
-      locatorRole = '';
-      locatorName = '';
+      locatorSnapshot = 'generic [ref=1]';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('generic [ref=1]');
       await tab.captureSnapshot();
 
@@ -520,18 +515,28 @@ describe('Tab', () => {
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
     });
 
-    it('caches an unchanged accessible name omitted from the snapshot', async () => {
+    it('reuses a cached ref whose long name is omitted from the snapshot', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
-      locatorName = 'x'.repeat(901);
+      locatorSnapshot = 'button [ref=1]';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button [ref=1]');
       await tab.captureSnapshot();
 
       await tab.refLocators([{ element: 'Long name', ref: '1' }]);
       await tab.refLocators([{ element: 'Long name', ref: '1' }]);
 
-      // The first lookup confirms that the fresh snapshot kept the same ref;
-      // subsequent lookups compare the remembered full name directly.
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(2);
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-captures when an omitted long name changes the Playwright ref', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button [ref=1]');
+      await tab.captureSnapshot();
+      locatorSnapshot = 'button [ref=2]';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button [ref=2]');
+
+      await expect(
+          tab.refLocators([{ element: 'Long name', ref: '1' }])
+      ).rejects.toThrow('Ref 1 not found');
     });
 
     it('re-reads the page for a ref the last snapshot does not hold', async () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -431,6 +431,45 @@ describe('Tab', () => {
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=2');
       expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
     });
+
+    it('resolves refs against the snapshot already returned to the caller', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+
+      await tab.refLocators([{ element: 'Submit', ref: '1' }]);
+
+      // The ref came from that snapshot, so re-reading the page adds nothing.
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=1');
+    });
+
+    it('re-reads the page for a ref the last snapshot does not hold', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1] button "Added" [ref=2]');
+
+      await tab.refLocators([{ element: 'Added', ref: '2' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=2');
+    });
+
+    it('stops trusting the cached snapshot once the tab navigates', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+      mockPage.goto = vi.fn().mockResolvedValue(undefined);
+      mockPage.waitForLoadState = vi.fn().mockResolvedValue(undefined);
+      await tab.navigate('https://example.com/next');
+
+      await tab.refLocators([{ element: 'Submit', ref: '1' }]);
+
+      // Two captures: the first one described a page that is gone.
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('consoleMessages', () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -393,6 +393,47 @@ describe('Tab', () => {
       expect(snapshot.ariaSnapshot).toContain('capturing page accessibility snapshot');
     });
 
+    it('does not cache an accessibility snapshot that resolves after its timeout', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      let resolveSnapshot!: (snapshot: string) => void;
+      mockPage.ariaSnapshot = vi.fn().mockReturnValue(new Promise(resolve => { resolveSnapshot = resolve; }));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshotPromise = tab.captureSnapshot();
+      await vi.advanceTimersByTimeAsync(25);
+      await snapshotPromise;
+      resolveSnapshot('button "Submit" [ref=1]');
+      await Promise.resolve();
+
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=2]');
+      await expect(
+          tab.refLocators([{ element: 'Submit', ref: '1' }])
+      ).rejects.toThrow('Ref 1 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches overlapping snapshots in completion order', async () => {
+      let resolveFirst!: (snapshot: string) => void;
+      let resolveSecond!: (snapshot: string) => void;
+      mockPage.ariaSnapshot = vi.fn()
+          .mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve; }))
+          .mockReturnValueOnce(new Promise(resolve => { resolveSecond = resolve; }));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const first = tab.captureSnapshot();
+      const second = tab.captureSnapshot();
+      resolveSecond('button "B" [ref=2]');
+      await second;
+      resolveFirst('button "A" [ref=1]');
+      await first;
+
+      locatorSnapshot = 'button "A" [ref=1]';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=3]');
+      await tab.refLocators([{ element: 'A', ref: '1' }]);
+      expect(mockPage.ariaSnapshot).not.toHaveBeenCalled();
+    });
+
     it('keeps data URL payloads in captured accessibility snapshots for session logs', async () => {
       const payload = '<svg viewBox="0 0 10 10"><text>Hello</text></svg>';
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- link "Example" [ref=e1]:\n  - /url: data:image/svg+xml,${payload}`);

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -413,6 +413,80 @@ describe('Tab', () => {
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
     });
 
+    it('does not return an accessibility snapshot captured before navigation', async () => {
+      let resolveSnapshot!: (snapshot: string) => void;
+      mockPage.ariaSnapshot = vi.fn().mockReturnValue(new Promise(resolve => { resolveSnapshot = resolve; }));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const snapshotPromise = tab.captureSnapshot();
+      mockPage.emit('framenavigated', { parentFrame: () => null });
+      resolveSnapshot('button "Old page" [ref=1]');
+      const snapshot = await snapshotPromise;
+
+      expect(snapshot.ariaSnapshot).toContain('Page snapshot unavailable');
+      expect(snapshot.ariaSnapshot).not.toContain('Old page');
+    });
+
+    it('does not invalidate a newer overlapping snapshot when an old capture resolves', async () => {
+      let resolveOld!: (snapshot: string) => void;
+      let resolveFresh!: (snapshot: string) => void;
+      mockPage.ariaSnapshot = vi.fn()
+          .mockReturnValueOnce(new Promise(resolve => { resolveOld = resolve; }))
+          .mockReturnValueOnce(new Promise(resolve => { resolveFresh = resolve; }));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const oldCapture = tab.captureSnapshot();
+      mockPage.emit('framenavigated', { parentFrame: () => null });
+      const freshCapture = tab.captureSnapshot();
+      resolveFresh('button "Fresh page" [ref=2]');
+      expect((await freshCapture).ariaSnapshot).toContain('Fresh page');
+      resolveOld('button "Old page" [ref=1]');
+      expect((await oldCapture).ariaSnapshot).toContain('Page snapshot unavailable');
+
+      locatorSnapshot = 'button "Fresh page" [ref=2]';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=3]');
+      await tab.refLocators([{ element: 'Fresh page', ref: '2' }]);
+      expect(mockPage.ariaSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('does not invalidate a newer overlapping snapshot when an old capture times out', async () => {
+      vi.useFakeTimers();
+      mockContext.config.timeouts.defaultTimeout = 25;
+      mockPage.ariaSnapshot = vi.fn()
+          .mockReturnValueOnce(new Promise(() => {}))
+          .mockResolvedValueOnce('button "Fresh page" [ref=2]');
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const oldCapture = tab.captureSnapshot();
+      const freshCapture = tab.captureSnapshot();
+      expect((await freshCapture).ariaSnapshot).toContain('Fresh page');
+      await vi.advanceTimersByTimeAsync(25);
+      expect((await oldCapture).ariaSnapshot).toContain('Page snapshot unavailable');
+
+      locatorSnapshot = 'button "Fresh page" [ref=2]';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=3]');
+      await tab.refLocators([{ element: 'Fresh page', ref: '2' }]);
+      expect(mockPage.ariaSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a snapshot completed after a modal interrupts capture', async () => {
+      let resolveSnapshot!: (snapshot: string) => void;
+      mockPage.ariaSnapshot = vi.fn().mockReturnValue(new Promise(resolve => { resolveSnapshot = resolve; }));
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      const pending = tab.captureSnapshot();
+      const modal = { type: 'dialog', description: 'Dialog', dialog: {} } as any;
+      tab.setModalState(modal);
+      expect((await pending).ariaSnapshot).toBe('');
+      tab.clearModalState(modal);
+      resolveSnapshot('button "Unseen" [ref=2]');
+      await Promise.resolve();
+
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Current" [ref=3]');
+      await expect(tab.refLocators([{ element: 'Unseen', ref: '2' }])).rejects.toThrow('Ref 2 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
     it('caches overlapping snapshots in completion order', async () => {
       let resolveFirst!: (snapshot: string) => void;
       let resolveSecond!: (snapshot: string) => void;

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -23,9 +23,8 @@ describe('Tab', () => {
   let mockContext: Context;
   let mockPage: any;
   let onPageClose: any;
-  // What an aria-ref locator resolves to; 0 stands for a ref whose element has
-  // left the page since the snapshot that issued it.
-  let locatorCount: number;
+  let locatorRole: string | undefined;
+  let locatorName: string;
 
   beforeEach(() => {
     mockPage = new EventEmitter();
@@ -38,10 +37,17 @@ describe('Tab', () => {
     mockPage.setDefaultTimeout = vi.fn();
     mockPage.goBack = vi.fn().mockResolvedValue(null);
     mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
-    locatorCount = 1;
+    locatorRole = 'button';
+    locatorName = 'Submit';
     mockPage.locator = vi.fn().mockReturnValue({
       describe: vi.fn().mockReturnValue({}),
-      count: vi.fn(async () => locatorCount),
+      _expect: vi.fn(async (expression, options) => {
+        if (locatorRole === undefined)
+          throw new Error('Element not found');
+        const expected = options.expectedText[0].string;
+        const value = expression === 'to.have.role' ? locatorRole : locatorName;
+        return { matches: expected === value, received: { value } };
+      }),
     });
 
     mockContext = {
@@ -457,13 +463,75 @@ describe('Tab', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
       await tab.captureSnapshot();
-      locatorCount = 0;
+      locatorRole = undefined;
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=2]');
 
       await expect(
           tab.refLocators([{ element: 'Submit', ref: '1' }])
       ).rejects.toThrow('Ref 1 not found');
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-captures when a cached ref has different accessible semantics', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      await tab.captureSnapshot();
+      locatorName = 'Delete';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Delete" [ref=2]');
+
+      await expect(
+          tab.refLocators([{ element: 'Submit', ref: '1' }])
+      ).rejects.toThrow('Ref 1 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not accept a generated locator that only partially matches the old name', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Save" [ref=1]');
+      await tab.captureSnapshot();
+      locatorName = 'Save 2';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Save 2" [ref=2]');
+
+      await expect(
+          tab.refLocators([{ element: 'Save', ref: '1' }])
+      ).rejects.toThrow('Ref 1 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('revalidates YAML-quoted snapshot entries without a full-page capture', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      locatorName = 'Warning: Delete';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- 'button "Warning: Delete" [ref=1]'`);
+      await tab.captureSnapshot();
+
+      await tab.refLocators([{ element: 'Delete', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts Playwright synthetic roles when the public ARIA role is empty', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      locatorRole = '';
+      locatorName = '';
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('generic [ref=1]');
+      await tab.captureSnapshot();
+
+      await tab.refLocators([{ element: 'Target', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches an unchanged accessible name omitted from the snapshot', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      locatorName = 'x'.repeat(901);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button [ref=1]');
+      await tab.captureSnapshot();
+
+      await tab.refLocators([{ element: 'Long name', ref: '1' }]);
+      await tab.refLocators([{ element: 'Long name', ref: '1' }]);
+
+      // The first lookup confirms that the fresh snapshot kept the same ref;
+      // subsequent lookups compare the remembered full name directly.
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(2);
     });
 
     it('re-reads the page for a ref the last snapshot does not hold', async () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -595,6 +595,24 @@ describe('Tab', () => {
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
     });
 
+    it('re-captures when the page navigates during cached ref validation', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      await tab.captureSnapshot();
+      let resolveValidation!: (snapshot: string) => void;
+      mockPage.locator = vi.fn().mockReturnValue({
+        ariaSnapshot: vi.fn().mockReturnValue(new Promise(resolve => { resolveValidation = resolve; })),
+        describe: vi.fn().mockReturnValue({}),
+      });
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "New page" [ref=2]');
+
+      const locators = tab.refLocators([{ element: 'Submit', ref: '1' }]);
+      mockPage.emit('framenavigated', { parentFrame: () => null });
+      resolveValidation('button "Submit" [ref=1]');
+
+      await expect(locators).rejects.toThrow('Ref 1 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
     it('does not accept a generated locator that only partially matches the old name', async () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Save" [ref=1]');

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -23,6 +23,9 @@ describe('Tab', () => {
   let mockContext: Context;
   let mockPage: any;
   let onPageClose: any;
+  // What an aria-ref locator resolves to; 0 stands for a ref whose element has
+  // left the page since the snapshot that issued it.
+  let locatorCount: number;
 
   beforeEach(() => {
     mockPage = new EventEmitter();
@@ -35,8 +38,10 @@ describe('Tab', () => {
     mockPage.setDefaultTimeout = vi.fn();
     mockPage.goBack = vi.fn().mockResolvedValue(null);
     mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+    locatorCount = 1;
     mockPage.locator = vi.fn().mockReturnValue({
       describe: vi.fn().mockReturnValue({}),
+      count: vi.fn(async () => locatorCount),
     });
 
     mockContext = {
@@ -443,6 +448,22 @@ describe('Tab', () => {
       // The ref came from that snapshot, so re-reading the page adds nothing.
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=1');
+    });
+
+    it('re-captures when a cached ref no longer resolves to an element', async () => {
+      // The element was removed after the snapshot went out: the ref is still in
+      // the cached text, but it matches nothing, and handing back that locator
+      // would fail as an action timeout instead of a useful message.
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+      locatorCount = 0;
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Other" [ref=2]');
+
+      await expect(
+          tab.refLocators([{ element: 'Submit', ref: '1' }])
+      ).rejects.toThrow('Ref 1 not found');
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
     });
 
     it('re-reads the page for a ref the last snapshot does not hold', async () => {

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -470,6 +470,30 @@ describe('Tab', () => {
       // Two captures: the first one described a page that is gone.
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(2);
     });
+
+    it('stops trusting the cached snapshot after any main-frame navigation', async () => {
+      // goBack(), page.reload() and a page-driven location change never reach
+      // Tab.navigate(), so the cache is keyed on the navigation event itself.
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+
+      mockPage.emit('framenavigated', { parentFrame: () => null });
+      await tab.refLocators([{ element: 'Submit', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the cached snapshot when only a sub-frame navigates', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue('button "Submit" [ref=1]');
+      await tab.captureSnapshot();
+
+      mockPage.emit('framenavigated', { parentFrame: () => ({}) });
+      await tab.refLocators([{ element: 'Submit', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('consoleMessages', () => {

--- a/tests/tools-auditSite.integration.test.ts
+++ b/tests/tools-auditSite.integration.test.ts
@@ -59,7 +59,10 @@ describe('audit_site integration', () => {
       context: vi.fn(() => ({ cookies: vi.fn(async () => []) })),
       url: vi.fn(() => currentUrl),
       title: vi.fn(async () => `Title for ${currentUrl}`),
-      evaluate: vi.fn(async () => linkMap[currentUrl] ?? []),
+      evaluate: vi.fn(async (_callback: unknown, selector?: string) => ({
+        title: `Title for ${currentUrl}`,
+        links: selector ? linkMap[currentUrl] ?? [] : [],
+      })),
     };
 
     const crawlTab: any = {

--- a/tests/tools-auditSite.integration.test.ts
+++ b/tests/tools-auditSite.integration.test.ts
@@ -31,6 +31,7 @@ function createAxeResult(url: string, violations: any[]) {
     incomplete: [],
     passes: [],
     inapplicable: [],
+    unscannedFrames: [],
   } as any;
 }
 

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -178,6 +178,66 @@ describe('audit_site tool', () => {
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
   });
 
+  it('warns about pages whose frames the scan could not reach', async () => {
+    // A page scanned with a frame missing reports fewer violations, so a reader
+    // counting them has to know which pages those numbers are incomplete for.
+    const { context, response } = createHarness({
+      'https://example.com/': ['https://example.com/embedded'],
+      'https://example.com/embedded': [],
+    });
+    vi.spyOn(axe, 'runAxeScan').mockImplementation(async (page: any) => ({
+      ...createAxeResult(page.url(), []),
+      unscannedFrames: page.url() === 'https://example.com/embedded' ? ['https://widget.example/embed'] : [],
+    }));
+
+    await tool.handle(context as any, {
+      strategy: 'links',
+      maxPages: 5,
+      maxDepth: 1,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+    } as any, response);
+
+    expect(response.result()).toContain('WARNING: Axe could not be installed in frames on 1 page(s)');
+    expect(response.result()).toContain('- https://example.com/embedded: https://widget.example/embed');
+
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    const embedded = report.pages.find((page: any) => page.url === 'https://example.com/embedded');
+    expect(embedded.unscannedFrames).toEqual(['https://widget.example/embed']);
+    // A client reading only structured output must be able to tell the same.
+    expect(response.structuredContent()!.pagesWithUnscannedFrames).toEqual([
+      { url: 'https://example.com/embedded', unscannedFrames: ['https://widget.example/embed'] },
+    ]);
+  });
+
+  it('says nothing about frames when every page was scanned in full', async () => {
+    const { context, response } = createHarness({ 'https://example.com/': [] });
+    vi.spyOn(axe, 'runAxeScan').mockImplementation(async (page: any) => createAxeResult(page.url(), []));
+
+    await tool.handle(context as any, {
+      strategy: 'links',
+      maxPages: 1,
+      maxDepth: 0,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+    } as any, response);
+
+    expect(response.result()).not.toContain('could not be installed');
+    expect(response.structuredContent()!.pagesWithUnscannedFrames).toEqual([]);
+  });
+
   it('passes tags, rule filters and scope selectors through to the axe scan', async () => {
     const { context, response } = createHarness({ 'https://example.com/': [] });
     const runAxeScanSpy = vi.spyOn(axe, 'runAxeScan')

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -29,6 +29,7 @@ function createAxeResult(url: string, violations: any[], incomplete: any[] = [])
     incomplete,
     passes: [],
     inapplicable: [],
+    unscannedFrames: [],
   } as any;
 }
 

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -711,8 +711,10 @@ describe('audit_site tool', () => {
     const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
     const crawledUrls = report.pages.map((page: any) => page.url);
     expect(crawledUrls).toEqual(['https://example.com/a', 'https://example.com/b']);
-    // The page is still read for its title; what must not happen is link
-    // discovery, which is what a non-empty selector argument would mean.
+    // The page is still read for its title - `every` alone would also pass if
+    // that read disappeared - and what must not happen is link discovery, which
+    // is what a non-empty selector argument would mean.
+    expect(crawlTab.page.evaluate.mock.calls.length).toBeGreaterThan(0);
     expect(crawlTab.page.evaluate.mock.calls.every((call: unknown[]) => !call[1])).toBe(true);
   });
 

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -69,12 +69,15 @@ function createHarness(
     context: vi.fn(() => ({ cookies: cookiesMock })),
     url: vi.fn(() => currentUrl),
     title: vi.fn(async () => `Title for ${currentUrl}`),
-    evaluate: vi.fn(async (callback: () => unknown) => {
-      const callbackText = String(callback);
-      const isNavExtraction = /role=.*navigation.*a\[href\]/.test(callbackText);
-      if (isNavExtraction)
-        return navLinkMap[currentUrl] ?? [];
-      return linkMap[currentUrl] ?? [];
+    // Mirrors readPage(): one evaluate per crawled page returning the title and,
+    // when a link selector is passed, the links that selector would collect.
+    evaluate: vi.fn(async (_callback: unknown, selector?: string) => {
+      const links = !selector
+        ? []
+        : /navigation/.test(selector)
+          ? navLinkMap[currentUrl] ?? []
+          : linkMap[currentUrl] ?? [];
+      return { title: `Title for ${currentUrl}`, links };
     }),
   };
 
@@ -708,7 +711,9 @@ describe('audit_site tool', () => {
     const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
     const crawledUrls = report.pages.map((page: any) => page.url);
     expect(crawledUrls).toEqual(['https://example.com/a', 'https://example.com/b']);
-    expect(crawlTab.page.evaluate).not.toHaveBeenCalled();
+    // The page is still read for its title; what must not happen is link
+    // discovery, which is what a non-empty selector argument would mean.
+    expect(crawlTab.page.evaluate.mock.calls.every((call: unknown[]) => !call[1])).toBe(true);
   });
 
   it('supports sitemap strategy by parsing loc entries', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -468,6 +468,23 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual(['https://example.com/nested']);
   });
 
+  it('reports a nested frame whose ancestor never got Axe', async () => {
+    resetScan();
+    // The nested frame took the injection fine, but the top-level run reaches it
+    // only by relaying through the outer frame, and a frame without Axe relays
+    // nothing. Both documents go unscanned, so both have to be listed.
+    const outer = makeFrame({}, 'https://example.com/outer', false);
+    const nested = makeFrame({}, 'https://example.com/nested', true);
+    nested.parentFrame = () => outer as any;
+
+    const result = await runAxeScan(pageWithSelectorCounts({}, [outer, nested]));
+
+    expect(result.unscannedFrames).toEqual([
+      'https://example.com/outer',
+      'https://example.com/nested',
+    ]);
+  });
+
   it('drops a nested frame when an ancestor frame is excluded', async () => {
     resetScan();
     // The mirror case: excluding the outer frame removes everything below it,

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -34,7 +34,13 @@ function makeFrame(
     // The scope check reads the owning iframe element in the parent document,
     // walking up one document per ancestor frame.
     frameElement: async () => ({
-      evaluate: async (_script: unknown, arg?: unknown) => arg === undefined ? scope.reachable ?? true : scope,
+      evaluate: async (_script: unknown, arg?: { include: string[], exclude: string[] }) => arg === undefined
+        ? scope.reachable ?? true
+        : {
+          included: !!arg.include.length && scope.included,
+          excluded: !!arg.exclude.length && scope.excluded,
+          hidden: scope.hidden ?? false,
+        },
       dispose: async () => undefined,
     }),
     evaluate: async (script: unknown, arg?: unknown) => {
@@ -443,7 +449,7 @@ describe('axe helpers', () => {
     let reads = 0;
     page.frames = () => ++reads < 4 ? [mainFrame, detached] : [mainFrame, replacement];
 
-    expect((await runAxeScan(page)).unscannedFrames).toEqual([]);
+    expect((await runAxeScan(page, { exclude: ['iframe.widget'] })).unscannedFrames).toEqual([]);
   });
 
   it('fails instead of reporting complete coverage when frames keep changing', async () => {
@@ -694,6 +700,19 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual([]);
   });
 
+  it('does not reapply a flat exclude selector inside a descendant document', async () => {
+    resetScan();
+    const outer = makeFrame({}, 'https://example.com/outer', true, '', true, { included: false, excluded: false });
+    const nested = makeFrame({}, 'https://example.com/nested', false, '', true, { included: false, excluded: true });
+    nested.parentFrame = () => outer as any;
+
+    const result = await runAxeScan(pageWithSelectorCounts({ '.widget': 1 }, [outer, nested]), {
+      exclude: ['.widget'],
+    });
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/nested']);
+  });
+
   it('rethrows scan failures untouched', async () => {
     resetScan();
     const failure = new Error('axe run failed');
@@ -715,13 +734,17 @@ describe('axe helpers', () => {
 });
 
 describe.skipIf(!fs.existsSync(chromium.executablePath()))('axe frame coverage in a real browser', () => {
-  it('reports a hidden iframe made visible by author CSS', async () => {
+  it('reports a hidden iframe made visible by author CSS outside a CSS-hidden modal', async () => {
     const browser = await chromium.launch({ headless: true, chromiumSandbox: false });
     try {
       const page = await browser.newPage();
       await page.setContent('<div id="host"></div>');
       const loaded = page.waitForEvent('framenavigated', frame => frame.url() === 'about:srcdoc');
       await page.evaluate(() => {
+        const dialog = document.createElement('dialog');
+        document.body.append(dialog);
+        dialog.showModal();
+        dialog.style.opacity = '0';
         const root = document.querySelector('#host')!.attachShadow({ mode: 'closed' });
         const style = document.createElement('style');
         style.textContent = 'iframe[hidden]{display:block}';
@@ -729,6 +752,31 @@ describe.skipIf(!fs.existsSync(chromium.executablePath()))('axe frame coverage i
         frame.hidden = true;
         frame.srcdoc = '<button>inside</button>';
         root.append(style, frame);
+      });
+      await loaded;
+
+      expect((await runAxeScan(page)).unscannedFrames).toEqual(['about:srcdoc']);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it('reports a frame inside the first slotted summary of closed details', async () => {
+    const browser = await chromium.launch({ headless: true, chromiumSandbox: false });
+    try {
+      const page = await browser.newPage();
+      await page.setContent('<div id="host"></div>');
+      const loaded = page.waitForEvent('framenavigated', frame => frame.url() === 'about:srcdoc');
+      await page.evaluate(() => {
+        const host = document.querySelector('#host')!;
+        host.attachShadow({ mode: 'closed' }).innerHTML = '<details><slot></slot></details>';
+        const summary = document.createElement('summary');
+        const innerHost = document.createElement('span');
+        const frame = document.createElement('iframe');
+        frame.srcdoc = '<button>inside</button>';
+        innerHost.attachShadow({ mode: 'closed' }).append(frame);
+        summary.append(innerHost);
+        host.append(summary);
       });
       await loaded;
 

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -18,13 +18,25 @@ const axeVersion = axeCore.version;
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '', keepsAxe = true, inScope = true) {
+type FrameScope = { included: boolean, excluded: boolean };
+
+function makeFrame(
+  countBySelector: Record<string, number>,
+  url = 'https://example.com/',
+  injectable = true,
+  name = '',
+  keepsAxe = true,
+  scope: FrameScope = { included: true, excluded: false }
+) {
   return {
     url: () => url,
     name: () => name,
-    // The scope check reads the owning iframe element in the parent document.
+    // Set by pageWithSelectorCounts, or by hand to build a nested frame chain.
+    parentFrame: () => null as any,
+    // The scope check reads the owning iframe element in the parent document,
+    // walking up one document per ancestor frame.
     frameElement: async () => ({
-      evaluate: async () => inScope,
+      evaluate: async () => scope,
       dispose: async () => undefined,
     }),
     evaluate: async (script: unknown, arg?: unknown) => {
@@ -50,11 +62,20 @@ function makeFrame(countBySelector: Record<string, number>, url = 'https://examp
 
 function pageWithSelectorCounts(countBySelector: Record<string, number> = {}, childFrames: any[] = []) {
   const frame = makeFrame(countBySelector);
-  return {
+  const page = {
     ...frame,
     frames: () => [frame, ...childFrames],
     mainFrame: () => frame,
   } as any;
+  // The main frame has no parent; a child hangs off it unless a test already
+  // placed it deeper in a chain of its own.
+  page.parentFrame = () => null;
+  frame.parentFrame = () => null;
+  for (const child of childFrames) {
+    if (!child.parentFrame())
+      child.parentFrame = () => frame;
+  }
+  return page;
 }
 
 function resetScan() {
@@ -410,7 +431,7 @@ describe('axe helpers', () => {
     // excludeSelectors: ["iframe.chat-widget"] is the documented way to drop a
     // flaky third-party widget. Warning that the widget went unscanned would be
     // a false alarm about content the caller removed on purpose.
-    const excluded = makeFrame({ '#main': 1, 'iframe.chat-widget': 1 }, 'https://widget.example/', false, '', true, false);
+    const excluded = makeFrame({ '#main': 1, 'iframe.chat-widget': 1 }, 'https://widget.example/', false, '', true, { included: false, excluded: true });
     const result = await runAxeScan(
         pageWithSelectorCounts({ '#main': 1, 'iframe.chat-widget': 1 }, [excluded]),
         { exclude: ['iframe.chat-widget'] },
@@ -421,13 +442,46 @@ describe('axe helpers', () => {
 
   it('still warns about an in-scope frame when a scope is set', async () => {
     resetScan();
-    const inScope = makeFrame({ '#main': 1 }, 'https://widget.example/', false, '', true, true);
+    const inScope = makeFrame({ '#main': 1 }, 'https://widget.example/', false, '', true, { included: true, excluded: false });
     const result = await runAxeScan(
         pageWithSelectorCounts({ '#main': 1 }, [inScope]),
         { include: ['#main'] },
     );
 
     expect(result.unscannedFrames).toEqual(['https://widget.example/']);
+  });
+
+  it('keeps a nested frame in scope when the include names an ancestor frame', async () => {
+    resetScan();
+    // #main holds iframe A, which holds iframe B. B's own iframe element lives
+    // in A's document, where `closest('#main')` cannot reach - but Axe's context
+    // descends into B all the same, so a failed B is a real coverage gap.
+    const outer = makeFrame({ '#main': 1 }, 'https://example.com/outer', true, '', true, { included: true, excluded: false });
+    const nested = makeFrame({ '#main': 1 }, 'https://example.com/nested', false, '', true, { included: false, excluded: false });
+    nested.parentFrame = () => outer as any;
+
+    const result = await runAxeScan(
+        pageWithSelectorCounts({ '#main': 1 }, [outer, nested]),
+        { include: ['#main'] },
+    );
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/nested']);
+  });
+
+  it('drops a nested frame when an ancestor frame is excluded', async () => {
+    resetScan();
+    // The mirror case: excluding the outer frame removes everything below it,
+    // so warning about the nested document would be the same false alarm.
+    const outer = makeFrame({ 'iframe.widget': 1 }, 'https://example.com/outer', true, '', true, { included: false, excluded: true });
+    const nested = makeFrame({ 'iframe.widget': 1 }, 'https://example.com/nested', false, '', true, { included: false, excluded: false });
+    nested.parentFrame = () => outer as any;
+
+    const result = await runAxeScan(
+        pageWithSelectorCounts({ 'iframe.widget': 1 }, [outer, nested]),
+        { exclude: ['iframe.widget'] },
+    );
+
+    expect(result.unscannedFrames).toEqual([]);
   });
 
   it('rethrows scan failures untouched', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -14,7 +14,7 @@ type ScanCall = { context: unknown; options: any };
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-type FrameScope = { included: boolean, excluded: boolean, hidden?: boolean };
+type FrameScope = { included: boolean, excluded: boolean, hidden?: boolean, reachable?: boolean };
 
 function makeFrame(
   countBySelector: Record<string, number>,
@@ -33,7 +33,7 @@ function makeFrame(
     // The scope check reads the owning iframe element in the parent document,
     // walking up one document per ancestor frame.
     frameElement: async () => ({
-      evaluate: async () => scope,
+      evaluate: async (_script: unknown, arg?: unknown) => arg === undefined ? scope.reachable ?? true : scope,
       dispose: async () => undefined,
     }),
     evaluate: async (script: unknown, arg?: unknown) => {
@@ -362,6 +362,18 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual([]);
   });
 
+  it('reports an injected frame that Axe cannot reach through a closed shadow root', async () => {
+    resetScan();
+    const closedShadow = makeFrame({}, 'https://example.com/closed-shadow', true, '', true, {
+      included: true,
+      excluded: false,
+      reachable: false,
+    });
+    const result = await runAxeScan(pageWithSelectorCounts({}, [closedShadow]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/closed-shadow']);
+  });
+
   it('reports a frame that took the injection and then navigated away from it', async () => {
     resetScan();
     // A frame that navigates while a slower sibling is still injecting has a new
@@ -460,6 +472,30 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [hidden]));
 
     expect(result.unscannedFrames).toEqual([]);
+  });
+
+  it('warns about a failed hidden-until-found frame that Axe still traverses', async () => {
+    resetScan();
+    const untilFound = makeFrame({}, 'https://example.com/until-found', false, '', true, {
+      included: true,
+      excluded: false,
+      hidden: false,
+    });
+    const result = await runAxeScan(pageWithSelectorCounts({}, [untilFound]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/until-found']);
+  });
+
+  it('warns about a failed slotted frame inside a shadow-root modal', async () => {
+    resetScan();
+    const slotted = makeFrame({}, 'https://example.com/slotted-modal', false, '', true, {
+      included: true,
+      excluded: false,
+      hidden: false,
+    });
+    const result = await runAxeScan(pageWithSelectorCounts({}, [slotted]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/slotted-modal']);
   });
 
   it('does not warn about a frame the caller scoped out of the scan', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -18,10 +18,15 @@ const axeVersion = axeCore.version;
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '', keepsAxe = true) {
+function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '', keepsAxe = true, inScope = true) {
   return {
     url: () => url,
     name: () => name,
+    // The scope check reads the owning iframe element in the parent document.
+    frameElement: async () => ({
+      evaluate: async () => inScope,
+      dispose: async () => undefined,
+    }),
     evaluate: async (script: unknown, arg?: unknown) => {
       // Injection: the axe source and its configuration, both plain strings.
       if (typeof script === 'string') {
@@ -398,6 +403,31 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [dataFrame]));
 
     expect(result.unscannedFrames).toEqual(['data:text/html;base64,...']);
+  });
+
+  it('does not warn about a frame the caller scoped out of the scan', async () => {
+    resetScan();
+    // excludeSelectors: ["iframe.chat-widget"] is the documented way to drop a
+    // flaky third-party widget. Warning that the widget went unscanned would be
+    // a false alarm about content the caller removed on purpose.
+    const excluded = makeFrame({ '#main': 1, 'iframe.chat-widget': 1 }, 'https://widget.example/', false, '', true, false);
+    const result = await runAxeScan(
+        pageWithSelectorCounts({ '#main': 1, 'iframe.chat-widget': 1 }, [excluded]),
+        { exclude: ['iframe.chat-widget'] },
+    );
+
+    expect(result.unscannedFrames).toEqual([]);
+  });
+
+  it('still warns about an in-scope frame when a scope is set', async () => {
+    resetScan();
+    const inScope = makeFrame({ '#main': 1 }, 'https://widget.example/', false, '', true, true);
+    const result = await runAxeScan(
+        pageWithSelectorCounts({ '#main': 1 }, [inScope]),
+        { include: ['#main'] },
+    );
+
+    expect(result.unscannedFrames).toEqual(['https://widget.example/']);
   });
 
   it('rethrows scan failures untouched', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -386,6 +387,126 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
   });
 
+  it('rechecks a frame that navigates during its reachability probe', async () => {
+    resetScan();
+    const navigated = makeFrame({}, 'https://example.com/widget');
+    const evaluate = navigated.evaluate;
+    let navigatedAway = false;
+    navigated.evaluate = async (script: unknown, arg?: unknown) =>
+      arg && typeof arg === 'object' && 'token' in arg && navigatedAway ? false : evaluate(script, arg);
+    navigated.frameElement = async () => ({
+      evaluate: async () => {
+        navigatedAway = true;
+        return true;
+      },
+      dispose: async () => undefined,
+    });
+
+    expect((await runAxeScan(pageWithSelectorCounts({}, [navigated]))).unscannedFrames)
+        .toEqual(['https://example.com/widget']);
+  });
+
+  it('does not report a failed frame that detached during coverage checks', async () => {
+    resetScan();
+    const detached = makeFrame({}, 'https://example.com/widget', false);
+    const page = pageWithSelectorCounts({}, [detached]);
+    const mainFrame = page.mainFrame();
+    let reads = 0;
+    page.frames = () => ++reads < 3 ? [mainFrame, detached] : [mainFrame];
+
+    expect((await runAxeScan(page)).unscannedFrames).toEqual([]);
+  });
+
+  it('reports a replacement frame that attaches during coverage checks', async () => {
+    resetScan();
+    const detached = makeFrame({}, 'https://example.com/old', false);
+    const replacement = makeFrame({}, 'https://example.com/replacement', false);
+    const page = pageWithSelectorCounts({}, [detached]);
+    const mainFrame = page.mainFrame();
+    replacement.parentFrame = () => mainFrame;
+    let reads = 0;
+    page.frames = () => ++reads < 4 ? [mainFrame, detached] : [mainFrame, replacement];
+
+    expect((await runAxeScan(page)).unscannedFrames).toEqual(['https://example.com/replacement']);
+  });
+
+  it('does not report an excluded replacement frame that attaches during coverage checks', async () => {
+    resetScan();
+    const detached = makeFrame({}, 'https://example.com/old', false);
+    const replacement = makeFrame({}, 'https://example.com/replacement', false, '', true, {
+      included: true,
+      excluded: true,
+    });
+    const page = pageWithSelectorCounts({}, [detached]);
+    const mainFrame = page.mainFrame();
+    replacement.parentFrame = () => mainFrame;
+    let reads = 0;
+    page.frames = () => ++reads < 4 ? [mainFrame, detached] : [mainFrame, replacement];
+
+    expect((await runAxeScan(page)).unscannedFrames).toEqual([]);
+  });
+
+  it('fails instead of reporting complete coverage when frames keep changing', async () => {
+    resetScan();
+    const frames = Array.from({ length: 9 }, (_, index) => makeFrame({}, `https://example.com/${index}`, false));
+    const page = pageWithSelectorCounts({}, [frames[0]]);
+    const mainFrame = page.mainFrame();
+    frames.forEach(frame => frame.parentFrame = () => mainFrame);
+    let reads = 0;
+    page.frames = () => [mainFrame, frames[Math.min(reads++, frames.length - 1)]];
+
+    await expect(runAxeScan(page)).rejects.toThrow(/frame tree kept changing/);
+  });
+
+  it('fails when frame replacements repeat the same transition', async () => {
+    resetScan();
+    const frames = [makeFrame({}, 'https://example.com/a', false), makeFrame({}, 'https://example.com/b', false)];
+    const page = pageWithSelectorCounts({}, frames);
+    const mainFrame = page.mainFrame();
+    frames.forEach(frame => frame.parentFrame = () => mainFrame);
+    const snapshots = [frames[0], frames[0], frames[0], frames[1], frames[1], frames[0], frames[0], frames[1], frames[1]];
+    let reads = 0;
+    page.frames = () => [mainFrame, snapshots[Math.min(reads++, snapshots.length - 1)]];
+
+    await expect(runAxeScan(page)).rejects.toThrow(/frame tree kept changing/);
+  });
+
+  it('limits concurrent coverage and scope probes', async () => {
+    resetScan();
+    let activeCoverage = 0;
+    let activeScope = 0;
+    let maxCoverage = 0;
+    let maxScope = 0;
+    const pause = () => new Promise(resolve => setTimeout(resolve, 5));
+    const frames = Array.from({ length: 8 }, (_, index) => {
+      const frame = makeFrame({}, `https://example.com/${index}`);
+      const evaluate = frame.evaluate;
+      frame.evaluate = async (script: unknown, arg?: unknown) => {
+        if (arg && typeof arg === 'object' && 'token' in arg) {
+          maxCoverage = Math.max(maxCoverage, ++activeCoverage);
+          await pause();
+          activeCoverage--;
+        }
+        return evaluate(script, arg);
+      };
+      frame.frameElement = async () => ({
+        evaluate: async (_script: unknown, arg?: unknown) => {
+          if (arg === undefined)
+            return false;
+          maxScope = Math.max(maxScope, ++activeScope);
+          await pause();
+          activeScope--;
+          return { included: true, excluded: false, hidden: false };
+        },
+        dispose: async () => undefined,
+      });
+      return frame;
+    });
+
+    expect((await runAxeScan(pageWithSelectorCounts({}, frames))).unscannedFrames).toHaveLength(frames.length);
+    expect({ maxCoverage, maxScope }).toEqual({ maxCoverage: 4, maxScope: 4 });
+  });
+
   it('does not accept a readiness marker left by an earlier scan', async () => {
     resetScan();
     const stale = makeFrame({}, 'https://example.com/widget');
@@ -590,5 +711,30 @@ describe('axe helpers', () => {
       byImpact: { serious: 3 },
       byRuleId: { 'rule-a': 1, 'rule-b': 2 },
     });
+  });
+});
+
+describe.skipIf(!fs.existsSync(chromium.executablePath()))('axe frame coverage in a real browser', () => {
+  it('reports a hidden iframe made visible by author CSS', async () => {
+    const browser = await chromium.launch({ headless: true, chromiumSandbox: false });
+    try {
+      const page = await browser.newPage();
+      await page.setContent('<div id="host"></div>');
+      const loaded = page.waitForEvent('framenavigated', frame => frame.url() === 'about:srcdoc');
+      await page.evaluate(() => {
+        const root = document.querySelector('#host')!.attachShadow({ mode: 'closed' });
+        const style = document.createElement('style');
+        style.textContent = 'iframe[hidden]{display:block}';
+        const frame = document.createElement('iframe');
+        frame.hidden = true;
+        frame.srcdoc = '<button>inside</button>';
+        root.append(style, frame);
+      });
+      await loaded;
+
+      expect((await runAxeScan(page)).unscannedFrames).toEqual(['about:srcdoc']);
+    } finally {
+      await browser.close();
+    }
   });
 });

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -3,6 +3,8 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
+import axeCore from 'axe-core';
+
 import { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } from '../src/tools/axe.js';
 
 // The scan drives the page itself: axe-core is injected into every frame, then
@@ -11,10 +13,12 @@ import { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTag
 // (-1 for CSS the browser rejects).
 type ScanCall = { context: unknown; options: any };
 
+const axeVersion = axeCore.version;
+
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '') {
+function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '', keepsAxe = true) {
   return {
     url: () => url,
     name: () => name,
@@ -25,8 +29,10 @@ function makeFrame(countBySelector: Record<string, number>, url = 'https://examp
           throw new Error('Execution context was destroyed');
         return undefined;
       }
+      // The post-injection coverage probe: a frame that took the injection
+      // reports the version, one that did not reports nothing.
       if (arg === undefined)
-        return undefined;
+        return injectable && keepsAxe ? axeVersion : undefined;
       if (Array.isArray(arg))
         return arg.map(selector => countBySelector[selector as string] ?? 0);
       lastScan = arg as ScanCall;
@@ -329,6 +335,40 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [healthy]));
 
     expect(result.unscannedFrames).toEqual([]);
+  });
+
+  it('reports a frame that took the injection and then navigated away from it', async () => {
+    resetScan();
+    // A frame that navigates while a slower sibling is still injecting has a new
+    // document with no Axe in it, so the run below silently skips it. The
+    // coverage check runs against the frames as they are, not against what the
+    // injection returned.
+    const navigated = makeFrame({}, 'https://example.com/widget', true, '', false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [navigated]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
+  });
+
+  it('counts every failed frame, even when they describe identically', async () => {
+    resetScan();
+    // Two unnamed about:blank frames are two documents that went unscanned;
+    // collapsing them would under-count the coverage gap.
+    const first = makeFrame({}, 'about:blank', false);
+    const second = makeFrame({}, 'about:blank', false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [first, second]));
+
+    expect(result.unscannedFrames).toEqual(['about:blank', 'about:blank']);
+  });
+
+  it('truncates a data URL frame rather than echoing the whole document', async () => {
+    resetScan();
+    // A data: frame's URL is its document, and this string reaches tool text,
+    // structured content and the JSON reports.
+    const payload = 'A'.repeat(5000);
+    const dataFrame = makeFrame({}, `data:text/html;base64,${payload}`, false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [dataFrame]));
+
+    expect(result.unscannedFrames).toEqual(['data:text/html;base64,...']);
   });
 
   it('rethrows scan failures untouched', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -14,9 +14,10 @@ type ScanCall = { context: unknown; options: any };
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true) {
+function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true, name = '') {
   return {
     url: () => url,
+    name: () => name,
     evaluate: async (script: unknown, arg?: unknown) => {
       // Injection: the axe source and its configuration, both plain strings.
       if (typeof script === 'string') {
@@ -303,13 +304,23 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
   });
 
-  it('does not report frames that hold nothing a scan would have covered', async () => {
+  it('reports a failed frame whatever its URL scheme', async () => {
     resetScan();
-    // about:blank and friends have no content to miss.
-    const blank = makeFrame({}, 'about:blank', false);
-    const result = await runAxeScan(pageWithSelectorCounts({}, [blank]));
+    // A srcdoc or scripted about:blank frame reports "about:blank" while holding
+    // a whole document, and injection into a genuinely empty one succeeds - so a
+    // frame that failed is worth reporting regardless of scheme.
+    const srcdoc = makeFrame({}, 'about:blank', false, 'promo');
+    const result = await runAxeScan(pageWithSelectorCounts({}, [srcdoc]));
 
-    expect(result.unscannedFrames).toEqual([]);
+    expect(result.unscannedFrames).toEqual(['about:blank (name="promo")']);
+  });
+
+  it('falls back to the URL alone for an unnamed failed frame', async () => {
+    resetScan();
+    const unnamed = makeFrame({}, '', false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [unnamed]));
+
+    expect(result.unscannedFrames).toEqual(['about:blank']);
   });
 
   it('reports no unscanned frames when every injection succeeds', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -18,7 +18,7 @@ const axeVersion = axeCore.version;
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-type FrameScope = { included: boolean, excluded: boolean };
+type FrameScope = { included: boolean, excluded: boolean, hidden?: boolean };
 
 function makeFrame(
   countBySelector: Record<string, number>,
@@ -424,6 +424,27 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [dataFrame]));
 
     expect(result.unscannedFrames).toEqual(['data:text/html;base64,...']);
+  });
+
+  it('truncates a data URL embedded in a failed frame URL', async () => {
+    resetScan();
+    const payload = 'A'.repeat(5000);
+    const frame = makeFrame({}, `https://example.com/frame?src=data:text/html;base64,${payload}`, false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [frame]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/frame?src=data:text/html;base64,...']);
+  });
+
+  it('does not warn about a failed frame hidden from the accessibility tree', async () => {
+    resetScan();
+    const hidden = makeFrame({}, 'https://example.com/hidden', false, '', true, {
+      included: true,
+      excluded: false,
+      hidden: true,
+    });
+    const result = await runAxeScan(pageWithSelectorCounts({}, [hidden]));
+
+    expect(result.unscannedFrames).toEqual([]);
   });
 
   it('does not warn about a frame the caller scoped out of the scan', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -1,65 +1,43 @@
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-const builderCalls: { withTags: string[][]; withRules: string[][]; disableRules: string[][]; include: string[]; exclude: string[] } = {
-  withTags: [],
-  withRules: [],
-  disableRules: [],
-  include: [],
-  exclude: [],
-};
-let analyzeResult: any = { violations: [], incomplete: [], passes: [], inapplicable: [] };
+import { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } from '../src/tools/axe.js';
 
-vi.mock('@axe-core/playwright', () => ({
-  AxeBuilder: class {
-    withTags(tags: string[]) {
-      builderCalls.withTags.push(tags);
-      return this;
-    }
-    withRules(rules: string[]) {
-      builderCalls.withRules.push(rules);
-      return this;
-    }
-    disableRules(rules: string[]) {
-      builderCalls.disableRules.push(rules);
-      return this;
-    }
-    include(selector: string) {
-      builderCalls.include.push(selector);
-      return this;
-    }
-    exclude(selector: string) {
-      builderCalls.exclude.push(selector);
-      return this;
-    }
-    async analyze() {
-      if (analyzeResult instanceof Error)
-        throw analyzeResult;
-      return analyzeResult;
-    }
-  },
-}));
+// The scan drives the page itself: axe-core is injected into every frame, then
+// run in the main one. The fake page records what the run was asked to do, and
+// answers the scope check with the match count each selector should resolve to
+// (-1 for CSS the browser rejects).
+type ScanCall = { context: unknown; options: any };
 
-const { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } = await import('../src/tools/axe.js');
+let lastScan: ScanCall | undefined;
+let scanResult: any;
 
-function resetBuilderCalls() {
-  builderCalls.withTags = [];
-  builderCalls.withRules = [];
-  builderCalls.disableRules = [];
-  builderCalls.include = [];
-  builderCalls.exclude = [];
-  analyzeResult = { violations: [], incomplete: [], passes: [], inapplicable: [] };
+function pageWithSelectorCounts(countBySelector: Record<string, number> = {}) {
+  const frame = {
+    evaluate: async (script: unknown, arg?: unknown) => {
+      // Injection: the version probe, then the axe source as a string.
+      if (typeof script === 'string' || arg === undefined)
+        return undefined;
+      if (Array.isArray(arg))
+        return arg.map(selector => countBySelector[selector as string] ?? 0);
+      lastScan = arg as ScanCall;
+      if (scanResult instanceof Error)
+        throw scanResult;
+      return scanResult;
+    },
+  };
+  return {
+    ...frame,
+    frames: () => [frame],
+    mainFrame: () => frame,
+  } as any;
 }
 
-// Stands in for page.evaluate(selectors => …): returns the match count each
-// selector should resolve to, or -1 for CSS the browser rejects.
-function pageWithSelectorCounts(countBySelector: Record<string, number>) {
-  return {
-    evaluate: async (_fn: unknown, selectors: string[]) =>
-      selectors.map(selector => countBySelector[selector] ?? 0),
-  } as any;
+function resetScan() {
+  lastScan = undefined;
+  scanResult = { url: 'https://example.com', violations: [], incomplete: [], passes: [], inapplicable: [] };
 }
 
 function node(target: string, html: string) {
@@ -148,31 +126,26 @@ describe('axe helpers', () => {
   });
 
   it('scans with the default tag set and no scope when given no options', async () => {
-    resetBuilderCalls();
-    await runAxeScan({} as any);
-    expect(builderCalls.withTags).toEqual([[...defaultAxeTags]]);
-    expect(builderCalls.withRules).toEqual([]);
-    expect(builderCalls.disableRules).toEqual([]);
-    expect(builderCalls.include).toEqual([]);
-    expect(builderCalls.exclude).toEqual([]);
+    resetScan();
+    await runAxeScan(pageWithSelectorCounts());
+    expect(lastScan?.options).toEqual({ runOnly: { type: 'tag', values: [...defaultAxeTags] } });
+    expect(lastScan?.context).toBeNull();
   });
 
   it('runs explicit rule ids instead of tags, because axe runOnly holds only one of them', async () => {
-    resetBuilderCalls();
-    await runAxeScan({} as any, { tags: ['wcag2aa'], rules: ['image-alt', 'label'] });
-    expect(builderCalls.withRules).toEqual([['image-alt', 'label']]);
-    // withTags would overwrite the rule list in axe's single runOnly slot.
-    expect(builderCalls.withTags).toEqual([]);
+    resetScan();
+    await runAxeScan(pageWithSelectorCounts(), { tags: ['wcag2aa'], rules: ['image-alt', 'label'] });
+    // A tag list would overwrite the rule list in axe's single runOnly slot.
+    expect(lastScan?.options).toEqual({ runOnly: { type: 'rule', values: ['image-alt', 'label'] } });
   });
 
   it('rejects an explicitly empty rule list instead of silently scanning the full tag set', async () => {
-    resetBuilderCalls();
+    resetScan();
     // "Run only these rules: none" is a contradiction; falling back to tags
     // would scan far more than the caller asked for.
-    await expect(runAxeScan({} as any, { tags: ['wcag2aa'], rules: [] }))
+    await expect(runAxeScan(pageWithSelectorCounts(), { tags: ['wcag2aa'], rules: [] }))
         .rejects.toThrow(/withRules is an empty list/);
-    expect(builderCalls.withTags).toEqual([]);
-    expect(builderCalls.withRules).toEqual([]);
+    expect(lastScan).toBeUndefined();
   });
 
   it('rejects an empty withRules list at the schema layer too', () => {
@@ -185,55 +158,55 @@ describe('axe helpers', () => {
   });
 
   it('composes disableRules with tags', async () => {
-    resetBuilderCalls();
-    await runAxeScan({} as any, { tags: ['wcag2aa'], disableRules: ['color-contrast'] });
-    expect(builderCalls.withTags).toEqual([['wcag2aa']]);
-    expect(builderCalls.disableRules).toEqual([['color-contrast']]);
+    resetScan();
+    await runAxeScan(pageWithSelectorCounts(), { tags: ['wcag2aa'], disableRules: ['color-contrast'] });
+    expect(lastScan?.options).toEqual({
+      runOnly: { type: 'tag', values: ['wcag2aa'] },
+      rules: { 'color-contrast': { enabled: false } },
+    });
   });
 
   it('subtracts disableRules from an explicit rule list rather than relying on axe', async () => {
-    resetBuilderCalls();
+    resetScan();
     // axe ignores the per-rule enabled flag once runOnly holds a rule list, so
     // passing both through would still have run `label`.
-    await runAxeScan({} as any, { rules: ['image-alt', 'label'], disableRules: ['label'] });
-    expect(builderCalls.withRules).toEqual([['image-alt']]);
-    expect(builderCalls.disableRules).toEqual([]);
+    await runAxeScan(pageWithSelectorCounts(), { rules: ['image-alt', 'label'], disableRules: ['label'] });
+    expect(lastScan?.options).toEqual({ runOnly: { type: 'rule', values: ['image-alt'] } });
   });
 
   it('refuses a rule list that disableRules empties, instead of silently scanning everything', async () => {
-    resetBuilderCalls();
-    await expect(runAxeScan({} as any, { rules: ['image-alt'], disableRules: ['image-alt'] }))
+    resetScan();
+    await expect(runAxeScan(pageWithSelectorCounts(), { rules: ['image-alt'], disableRules: ['image-alt'] }))
         .rejects.toThrow(/disableRules disabled every rule in withRules \(image-alt\)/);
-    expect(builderCalls.withRules).toEqual([]);
-    expect(builderCalls.withTags).toEqual([]);
+    expect(lastScan).toBeUndefined();
   });
 
   it('rejects an unknown rule id in withRules instead of scanning nothing', async () => {
-    resetBuilderCalls();
-    await expect(runAxeScan({} as any, { rules: ['image-alt', 'image-altt'] }))
+    resetScan();
+    await expect(runAxeScan(pageWithSelectorCounts(), { rules: ['image-alt', 'image-altt'] }))
         .rejects.toThrow(/Unknown Axe rule id\(s\) in withRules: image-altt/);
-    expect(builderCalls.withRules).toEqual([]);
+    expect(lastScan).toBeUndefined();
   });
 
   it('rejects an unknown rule id in disableRules instead of disabling nothing', async () => {
-    resetBuilderCalls();
-    await expect(runAxeScan({} as any, { disableRules: ['colour-contrast'] }))
+    resetScan();
+    await expect(runAxeScan(pageWithSelectorCounts(), { disableRules: ['colour-contrast'] }))
         .rejects.toThrow(/Unknown Axe rule id\(s\) in disableRules: colour-contrast/);
-    expect(builderCalls.disableRules).toEqual([]);
+    expect(lastScan).toBeUndefined();
   });
 
   it('validates rule ids before touching the page, so a bad id cannot cost a scan', async () => {
-    resetBuilderCalls();
+    resetScan();
     const page = { evaluate: () => { throw new Error('page should not be touched'); } } as any;
     await expect(runAxeScan(page, { rules: ['nope'], include: ['#content'] }))
         .rejects.toThrow(/Unknown Axe rule id/);
   });
 
   it('accepts every rule id axe-core actually ships', async () => {
-    resetBuilderCalls();
+    resetScan();
     // Guards against the catalogue check drifting from the injected axe build.
-    await runAxeScan({} as any, { rules: ['color-contrast', 'region', 'frame-tested', 'aria-allowed-attr'] });
-    expect(builderCalls.withRules[0]).toHaveLength(4);
+    await runAxeScan(pageWithSelectorCounts(), { rules: ['color-contrast', 'region', 'frame-tested', 'aria-allowed-attr'] });
+    expect(lastScan?.options.runOnly.values).toHaveLength(4);
   });
 
   it('validates rule options without a page, so crawlers can check them before navigating', () => {
@@ -249,28 +222,14 @@ describe('axe helpers', () => {
         .toThrow(/disableRules disabled every rule in withRules \(image-alt\)/);
   });
 
-  it('validates rule ids against the exact axe-core build @axe-core/playwright injects', async () => {
-    // The catalogue check is only meaningful while both resolve to one version,
-    // which is why package.json pins axe-core exactly.
+  it('validates rule ids against the exact axe-core build it injects', async () => {
+    // The rule catalogue and the injected source are the same module, and the
+    // exact pin keeps a lockfile-less install from resolving a different one.
     const [ownPackage, installedAxeCore] = await Promise.all([
       import('../package.json', { with: { type: 'json' } }),
       import('axe-core/package.json', { with: { type: 'json' } }),
     ]);
     expect(ownPackage.default.dependencies['axe-core']).toBe(installedAxeCore.default.version);
-  });
-
-  it('pins @axe-core/playwright exactly so a newer wrapper cannot nest a different axe-core', async () => {
-    // A ranged wrapper could resolve to a newer release on a clean install and
-    // bring its own nested axe-core; validation would then use one catalogue
-    // while AxeBuilder injects another. The exact pin makes the two axe-core
-    // requirements (ours and the wrapper's) meet in a single resolved copy.
-    const ownPackage = await import('../package.json', { with: { type: 'json' } });
-    // The wrapper's exports map hides its package.json from import(), so read it.
-    const installedWrapper = JSON.parse(fs.readFileSync(
-        fileURLToPath(new URL('../node_modules/@axe-core/playwright/package.json', import.meta.url)), 'utf-8'));
-    expect(ownPackage.default.dependencies['@axe-core/playwright']).toBe(installedWrapper.version);
-    // The proof that nothing nested: the wrapper has no private axe-core copy.
-    expect(fs.existsSync(fileURLToPath(new URL('../node_modules/@axe-core/playwright/node_modules/axe-core', import.meta.url)))).toBe(false);
   });
 
   it('documents the codegen command with the pinned Playwright version', async () => {
@@ -288,30 +247,29 @@ describe('axe helpers', () => {
     }
   });
 
-  it('applies include and exclude selectors to the builder', async () => {
-    resetBuilderCalls();
+  it('applies include and exclude selectors as the scan context', async () => {
+    resetScan();
     await runAxeScan(pageWithSelectorCounts({ '#checkout': 1, '#summary': 2, '#cookie-banner': 1 }), {
       tags: ['wcag2aa'],
       include: ['#checkout', '#summary'],
       exclude: ['#cookie-banner'],
     });
-    expect(builderCalls.withTags).toEqual([['wcag2aa']]);
-    expect(builderCalls.include).toEqual(['#checkout', '#summary']);
-    expect(builderCalls.exclude).toEqual(['#cookie-banner']);
+    expect(lastScan?.options).toEqual({ runOnly: { type: 'tag', values: ['wcag2aa'] } });
+    expect(lastScan?.context).toEqual({ include: ['#checkout', '#summary'], exclude: ['#cookie-banner'] });
   });
 
   it('fails instead of silently narrowing when one of several include selectors matches nothing', async () => {
-    resetBuilderCalls();
+    resetScan();
     // Axe itself only errors when the whole include set is empty, so this is
     // the case that would otherwise produce a clean but half-scoped report.
     await expect(runAxeScan(pageWithSelectorCounts({ '#checkout': 1, '#billing-summry': 0 }), {
       include: ['#checkout', '#billing-summry'],
     })).rejects.toThrow(/No elements matched includeSelectors: #billing-summry/);
-    expect(builderCalls.include).toEqual([]);
+    expect(lastScan).toBeUndefined();
   });
 
   it('rejects CSS the browser cannot parse, for includes and excludes alike', async () => {
-    resetBuilderCalls();
+    resetScan();
     await expect(runAxeScan(pageWithSelectorCounts({ '#ok': 1, ':::bad': -1 }), {
       include: ['#ok'],
       exclude: [':::bad'],
@@ -319,17 +277,17 @@ describe('axe helpers', () => {
   });
 
   it('allows an exclude selector that matches nothing on this page', async () => {
-    resetBuilderCalls();
+    resetScan();
     // A crawl legitimately hits pages without the excluded widget.
     await runAxeScan(pageWithSelectorCounts({ '#cookie-banner': 0 }), { exclude: ['#cookie-banner'] });
-    expect(builderCalls.exclude).toEqual(['#cookie-banner']);
+    expect(lastScan?.context).toEqual({ include: [], exclude: ['#cookie-banner'] });
   });
 
   it('rethrows scan failures untouched', async () => {
-    resetBuilderCalls();
-    const failure = new Error('axe injection failed');
-    analyzeResult = failure;
-    await expect(runAxeScan({} as any)).rejects.toBe(failure);
+    resetScan();
+    const failure = new Error('axe run failed');
+    scanResult = failure;
+    await expect(runAxeScan(pageWithSelectorCounts())).rejects.toBe(failure);
   });
 
   it('summarizes counts by impact and rule id', () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -29,9 +29,9 @@ function makeFrame(countBySelector: Record<string, number>, url = 'https://examp
           throw new Error('Execution context was destroyed');
         return undefined;
       }
-      // The post-injection coverage probe: a frame that took the injection
-      // reports the version, one that did not reports nothing.
-      if (arg === undefined)
+      // The post-injection coverage probe reads the marker this server sets
+      // when it configures its own injection.
+      if (typeof arg === 'string')
         return injectable && keepsAxe ? axeVersion : undefined;
       if (Array.isArray(arg))
         return arg.map(selector => countBySelector[selector as string] ?? 0);
@@ -347,6 +347,35 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [navigated]));
 
     expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
+  });
+
+  it('reports a frame carrying only the page own Axe, not this injection', async () => {
+    resetScan();
+    // Same version, but no marker: the page's own instance is not configured
+    // with allowedOrigins, so the top-level run's ping goes unanswered and the
+    // frame contributes nothing. It must not read as covered.
+    const pageOwned = makeFrame({}, 'https://example.com/widget');
+    pageOwned.evaluate = async (script: unknown, arg?: unknown) => {
+      if (typeof script === 'string')
+        return undefined;
+      // Answers a bare `window.axe.version` probe, but not the marker.
+      if (typeof arg === 'string')
+        return undefined;
+      return undefined;
+    };
+    const result = await runAxeScan(pageWithSelectorCounts({}, [pageOwned]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
+  });
+
+  it('caps and truncates an author-controlled frame name', async () => {
+    resetScan();
+    // The name attribute is author-controlled and unbounded, and can carry a
+    // data URL of its own.
+    const noisy = makeFrame({}, 'https://example.com/widget', false, `promo data:text/html;base64,${'A'.repeat(4000)}`);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [noisy]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/widget (name="promo data:text/html;base64,...")']);
   });
 
   it('counts every failed frame, even when they describe identically', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -589,6 +589,15 @@ describe('axe helpers', () => {
     expect(result.unscannedFrames).toEqual(['https://example.com/frame?src=data:text/html;base64,...']);
   });
 
+  it('caps an ordinary failed frame URL', async () => {
+    resetScan();
+    const frame = makeFrame({}, `https://example.com/frame?value=${'A'.repeat(5000)}`, false);
+    const [url] = (await runAxeScan(pageWithSelectorCounts({}, [frame]))).unscannedFrames;
+
+    expect(url).toHaveLength(2048);
+    expect(url).toMatch(/^https:\/\/example\.com\/frame\?value=A+\.\.\.$/);
+  });
+
   it('does not warn about a failed frame hidden from the accessibility tree', async () => {
     resetScan();
     const hidden = makeFrame({}, 'https://example.com/hidden', false, '', true, {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -14,11 +14,17 @@ type ScanCall = { context: unknown; options: any };
 let lastScan: ScanCall | undefined;
 let scanResult: any;
 
-function pageWithSelectorCounts(countBySelector: Record<string, number> = {}) {
-  const frame = {
+function makeFrame(countBySelector: Record<string, number>, url = 'https://example.com/', injectable = true) {
+  return {
+    url: () => url,
     evaluate: async (script: unknown, arg?: unknown) => {
-      // Injection: the version probe, then the axe source as a string.
-      if (typeof script === 'string' || arg === undefined)
+      // Injection: the axe source and its configuration, both plain strings.
+      if (typeof script === 'string') {
+        if (!injectable)
+          throw new Error('Execution context was destroyed');
+        return undefined;
+      }
+      if (arg === undefined)
         return undefined;
       if (Array.isArray(arg))
         return arg.map(selector => countBySelector[selector as string] ?? 0);
@@ -28,9 +34,13 @@ function pageWithSelectorCounts(countBySelector: Record<string, number> = {}) {
       return scanResult;
     },
   };
+}
+
+function pageWithSelectorCounts(countBySelector: Record<string, number> = {}, childFrames: any[] = []) {
+  const frame = makeFrame(countBySelector);
   return {
     ...frame,
-    frames: () => [frame],
+    frames: () => [frame, ...childFrames],
     mainFrame: () => frame,
   } as any;
 }
@@ -281,6 +291,33 @@ describe('axe helpers', () => {
     // A crawl legitimately hits pages without the excluded widget.
     await runAxeScan(pageWithSelectorCounts({ '#cookie-banner': 0 }), { exclude: ['#cookie-banner'] });
     expect(lastScan?.context).toEqual({ include: [], exclude: ['#cookie-banner'] });
+  });
+
+  it('reports a child frame Axe could not be installed in, rather than scanning around it', async () => {
+    resetScan();
+    // A frame that navigates mid-injection contributes no violations, and a
+    // report that stays silent about it reads as a clean scan of the whole page.
+    const broken = makeFrame({}, 'https://example.com/widget', false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [broken]));
+
+    expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
+  });
+
+  it('does not report frames that hold nothing a scan would have covered', async () => {
+    resetScan();
+    // about:blank and friends have no content to miss.
+    const blank = makeFrame({}, 'about:blank', false);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [blank]));
+
+    expect(result.unscannedFrames).toEqual([]);
+  });
+
+  it('reports no unscanned frames when every injection succeeds', async () => {
+    resetScan();
+    const healthy = makeFrame({}, 'https://example.com/widget', true);
+    const result = await runAxeScan(pageWithSelectorCounts({}, [healthy]));
+
+    expect(result.unscannedFrames).toEqual([]);
   });
 
   it('rethrows scan failures untouched', async () => {

--- a/tests/tools-axe.test.ts
+++ b/tests/tools-axe.test.ts
@@ -3,8 +3,6 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import axeCore from 'axe-core';
-
 import { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTags, dedupeAxeNodes, prepareAxeResults, runAxeScan, summarizeAxeViolations, trimAxeResults } from '../src/tools/axe.js';
 
 // The scan drives the page itself: axe-core is injected into every frame, then
@@ -12,8 +10,6 @@ import { assertRuleOptionsValid, axeRuleSchemaShape, axeTagValues, defaultAxeTag
 // answers the scope check with the match count each selector should resolve to
 // (-1 for CSS the browser rejects).
 type ScanCall = { context: unknown; options: any };
-
-const axeVersion = axeCore.version;
 
 let lastScan: ScanCall | undefined;
 let scanResult: any;
@@ -28,6 +24,7 @@ function makeFrame(
   keepsAxe = true,
   scope: FrameScope = { included: true, excluded: false }
 ) {
+  let readyToken: string | undefined;
   return {
     url: () => url,
     name: () => name,
@@ -44,12 +41,14 @@ function makeFrame(
       if (typeof script === 'string') {
         if (!injectable)
           throw new Error('Execution context was destroyed');
+        const match = /window\["__mcpAccessibilityScannerAxeReady"\]=("[^"]+")/.exec(script);
+        readyToken = match ? JSON.parse(match[1]) : undefined;
         return undefined;
       }
       // The post-injection coverage probe reads the marker this server sets
       // when it configures its own injection.
-      if (typeof arg === 'string')
-        return injectable && keepsAxe ? axeVersion : undefined;
+      if (arg && typeof arg === 'object' && 'token' in arg)
+        return injectable && keepsAxe && readyToken === arg.token;
       if (Array.isArray(arg))
         return arg.map(selector => countBySelector[selector as string] ?? 0);
       lastScan = arg as ScanCall;
@@ -373,6 +372,22 @@ describe('axe helpers', () => {
     const result = await runAxeScan(pageWithSelectorCounts({}, [navigated]));
 
     expect(result.unscannedFrames).toEqual(['https://example.com/widget']);
+  });
+
+  it('does not accept a readiness marker left by an earlier scan', async () => {
+    resetScan();
+    const stale = makeFrame({}, 'https://example.com/widget');
+    const evaluate = stale.evaluate;
+    let injections = 0;
+    stale.evaluate = async (script: unknown, arg?: unknown) => {
+      if (typeof script === 'string' && ++injections === 2)
+        return new Promise(() => {});
+      return evaluate(script, arg);
+    };
+    const page = pageWithSelectorCounts({}, [stale]);
+
+    expect((await runAxeScan(page)).unscannedFrames).toEqual([]);
+    expect((await runAxeScan(page)).unscannedFrames).toEqual(['https://example.com/widget']);
   });
 
   it('reports a frame carrying only the page own Axe, not this injection', async () => {

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -333,6 +333,7 @@ describe('scan_page_matrix tool', () => {
     } as any, response);
 
     const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(report.version).toBe('v2');
     // The baseline itself was fully covered, so it still compares with itself.
     expect(report.variants[0].diffFromBaseline).not.toBeNull();
     // "label" is absent from the variant only because a frame went unscanned.

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -4,6 +4,21 @@ import scanPageMatrixTools from '../src/tools/scanPageMatrix.js';
 import { Response } from '../src/response.js';
 import * as axe from '../src/tools/axe.js';
 
+// The page's media emulation as an unconfigured browser reports it. Variants
+// fall back to this rather than to null, so emulation the session was created
+// with survives both the scan and the restore.
+const defaultMedia = {
+  colorScheme: 'light',
+  forcedColors: 'none',
+  contrast: 'no-preference',
+  reducedMotion: 'no-preference',
+};
+
+// What the single setup evaluate returns: the page's zoom and media state.
+function pageState(zoom = '', media: Record<string, unknown> = {}) {
+  return { zoom, media: { ...defaultMedia, ...media } };
+}
+
 function createViolation(id: string) {
   return {
     id,
@@ -39,7 +54,7 @@ function createMatrixHarness(outputFile: string) {
     viewportSize: vi.fn(() => ({ width: 1024, height: 768 })),
     setViewportSize: vi.fn(async () => undefined),
     emulateMedia: vi.fn(async () => undefined),
-    evaluate: vi.fn().mockResolvedValueOnce('').mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValueOnce(pageState('')).mockResolvedValue(undefined),
     reload: vi.fn(async () => undefined),
   };
   const mockTab = {
@@ -155,7 +170,7 @@ describe('scan_page_matrix tool', () => {
 
   it('runs variants in baseline-first order and computes baseline diffs', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -215,7 +230,7 @@ describe('scan_page_matrix tool', () => {
 
   it('restores viewport, media emulation, and zoom in finally', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('150%')
+        .mockResolvedValueOnce(pageState('150%'))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -258,18 +273,69 @@ describe('scan_page_matrix tool', () => {
     const lastEvaluateCall = mockPage.evaluate.mock.calls.at(-1);
 
     expect(lastViewportCall?.[0]).toEqual({ width: 1280, height: 720 });
-    expect(lastMediaCall?.[0]).toEqual({
-      colorScheme: null,
-      forcedColors: null,
-      contrast: null,
-      reducedMotion: null,
-    });
+    expect(lastMediaCall?.[0]).toEqual(defaultMedia);
     expect(lastEvaluateCall?.[1]).toBe('150%');
+  });
+
+  it('keeps the session’s own media emulation across the scan', async () => {
+    // A context created with colorScheme "dark" is the state this page is meant
+    // to be audited in. Passing null for the properties a variant leaves unset
+    // resets them to the browser default instead, so the baseline would be
+    // scanned light and the page would stay light after the tool returned.
+    const configured = { colorScheme: 'dark', reducedMotion: 'reduce' };
+    const { context, mockPage, response } = createMatrixHarness('/tmp/scan-configured-media.json');
+    mockPage.evaluate = vi.fn()
+        .mockResolvedValueOnce(pageState('', configured))
+        .mockResolvedValue(undefined) as any;
+
+    vi.spyOn(axe, 'runAxeScan').mockResolvedValue(createAxeResult('https://example.com/page', []));
+
+    await tool.handle(context as any, {
+      variants: [{ name: 'baseline' }, { name: 'forced-colors', media: { forcedColors: 'active' } }],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterApplyMs: 0,
+      reloadBetweenVariants: false,
+    } as any, response);
+
+    const media = { ...defaultMedia, ...configured };
+    // The baseline variant sets nothing of its own, so it runs as configured.
+    expect(mockPage.emulateMedia.mock.calls[0][0]).toEqual(media);
+    // A variant overrides only the property it names.
+    expect(mockPage.emulateMedia.mock.calls[1][0]).toEqual({ ...media, forcedColors: 'active' });
+    // And the page is handed back in the state it arrived in.
+    expect(mockPage.emulateMedia.mock.calls.at(-1)?.[0]).toEqual(media);
+
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(report.variants[0].applied.media.colorScheme).toBe('dark');
+  });
+
+  it('applies zoom after a reload, not before it', async () => {
+    // Zoom is an inline style on documentElement, so a reload discards it while
+    // the viewport and media emulation survive. Applying it first would scan the
+    // variant unzoomed while applied.zoomPercent still claimed 200.
+    const { context, mockPage, response } = createMatrixHarness('/tmp/scan-reload-zoom.json');
+    vi.spyOn(axe, 'runAxeScan').mockResolvedValue(createAxeResult('https://example.com/page', []));
+
+    await tool.handle(context as any, {
+      variants: [{ name: 'zoom-200', zoomPercent: 200 }],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterApplyMs: 0,
+      reloadBetweenVariants: true,
+    } as any, response);
+
+    const zoomCallIndex = mockPage.evaluate.mock.calls.findIndex(call => call[1] === '200%');
+    expect(zoomCallIndex).toBeGreaterThan(-1);
+    expect(mockPage.evaluate.mock.invocationCallOrder[zoomCallIndex])
+        .toBeGreaterThan(mockPage.reload.mock.invocationCallOrder[0]);
   });
 
   it('runs only custom variants and treats first variant as baseline', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -320,7 +386,7 @@ describe('scan_page_matrix tool', () => {
 
   it('records forced-colors/contrast media and zoomPercent metadata in report', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -370,7 +436,7 @@ describe('scan_page_matrix tool', () => {
 
   it('reloads page between variants when reloadBetweenVariants=true', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -414,7 +480,7 @@ describe('scan_page_matrix tool', () => {
 
   it('restores page state even when axe scan fails mid-run', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('125%')
+        .mockResolvedValueOnce(pageState('125%'))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -457,18 +523,13 @@ describe('scan_page_matrix tool', () => {
     const lastMediaCall = mockPage.emulateMedia.mock.calls.at(-1);
     const lastEvaluateCall = mockPage.evaluate.mock.calls.at(-1);
     expect(lastViewportCall?.[0]).toEqual({ width: 1440, height: 900 });
-    expect(lastMediaCall?.[0]).toEqual({
-      colorScheme: null,
-      forcedColors: null,
-      contrast: null,
-      reducedMotion: null,
-    });
+    expect(lastMediaCall?.[0]).toEqual(defaultMedia);
     expect(lastEvaluateCall?.[1]).toBe('125%');
   });
 
   it('writes report using custom reportFile name', async () => {
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {
@@ -513,7 +574,7 @@ describe('scan_page_matrix tool', () => {
   it('emits progress notifications as variants finish', async () => {
     const sendNotification = vi.fn(async () => undefined);
     const evaluateMock = vi.fn()
-        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(pageState(''))
         .mockResolvedValue(undefined);
 
     const mockPage = {

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -340,6 +340,7 @@ describe('scan_page_matrix tool', () => {
     expect(report.variants[1].diffFromBaseline).toBeNull();
 
     const structured = response.structuredContent() as any;
+    expect(structured.version).toBe('v2');
     // null, not [] - an empty list would read as "compared, nothing changed".
     expect(structured.variants[1].resolvedViolationIds).toBeNull();
     expect(structured.variants[1].newViolationIds).toBeNull();

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -311,6 +311,65 @@ describe('scan_page_matrix tool', () => {
     expect(report.variants[0].applied.media.colorScheme).toBe('dark');
   });
 
+  it('reports no baseline delta when the two scans covered different documents', async () => {
+    // A rule missing from a variant whose iframe went unscanned has not been
+    // "resolved" - the document it lives in was never looked at. Reporting that
+    // as a delta states an accessibility outcome the run cannot support.
+    const { context, response } = createMatrixHarness('/tmp/scan-partial-delta.json');
+    vi.spyOn(axe, 'runAxeScan')
+        .mockResolvedValueOnce(createAxeResult('https://example.com/page', ['color-contrast', 'label']))
+        .mockResolvedValueOnce({
+          ...createAxeResult('https://example.com/page', ['color-contrast']),
+          unscannedFrames: ['https://widget.example/'],
+        } as any);
+
+    await tool.handle(context as any, {
+      variants: [{ name: 'baseline' }, { name: 'mobile', viewport: { width: 375, height: 812 } }],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterApplyMs: 0,
+      reloadBetweenVariants: false,
+    } as any, response);
+
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    // The baseline itself was fully covered, so it still compares with itself.
+    expect(report.variants[0].diffFromBaseline).not.toBeNull();
+    // "label" is absent from the variant only because a frame went unscanned.
+    expect(report.variants[1].diffFromBaseline).toBeNull();
+
+    const structured = response.structuredContent() as any;
+    // null, not [] - an empty list would read as "compared, nothing changed".
+    expect(structured.variants[1].resolvedViolationIds).toBeNull();
+    expect(structured.variants[1].newViolationIds).toBeNull();
+    expect(structured.variants[1].changedRuleIds).toBeNull();
+    expect(response.result()).toContain('n/a (partial scan)');
+  });
+
+  it('leaves an unnameable color scheme un-emulated rather than pinning it light', async () => {
+    // If neither media query matches, the page is in a state emulateMedia
+    // cannot name. Recording it as "light" would emulate a preference the page
+    // never had, and leave it emulated after the tool returned.
+    const { context, mockPage, response } = createMatrixHarness('/tmp/scan-unnamed-scheme.json');
+    mockPage.evaluate = vi.fn()
+        .mockResolvedValueOnce(pageState('', { colorScheme: null }))
+        .mockResolvedValue(undefined) as any;
+
+    vi.spyOn(axe, 'runAxeScan').mockResolvedValue(createAxeResult('https://example.com/page', []));
+
+    await tool.handle(context as any, {
+      variants: [{ name: 'baseline' }],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterApplyMs: 0,
+      reloadBetweenVariants: false,
+    } as any, response);
+
+    expect(mockPage.emulateMedia.mock.calls[0][0].colorScheme).toBeNull();
+    expect(mockPage.emulateMedia.mock.calls.at(-1)?.[0].colorScheme).toBeNull();
+  });
+
   it('applies zoom after a reload, not before it', async () => {
     // Zoom is an inline style on documentElement, so a reload discards it while
     // the viewport and media emulation survive. Applying it first would scan the

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -29,6 +29,7 @@ function createAxeResult(url: string, violationIds: string[], incompleteIds: str
     incomplete: incompleteIds.map(id => createViolation(id)),
     passes: [],
     inapplicable: [],
+    unscannedFrames: [],
   } as any;
 }
 

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -343,7 +343,41 @@ describe('scan_page_matrix tool', () => {
     expect(structured.variants[1].resolvedViolationIds).toBeNull();
     expect(structured.variants[1].newViolationIds).toBeNull();
     expect(structured.variants[1].changedRuleIds).toBeNull();
-    expect(response.result()).toContain('n/a (partial scan)');
+    expect(response.result()).toContain('n/a (coverage differs)');
+  });
+
+  it('reports no delta on a complete variant when the baseline is the incomplete one', async () => {
+    // The mirror of the case above. A fully scanned variant still cannot be
+    // compared against a baseline that missed a frame, and the reason must not
+    // read as though this variant were the partial one - the gap is upstream.
+    const { context, response } = createMatrixHarness('/tmp/scan-partial-baseline.json');
+    vi.spyOn(axe, 'runAxeScan')
+        .mockResolvedValueOnce({
+          ...createAxeResult('https://example.com/page', ['color-contrast']),
+          unscannedFrames: ['https://widget.example/'],
+        } as any)
+        .mockResolvedValueOnce(createAxeResult('https://example.com/page', ['color-contrast']));
+
+    await tool.handle(context as any, {
+      variants: [{ name: 'baseline' }, { name: 'mobile', viewport: { width: 375, height: 812 } }],
+      violationsTag: ['wcag2aa'],
+      includeIncomplete: false,
+      maxNodesPerViolation: 10,
+      waitAfterApplyMs: 0,
+      reloadBetweenVariants: false,
+    } as any, response);
+
+    const report = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    // Neither row is comparable: the baseline is the one with the gap.
+    expect(report.variants[0].diffFromBaseline).toBeNull();
+    expect(report.variants[1].diffFromBaseline).toBeNull();
+    expect(report.variants[1].unscannedFrames).toEqual([]);
+
+    const structured = response.structuredContent() as any;
+    expect(structured.variants[1].newViolationIds).toBeNull();
+    // The wording must not blame the variant for the baseline's missing frame.
+    expect(response.result()).not.toContain('partial scan');
+    expect(response.result()).toContain('n/a (coverage differs)');
   });
 
   it('leaves an unnameable color scheme un-emulated rather than pinning it light', async () => {

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -244,7 +244,7 @@ describe('Snapshot Tools', () => {
     const scanPageTool = snapshotTools.find(tool => tool.schema.name === 'scan_page')!;
 
     function scanResult(violations: any[], incomplete: any[] = []) {
-      return { url: 'https://example.com/', violations, incomplete, passes: [], inapplicable: [] } as any;
+      return { url: 'https://example.com/', violations, incomplete, passes: [], inapplicable: [], unscannedFrames: [] } as any;
     }
 
     function scanRule(id: string, nodeCount: number) {
@@ -475,7 +475,7 @@ describe.skipIf(!fs.existsSync(chromium.executablePath()))('scan_page annotated 
     const page = await context.newPage();
     await page.setContent(html);
     vi.spyOn(axe, 'runAxeScan').mockResolvedValue({
-      url: 'https://example.com/', violations, incomplete: [], passes: [], inapplicable: [],
+      url: 'https://example.com/', violations, incomplete: [], passes: [], inapplicable: [], unscannedFrames: [],
     } as any);
     const screenshot = page.screenshot.bind(page);
     let drawn: any;
@@ -656,6 +656,7 @@ function scanHarness(options: { violations?: any[], markedNodes?: number, screen
     incomplete: [],
     passes: [],
     inapplicable: [],
+    unscannedFrames: [],
   } as any);
 
   const evaluate = vi.fn(async () => {

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -293,6 +293,39 @@ describe('Snapshot Tools', () => {
       });
     });
 
+    it('warns about frames the scan could not reach, naming them', async () => {
+      // A frame Axe never reached contributes no violations, so a silent result
+      // reads as a clean page rather than a partly-scanned one.
+      vi.spyOn(axe, 'runAxeScan').mockResolvedValue({
+        ...scanResult([]),
+        unscannedFrames: ['https://widget.example/embed', 'about:blank (name="promo")'],
+      });
+      const { context, response, text } = scanHarness();
+
+      await scanPageTool.handle(context as any, {
+        violationsTag: ['wcag2aa'],
+        includeIncomplete: true,
+        maxNodesPerViolation: 10,
+      } as any, response as any);
+
+      expect(text()).toContain('WARNING: Axe could not be installed in 2 frame(s)');
+      expect(text()).toContain('- https://widget.example/embed');
+      expect(text()).toContain('- about:blank (name="promo")');
+    });
+
+    it('says nothing about frames when the scan covered all of them', async () => {
+      vi.spyOn(axe, 'runAxeScan').mockResolvedValue(scanResult([]));
+      const { context, response, text } = scanHarness();
+
+      await scanPageTool.handle(context as any, {
+        violationsTag: ['wcag2aa'],
+        includeIncomplete: true,
+        maxNodesPerViolation: 10,
+      } as any, response as any);
+
+      expect(text()).not.toContain('could not be installed');
+    });
+
     it('reports the rule id and flags truncated node lists', async () => {
       vi.spyOn(axe, 'runAxeScan').mockResolvedValue(scanResult([scanRule('image-alt', 3), scanRule('label', 1)]));
       const { context, response, text } = scanHarness();

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -57,6 +57,7 @@ describe('Tool Utils', () => {
   beforeEach(() => {
     mockPage = new EventEmitter();
     mockPage.url = () => 'https://example.com';
+    mockPage.isClosed = vi.fn().mockReturnValue(false);
     mockPage.waitForLoadState = vi.fn().mockResolvedValue(undefined);
     mockPage.evaluate = vi.fn().mockResolvedValue(undefined);
     mockPage._wrapApiCall = vi.fn().mockImplementation(cb => cb());
@@ -140,15 +141,32 @@ describe('Tool Utils', () => {
       expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
     });
 
-    it('should skip the settle delay when the action started nothing', async () => {
-      // No request and no navigation means nothing is in flight to settle, and
-      // the fixed wait would be pure latency on every click and keypress.
+    it('should preserve the settle delay for delayed DOM-only work', async () => {
+      // A timer can update the DOM without a request or navigation signal.
       mockTab.context.config.timeouts.settle = 5;
       const callback = vi.fn().mockResolvedValue('result');
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).not.toHaveBeenCalled();
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(5);
+    });
+
+    it('should not fail when the action closes its page before settling', async () => {
+      mockTab.waitForTimeout = vi.fn().mockImplementation(async () => {
+        mockPage.isClosed.mockReturnValue(true);
+        throw new Error('page._wrapApiCall: Target page, context or browser has been closed');
+      });
+
+      await expect(waitForCompletion(mockTab, vi.fn().mockResolvedValue('result'))).resolves.toBe('result');
+    });
+
+    it('should not hide an unrelated settle error when the page also closes', async () => {
+      mockTab.waitForTimeout = vi.fn().mockImplementation(async () => {
+        mockPage.isClosed.mockReturnValue(true);
+        throw new Error('Protocol failure');
+      });
+
+      await expect(waitForCompletion(mockTab, vi.fn().mockResolvedValue('result'))).rejects.toThrow('Protocol failure');
     });
 
     it('should settle for work the action scheduled rather than started', async () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -180,6 +180,24 @@ describe('Tool Utils', () => {
 
       expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
     });
+
+    it('should settle after a sub-frame navigation that issued no request', async () => {
+      // Swapping an iframe's srcdoc or pointing it at a data: URL replaces a
+      // document without touching the network, so nothing else here marks it as
+      // page work. Skipping the settle would capture the old frame while the
+      // replacement is still initializing.
+      mockTab.context.config.timeouts.settle = 25;
+      const callback = vi.fn().mockImplementation(() => {
+        mockPage.emit('framenavigated', { parentFrame: () => ({}) });
+        return Promise.resolve('result');
+      });
+
+      await waitForCompletion(mockTab, callback);
+
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+      // Still no top-level load state: a sub-frame navigation never produces one.
+      expect(mockTab.waitForLoadState).not.toHaveBeenCalled();
+    });
   });
 
   describe('generateLocator', () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -101,8 +101,8 @@ describe('Tool Utils', () => {
 
       await waitForCompletion(mockTab, callback);
 
-      // Should not wait for load state for sub-frames
-      expect(mockTab.waitForTimeout).toHaveBeenCalled();
+      // Should not wait for the load state of a sub-frame navigation.
+      expect(mockTab.waitForLoadState).not.toHaveBeenCalled();
     });
 
     it('should timeout after 10 seconds', async () => {
@@ -126,9 +126,36 @@ describe('Tool Utils', () => {
       vi.useRealTimers();
     });
 
-    it('should use the configured settle delay after completion', async () => {
-      const callback = vi.fn().mockResolvedValue('result');
+    it('should use the configured settle delay after a request', async () => {
       mockTab.context.config.timeouts.settle = 25;
+      const callback = vi.fn().mockImplementation(() => {
+        const request = { url: 'https://api.example.com' };
+        mockPage.emit('request', request);
+        mockPage.emit('requestfinished', request);
+        return Promise.resolve('result');
+      });
+
+      await waitForCompletion(mockTab, callback);
+
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+    });
+
+    it('should skip the settle delay when the action started nothing', async () => {
+      // No request and no navigation means nothing is in flight to settle, and
+      // the fixed wait would be pure latency on every click and keypress.
+      const callback = vi.fn().mockResolvedValue('result');
+
+      await waitForCompletion(mockTab, callback);
+
+      expect(mockTab.waitForTimeout).not.toHaveBeenCalled();
+    });
+
+    it('should settle after a main-frame navigation', async () => {
+      mockTab.context.config.timeouts.settle = 25;
+      const callback = vi.fn().mockImplementation(() => {
+        mockPage.emit('framenavigated', { parentFrame: () => null });
+        return Promise.resolve('result');
+      });
 
       await waitForCompletion(mockTab, callback);
 

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -143,11 +143,30 @@ describe('Tool Utils', () => {
     it('should skip the settle delay when the action started nothing', async () => {
       // No request and no navigation means nothing is in flight to settle, and
       // the fixed wait would be pure latency on every click and keypress.
+      mockTab.context.config.timeouts.settle = 5;
       const callback = vi.fn().mockResolvedValue('result');
 
       await waitForCompletion(mockTab, callback);
 
       expect(mockTab.waitForTimeout).not.toHaveBeenCalled();
+    });
+
+    it('should settle for work the action scheduled rather than started', async () => {
+      // A click handler whose fetch fires from a timer has issued no request by
+      // the time its own promise resolves; the quiet window still catches it.
+      mockTab.context.config.timeouts.settle = 25;
+      const request = { url: 'https://api.example.com' };
+      const callback = vi.fn().mockImplementation(() => {
+        setTimeout(() => {
+          mockPage.emit('request', request);
+          mockPage.emit('requestfinished', request);
+        }, 5);
+        return Promise.resolve('result');
+      });
+
+      await waitForCompletion(mockTab, callback);
+
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
     });
 
     it('should settle after a main-frame navigation', async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -125,6 +125,17 @@ describe('Utils', () => {
       expect(result).not.toContain('<text>');
     });
 
+    it('should truncate data URLs whatever the case of the scheme', () => {
+      expect(truncateDataUrls('- /url: DATA:TEXT/HTML;BASE64,PHAgLz4=')).toBe('- /url: DATA:TEXT/HTML;BASE64,...');
+      expect(truncateDataUrls('?src=Data%3Atext/html;base64%2CPHAgLz4=')).toBe('?src=Data%3Atext/html;base64%2C...');
+    });
+
+    it('should keep offsets correct when text before the URL lower-cases to a different length', () => {
+      // "İ".toLowerCase() is two code units, so matching against a lower-cased
+      // copy of the text would shift every later offset by one.
+      expect(truncateDataUrls('İ data:text/html;base64,PHAgLz4=')).toBe('İ data:text/html;base64,...');
+    });
+
     it('should truncate data URLs embedded in query strings', () => {
       const payload = Buffer.from('<p>hello</p>').toString('base64');
       const text = `https://api.example/upload?src=data:text/html;base64,${payload}&id=123`;


### PR DESCRIPTION
## Summary

Cuts end-to-end MCP tool latency by **66%** (31.1s → 10.5s across the benchmark suite) and adds the benchmark that measures it. Every optimization removes work that was never needed, so the tool surface and its output are unchanged — except where this PR now reports coverage, or applies state, that it previously left implicit or got wrong.

## Measured result

`npm run bench`, median of 5 iterations after 1 warmup, headless Chromium, against `main`:

| Scenario | before | after | Speedup |
|---|---|---|---|
| tools/list | 3.6 ms | 2.1 ms | 1.75x |
| browser_click (ref + snapshot) | 644.9 ms | 223.2 ms | 2.89x |
| browser_type (ref, fill only) | 618.2 ms | 176.7 ms | 3.50x |
| browser_hover (ref + snapshot) | 664.0 ms | 251.3 ms | 2.64x |
| browser_press_key | 554.6 ms | 159.2 ms | 3.48x |
| scan_page (axe) | 4728.3 ms | 1615.1 ms | 2.93x |
| audit_keyboard (12 tabs) | 6218.8 ms | 1362.2 ms | 4.57x |
| scan_page_matrix (3 variants) | 14066.9 ms | 4402.7 ms | 3.20x |
| audit_site (6 pages) | 3391.6 ms | 2020.9 ms | 1.68x |
| **TOTAL** | **31144.1 ms** | **10472.8 ms** | **2.97x (-66.4%)** |

**Read the total, not the rows.** This runner drifts: the *baseline* measured 4125, 4412 and 4728 ms for `scan_page` across three separate runs of unmodified `main` — a 15% spread on identical code. Treat individual rows as ±15%.

`browser_navigate` and `browser_snapshot` show single-digit percentage moves in both directions across runs — neither touches a changed code path; that is run-to-run variance on 40-130 ms scenarios.

The figure started at -73% and settled at -66.4%. Eight rounds of review fixes cost those points, and each one bought back a way for a result to be wrong or a coverage gap to go unreported. That is the right trade in an accessibility tool: the settle observation window, per-scan Axe injection, the ref resolve check and strict sequential emulation are all latency given back deliberately.

## Scan path — `scan_page`, `scan_page_matrix`, `audit_site`

- **Run axe-core directly instead of through `@axe-core/playwright`.** Its default path opens a blank helper page per scan, injects axe into it, and ships the whole partial-result set through it for `axe.finishRun`. Injecting into the frames that already exist and running `axe.run` in the main one produces identical results, cross-origin iframes included — verified against the wrapper on a page with same- and cross-origin frames before switching.
- **Reduce the result inside the page.** Only violations, incomplete and the rule counts of passes/inapplicable are ever reported; a content-heavy page was serializing ~1.9 MB per scan to throw ~85% of it away.
- Validate `includeSelectors` and `excludeSelectors` in one round trip instead of two.
- Drops the `@axe-core/playwright` dependency, and with it the blank helper page that made `scan_page` fail on Electron CDP targets (`Target.createTarget: Not supported`).

Axe is injected fresh for every scan rather than reused when `window.axe` already looks right: that global belongs to the page, which may have installed its own axe or reconfigured ours.

## Interaction path — click, type, hover, press_key, fill_form, audit_keyboard

- **Skip the fixed settle delay when the action issued no request and navigated nowhere** — nothing was started, so there is nothing to settle. An action that finishes quietly is still watched for up to 100 ms (or the settle delay, whichever is shorter) in case it scheduled work on a timer rather than starting it; if something appears, the full settle applies. A request that *fails* releases the barrier the same way one that finishes does, so a doomed fetch cannot stall a click for ten seconds.
- **Resolve element refs against the snapshot already returned to the caller** — which is where those refs came from — instead of capturing a fresh one per call. A cache hit is confirmed with a `count()` resolve check (~1.5 ms against the ~37 ms snapshot it avoids, and bounded by the same page-state timeout as every other read in `Tab`) so a ref whose element has gone still fails fast with &#34;capture a new snapshot&#34; rather than as an action timeout. The cache is invalidated on any main-frame navigation, which covers `goBack()`, `page.reload()`, meta refresh and page-driven `location` changes alike.

## Coverage reporting (new behaviour)

A child frame Axe cannot be installed into contributes no violations, and previously said nothing about it — so a partly-scanned page read as clean. `runAxeScan` now returns an identifier for every such frame (URL plus frame name, since a `srcdoc` frame reports `about:blank`; both truncated, as either can carry a data URL), and all three scan tools surface them: a `WARNING` block, plus `unscannedFrames` per page and per variant in the JSON reports and in `structuredContent`. Reporting rather than failing, so one flaky third-party embed cannot break an entire audit.

Coverage is judged by probing each frame for this server's own configured injection after injection completes — not by what injection returned — so a frame that navigated mid-scan, or appeared late, or carries only the page's own axe, is counted as unscanned. Frames the caller scoped out with `includeSelectors`/`excludeSelectors` are not reported, since their contents were never going to be. Scope is resolved through the whole ancestor frame chain, so an include naming an ancestor still covers frames nested below it. Anything the check cannot resolve is reported rather than hidden.

## Correctness fixes in `scan_page_matrix`

Both found in review, both changing what a report claims:

- **The page's own media emulation is preserved.** Unset variant properties fell back to `null`, which resets a feature to the browser default rather than to the session's configured state — so a context created `colorScheme: 'dark'` was scanned light, including the baseline every other variant is diffed against, and was left light afterwards. The effective state is now measured from the page and used as both the per-variant fallback and the restore. `applied.media` consequently reports the effective value rather than `null`.
- **Zoom is applied after a reload, not before.** Viewport and media emulation survive a reload; zoom is an inline style on `documentElement` and does not, so `reloadBetweenVariants` scanned unzoomed while `applied.zoomPercent` claimed otherwise.

## Elsewhere

- Snapshot the current tab and refresh the other tabs&#39; titles concurrently.
- Cache the tool list&#39;s JSON-schema conversion; look tools up by name instead of scanning.
- `truncateDataUrls`: scan case-insensitively instead of lower-casing a copy of the whole text, and return the input untouched when it holds no data URL. This also fixes offsets after characters whose lower-case form is longer (e.g. `İ`).
- `audit_site` reads each page&#39;s title and links in one evaluate.

## Benchmark

`bench/mcp-bench.mjs` serves a fixed synthetic site, speaks MCP to the built server over stdio, and times real `tools/call` round trips. `--server`/`--lib` point it at another build so two revisions can be compared, and `npm run bench:compare` prints the table above. Documented in the README.

## Verification

`npm run lint` and `npm run typecheck` clean; **707 tests pass**. All 30 tools pass the direct MCP harness (`npm run test:mcp`) against a real browser.

23 failures in `tests/tools-auditScreenReader.test.ts` are container-only — they need a `chromium.launch()` this environment cannot provide — and reproduce unchanged on the base commit.

Note: the repo&#39;s CI workflow only triggers on PRs targeting `feat/` branches, so no check runs appear on this PR.

https://claude.ai/code/session_0169kf5JnRWzLgwDDcBSmsnn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accessibility scans now report unscanned frames and warn when results may be incomplete.
  * Page-matrix scans preserve and restore media preferences and zoom settings.
  * Added benchmark commands for measuring and comparing tool-call latency.

* **Bug Fixes**
  * Improved settling for delayed network activity and navigation.
  * Enhanced accessibility scan coverage, nested-frame handling, selector scoping, snapshot reuse, and partial-scan comparisons.
  * Improved responsiveness through cached tool schemas, snapshots, and optimized data URL handling.

* **Documentation**
  * Clarified timeout behavior, frame-scan warnings, scanning workflows, and benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->