### PR TITLE
perf: adaptive DOM-quiet settle and parallel audit_site crawl

### DIFF
--- a/.claude/run-mcp-direct-harness.mjs
+++ b/.claude/run-mcp-direct-harness.mjs
@@ -444,6 +444,11 @@ const tests = [
       violationsTag: ['wcag2a', 'wcag2aa'],
       maxNodesPerViolation: 5,
       waitAfterNavigationMs: 50,
+      // The session-loss scenarios below assert *which* URL dropped the cookie.
+      // Exact attribution is only guaranteed on a sequential crawl - with the
+      // default worker pool the loss lands on whichever in-flight page's check
+      // first observes it (see the audit_site concurrency docs).
+      concurrency: 1,
     };
     const result = await callTool('audit_site', {
       ...auditSiteDefaults,

--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Create a `config.json` file with the following options:
 - `browser.contextOptions.storageState`: Start each session from a recorded Playwright storage state; applied in every mode except `--extension` (fresh contexts receive it at creation, reused contexts via `setStorageState()`). Sessions that share one reused context (non-isolated CDP modes) get the state applied once per context — a session joining a live context inherits its current state, not a fresh copy of the file; see [Auditing pages behind a login](#auditing-pages-behind-a-login)
 - `timeouts.navigationTimeout`: Maximum time for page navigation in milliseconds (default: `60000`)
 - `timeouts.defaultTimeout`: Default timeout for Playwright operations in milliseconds (default: `5000`)
-- `timeouts.settle`: How long to wait after every action before responding (default: `500`). An action that finishes quietly is first watched for up to 100ms (or the settle delay, whichever is shorter) so scheduled network work can still be awaited before the settle delay.
+- `timeouts.settle`: Maximum time to wait after every action before responding (default: `500`). The wait ends early once the DOM has been mutation-free for 100ms, so quiet pages respond in a fraction of the budget while a page that keeps mutating still gets the full delay. An action that finishes quietly is first watched for up to 100ms (or the settle delay, whichever is shorter) so scheduled network work can still be awaited before the settle delay.
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after every action so delayed DOM-only updates are included in the response; a short observation window also catches scheduled requests and waits for them before that delay.
+Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle budget. It applies after every action so delayed DOM-only updates are included in the response, but it is a ceiling rather than a fixed sleep: the response returns as soon as the DOM stays quiet for 100ms. A short observation window also catches scheduled requests and waits for them before that delay.
 
 #### HTTP Heartbeat
 
@@ -239,7 +239,7 @@ Most real audits target pages that only exist for a signed-in user. There are tw
 
 ### Interactive route (no setup)
 
-Every tool shares one browser context, and `audit_site` crawls in a temporary tab of that same context, so cookies and local storage created while you drive the browser are already available to the crawl:
+Every tool shares one browser context, and `audit_site` crawls in temporary tabs of that same context, so cookies and local storage created while you drive the browser are already available to the crawl:
 
 ```text
 1. browser_navigate to the login page
@@ -301,6 +301,8 @@ PLAYWRIGHT_MCP_ISOLATED=true PLAYWRIGHT_MCP_STORAGE_STATE=./auth.json npx mcp-ac
 Note that `excludePathPatterns` replaces the default rather than extending it, so repeat `logout|signout` in your list.
 
 If a session cookie disappears anyway, `audit_site` says so instead of reporting a confident, wrong audit: the result starts with a `WARNING: cookie(s) … disappeared while loading <url>` line, and both the JSON report and the structured content carry a `sessionLosses` list naming, for each lost cookie, the page that dropped it — the page reached after any redirect, and reported even when that page failed to finish loading. If one of the lost cookies was the session, every page scanned after that point was audited as a signed-out user — exclude the offending URL, sign in again, and re-run.
+
+With the default `concurrency` of 4 several pages load at once and share the cookie jar, so a loss is attributed to the page whose check first observed it — close, but not guaranteed exact. Re-run with `concurrency: 1` when you need the offending URL pinned down precisely.
 
 The check compares which cookies the crawled URLs carry, not their values, so a rotating CSRF token never reads as a lost session. A cookie the browser deleted at its own stated expiry is ignored for the same reason — Cloudflare's `__cf_bm` lives 30 minutes and would otherwise warn on any longer crawl. Beyond that no attempt is made to tell an authentication cookie from any other: nothing in a cookie marks it as one, so any cookie the crawl started with and later lost is reported. Monitoring does not stop at the first loss — each cookie is reported once, at the URL where it vanished, so an analytics cookie expiring early cannot mask the session cookie being dropped later. URLs discovered mid-crawl join the cookie tracking before they are visited, so a session cookie scoped to a path below the start URL (say `/app`) is watched too.
 
@@ -373,6 +375,7 @@ A frame you scoped out yourself is not reported: with `excludeSelectors: ["ifram
 Crawls and scans multiple internal pages, then aggregates violations across the site.
 - Default strategy: link-based BFS from the current URL
 - Supports `links`, `nav`, `sitemap`, and `provided` URL strategies
+- Crawls up to `concurrency` pages in parallel (default `4`), each in its own tab of the shared context; set `concurrency: 1` for strictly sequential crawling — when exact session-loss attribution matters, or when the target server should not receive concurrent page loads
 - Always writes a JSON report (default filename: `audit-site-{timestamp}.json`)
 - Warns and records `sessionLosses` if the crawl loses cookies it started with — see [Auditing pages behind a login](#auditing-pages-behind-a-login)
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -120,7 +120,7 @@ function configureBaseProgram() {
       .option('--viewport-size <size>', 'specify browser viewport size in pixels, for example "1280, 720"')
       .option('--navigation-timeout <ms>', 'maximum time in milliseconds for page navigation. Defaults to 60000ms (60 seconds).', parseInt)
       .option('--default-timeout <ms>', 'default timeout for all Playwright operations (clicks, fills, etc). Defaults to 5000ms (5 seconds).', parseInt)
-      .option('--timeout-settle <ms>', 'how long to wait after each action for triggered work to settle, in milliseconds. Defaults to 500ms.', parseInt)
+      .option('--timeout-settle <ms>', 'maximum wait after each action for triggered work to settle, in milliseconds; ends early once the DOM goes quiet. Defaults to 500ms.', parseInt)
       .addOption(new Option('--connect-tool', 'Allow to switch between different browser connection methods.').hideHelp())
       .addOption(new Option('--vscode', 'VS Code tools.').hideHelp());
 

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -125,6 +125,7 @@ const auditSiteSchema = z.object({
   includeIncomplete: z.boolean().default(true).describe('Also collect Axe "incomplete" results — checks Axe could not decide automatically. They are reported separately from violations.'),
   maxNodesPerViolation: z.number().int().min(1).max(50).default(10).describe('Maximum nodes kept per violation in the report.'),
   waitAfterNavigationMs: z.number().int().min(0).max(5000).default(250).describe('Extra wait after navigation before scanning.'),
+  concurrency: z.number().int().min(1).max(8).default(4).describe('Pages crawled in parallel, each in its own tab. The default of 4 makes large crawls several times faster. Set 1 for strictly sequential crawling: when exact session-cookie loss attribution matters (parallel workers attribute a loss to the page whose check first observed it), or when the target server should not receive concurrent page loads.'),
   reportFile: z.string().optional().describe('Output JSON report file name.'),
   ...axeScopeSchemaShape,
   ...axeRuleSchemaShape,
@@ -446,6 +447,14 @@ const auditSite = defineTabTool({
     const summaryByViolation = new Map<string, ViolationSummaryAggregate>();
     const summaryByIncomplete = new Map<string, ViolationSummaryAggregate>();
 
+    // Workers idle when the queue is empty but pages still in flight may
+    // discover more links; every enqueue and every finished page wakes them.
+    const idleWaiters: (() => void)[] = [];
+    const wakeIdleWorkers = () => {
+      while (idleWaiters.length)
+        idleWaiters.pop()!();
+    };
+
     const enqueueUrl = (rawUrl: string, depth: number, discoveredFrom: string | null) => {
       const normalizedUrl = normalizeUrl(rawUrl, startUrl, ignoredParams);
       if (!normalizedUrl) {
@@ -483,6 +492,7 @@ const auditSite = defineTabTool({
         discoveredFrom,
       });
       queued.add(normalizedUrlString);
+      wakeIdleWorkers();
     };
 
     if (params.strategy === 'provided') {
@@ -510,32 +520,37 @@ const auditSite = defineTabTool({
       message: `Initialized site audit with ${queue.length} queued URL(s).`,
     });
 
-    const crawlTab = await context.newTab();
+    // One worker tab per unit of concurrency. Pages load, wait and scan
+    // independently of one another, so a pool of tabs overlaps the navigation,
+    // settle and scan time that a sequential crawl serializes.
+    const concurrency = Math.max(1, Math.min(params.concurrency ?? 1, 8));
+    const crawlTabs: (typeof tab)[] = [];
     // Cookies the crawl URLs carry before the crawl are the session the caller
     // signed in with. If one disappears mid-crawl every later page is audited as a
     // signed-out user, which still looks like a clean run, so record where it happened.
     const cookieScopeUrls = queue.map(item => item.cookieUrl);
     const cookieScope = new Set(cookieScopeUrls);
-    // The whole jar is snapshotted once, so a URL discovered mid-crawl can only
-    // add identities that existed when the crawl started. Without this, a cookie
-    // minted by an earlier crawled page would enter the baseline at discovery
-    // and its later removal would be misreported as losing a crawl-start cookie.
-    const initialCookieIdentities = new Set(
-        (await crawlTab.page.context().cookies().catch(() => []))
-            .map(cookie => `${cookie.name}\n${cookie.domain}\n${cookie.path}`));
-    const baselineCookies = await readCrawlCookies(crawlTab.page, cookieScopeUrls);
+    // Assigned once the first worker tab exists, before any worker runs; the
+    // workers below read and mutate these through the shared bindings.
+    let initialCookieIdentities = new Set<string>();
+    let baselineCookies = new Map<string, { name: string, expires: number }>();
     const sessionLosses: { url: string, cookies: string[] }[] = [];
     let processedPages = 0;
-    try {
-      while (queue.length && pages.length < params.maxPages) {
-        const item = queue.shift()!;
-        queued.delete(item.url);
-        if (visited.has(item.url)) {
-          skippedUrls++;
-          continue;
-        }
-        visited.add(item.url);
 
+    // The cookie jar is context-global, so the read-compare-delete sequences
+    // below must not interleave across workers: each runs to completion before
+    // the next starts. Under concurrency > 1 the exact navigation that dropped
+    // a cookie is not observable from outside - overlapping loads share the
+    // jar - so a loss is attributed to the page whose serialized check first
+    // observed it. concurrency: 1 restores exact attribution.
+    let cookieChain: Promise<unknown> = Promise.resolve();
+    const withCookieLock = <T,>(work: () => Promise<T>): Promise<T> => {
+      const result = cookieChain.then(work);
+      cookieChain = result.catch(() => undefined);
+      return result;
+    };
+
+    const processQueueItem = async (workerTab: typeof tab, item: CrawlItem) => {
         const pageReport: PageReport = {
           url: item.url,
           title: '',
@@ -564,17 +579,19 @@ const auditSite = defineTabTool({
         if (!cookieScope.has(item.cookieUrl)) {
           cookieScope.add(item.cookieUrl);
           cookieScopeUrls.push(item.cookieUrl);
-          const discovered = await readCrawlCookies(crawlTab.page, [item.cookieUrl]).catch(() => null);
-          for (const [identity, cookie] of discovered ?? []) {
-            if (initialCookieIdentities.has(identity) && !baselineCookies.has(identity))
-              baselineCookies.set(identity, cookie);
-          }
+          await withCookieLock(async () => {
+            const discovered = await readCrawlCookies(workerTab.page, [item.cookieUrl]).catch(() => null);
+            for (const [identity, cookie] of discovered ?? []) {
+              if (initialCookieIdentities.has(identity) && !baselineCookies.has(identity))
+                baselineCookies.set(identity, cookie);
+            }
+          });
         }
 
-        const urlBeforeNavigation = crawlTab.page.url();
+        const urlBeforeNavigation = workerTab.page.url();
         try {
-          await crawlTab.navigate(item.url);
-          await crawlTab.waitForTimeout(params.waitAfterNavigationMs);
+          await workerTab.navigate(item.url);
+          await workerTab.waitForTimeout(params.waitAfterNavigationMs);
 
           // Discover before scanning. A scoped scan throws when an
           // includeSelectors entry is absent from this page, and that must not
@@ -585,12 +602,12 @@ const auditSite = defineTabTool({
           else if (params.strategy === 'nav' && item.depth === 0)
             linkSelector = navLinksSelector;
 
-          const { title, links } = await readPage(crawlTab.page, linkSelector);
+          const { title, links } = await readPage(workerTab.page, linkSelector);
           pageReport.title = title;
           for (const link of links)
             enqueueUrl(link, item.depth + 1, item.url);
 
-          const axeResult = await runAxeScan(crawlTab.page, {
+          const axeResult = await runAxeScan(workerTab.page, {
             tags: params.violationsTag as AxeTag[],
             rules: params.withRules,
             disableRules: params.disableRules,
@@ -622,17 +639,21 @@ const auditSite = defineTabTool({
           // baseline, so each later disappearance is still caught and attributed
           // to its own URL instead of being masked by an earlier, unrelated one.
           if (baselineCookies.size) {
-            const loss = await findCookieLoss(crawlTab.page, cookieScopeUrls, baselineCookies, item.url, urlBeforeNavigation);
-            if (loss) {
-              sessionLosses.push({ url: loss.url, cookies: loss.cookies });
-              // Removed from the jar snapshot too, or a later-discovered URL
-              // could re-admit an already-reported cookie to the baseline and
-              // report the same loss twice.
-              for (const identity of loss.identities) {
-                baselineCookies.delete(identity);
-                initialCookieIdentities.delete(identity);
+            await withCookieLock(async () => {
+              if (!baselineCookies.size)
+                return;
+              const loss = await findCookieLoss(workerTab.page, cookieScopeUrls, baselineCookies, item.url, urlBeforeNavigation);
+              if (loss) {
+                sessionLosses.push({ url: loss.url, cookies: loss.cookies });
+                // Removed from the jar snapshot too, or a later-discovered URL
+                // could re-admit an already-reported cookie to the baseline and
+                // report the same loss twice.
+                for (const identity of loss.identities) {
+                  baselineCookies.delete(identity);
+                  initialCookieIdentities.delete(identity);
+                }
               }
-            }
+            });
           }
           processedPages++;
           const message = pageReport.status === 'scanned'
@@ -644,11 +665,62 @@ const auditSite = defineTabTool({
             message,
           });
         }
+    };
+
+    // Dequeue-and-mark-visited is synchronous, so two workers can never claim
+    // the same URL; the maxPages ceiling holds because enqueueUrl already
+    // bounds queued + visited, whatever the worker count.
+    let inFlight = 0;
+    const crawlWorker = async (workerTab: typeof tab) => {
+      while (pages.length < params.maxPages) {
+        const item = queue.shift();
+        if (!item) {
+          // Pages still in flight may discover more links; when nothing is in
+          // flight, nothing can be discovered and the crawl is done.
+          if (!inFlight)
+            return;
+          await new Promise<void>(resolve => idleWaiters.push(resolve));
+          continue;
+        }
+        queued.delete(item.url);
+        if (visited.has(item.url)) {
+          skippedUrls++;
+          continue;
+        }
+        visited.add(item.url);
+        inFlight++;
+        try {
+          await processQueueItem(workerTab, item);
+        } finally {
+          inFlight--;
+          wakeIdleWorkers();
+        }
       }
+    };
+
+    try {
+      // Tab creation and the baseline reads live inside the try so a failure
+      // mid-pool still closes the tabs already opened.
+      for (let index = 0; index < Math.min(concurrency, params.maxPages); index++)
+        crawlTabs.push(await context.newTab());
+      // The whole jar is snapshotted once, so a URL discovered mid-crawl can only
+      // add identities that existed when the crawl started. Without this, a cookie
+      // minted by an earlier crawled page would enter the baseline at discovery
+      // and its later removal would be misreported as losing a crawl-start cookie.
+      initialCookieIdentities = new Set(
+          (await crawlTabs[0].page.context().cookies().catch(() => []))
+              .map(cookie => `${cookie.name}\n${cookie.domain}\n${cookie.path}`));
+      baselineCookies = await readCrawlCookies(crawlTabs[0].page, cookieScopeUrls);
+      await Promise.all(crawlTabs.map(workerTab => crawlWorker(workerTab)));
     } finally {
-      const crawlTabIndex = context.tabs().indexOf(crawlTab);
-      if (crawlTabIndex !== -1)
-        await context.closeTab(crawlTabIndex);
+      // A worker failing must still release every idle sibling, or the crawl
+      // would hang on waiters nobody wakes again.
+      wakeIdleWorkers();
+      for (const workerTab of crawlTabs) {
+        const workerTabIndex = context.tabs().indexOf(workerTab);
+        if (workerTabIndex !== -1)
+          await context.closeTab(workerTabIndex);
+      }
       const originalTabIndex = context.tabs().indexOf(originalTab);
       if (originalTabIndex !== -1)
         await context.selectTab(originalTabIndex);
@@ -694,6 +766,7 @@ const auditSite = defineTabTool({
           disableRules: params.disableRules ?? null,
           maxNodesPerViolation: params.maxNodesPerViolation,
           waitAfterNavigationMs: params.waitAfterNavigationMs,
+          concurrency,
         },
         startedAt: startedAtIso,
         finishedAt: new Date().toISOString(),

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -21,27 +21,93 @@ const { asLocator } = coreBundle.iso;
 import type * as playwright from 'playwright';
 import type { Tab } from '../tab.js';
 
-// How long an action that finished quietly is watched for work it scheduled
-// rather than started - a click handler whose fetch fires from a timer has
-// issued nothing by the time its own promise resolves. Capped by the settle
-// delay it defers to, so lowering that lowers this with it.
-const quietWindowMs = 100;
+// How long the DOM must stay mutation-free before the settle ends early. The
+// configured settle delay remains the ceiling: a page that keeps mutating (a
+// spinner toggling classes, a carousel) still gets the full budget, while the
+// common case - an action that changed nothing more after it ran - stops
+// paying a fixed half-second on every tool call. This is also the minimum
+// wall-clock length of the settle, which is what lets it double as the watch
+// for work an action scheduled rather than started (see waitForCompletion).
+//
+// Ceiling: the observer watches the top document only. Mutations confined to a
+// shadow root or a child frame's document do not reach it, so timer work that
+// lands there between the quiet threshold and the old fixed delay is no longer
+// waited for. Child-frame *navigations* still get a full settle window - the
+// framenavigated listener marks them as page work - and shadow-root updates
+// driven by requests or light-DOM changes are seen through those signals;
+// only DOM-only timer work entirely inside a shadow root is quicker now.
+const domQuietMs = 100;
+
+// Runs in the page: resolves once the DOM has been mutation-free for quietMs,
+// or after maxMs, whichever comes first. The deadline lives in-page too, so a
+// caller abandoning the evaluate never leaves an observer running forever.
+function inPageDomQuietWait({ quietMs, maxMs }: { quietMs: number, maxMs: number }) {
+  return new Promise<void>(resolve => {
+    let quietTimer: ReturnType<typeof setTimeout>;
+    const done = () => {
+      observer.disconnect();
+      clearTimeout(quietTimer);
+      clearTimeout(deadline);
+      resolve();
+    };
+    const observer = new MutationObserver(() => {
+      clearTimeout(quietTimer);
+      quietTimer = setTimeout(done, quietMs);
+    });
+    observer.observe(document, { subtree: true, childList: true, attributes: true, characterData: true });
+    quietTimer = setTimeout(done, quietMs);
+    const deadline = setTimeout(done, maxMs);
+  });
+}
+
+// The settle delay after an action, ended early once the DOM goes quiet. Timers
+// can schedule DOM-only work without producing any observable page signal, so
+// some delay must remain - but a fixed sleep charges every action for the page
+// that might mutate, and almost none do. Watching mutations keeps the returned
+// snapshot just as fresh at a fraction of the wall-clock cost.
+async function settleAfterAction(tab: Tab, settleMs: number): Promise<void> {
+  const startedAt = Date.now();
+  try {
+    // Raced against the full settle budget rather than awaited bare: a dialog
+    // blocking JavaScript would hold the evaluate open indefinitely, and the
+    // old fixed sleep never waited longer than settleMs either.
+    await raceTimeout(
+        callOnPageNoTrace(tab.page, page => page.evaluate(inPageDomQuietWait, {
+          quietMs: Math.min(domQuietMs, settleMs),
+          maxMs: settleMs,
+        })),
+        settleMs,
+    );
+    return;
+  } catch {
+    // The page could not host the observer - a navigation racing the settle,
+    // or the page closing. Fall back to the fixed delay for whatever remains
+    // of the budget, through the path that understands blocked JavaScript.
+  }
+  const remainingMs = settleMs - (Date.now() - startedAt);
+  if (remainingMs > 0 && !tab.page.isClosed()) {
+    try {
+      await tab.waitForTimeout(remainingMs);
+    } catch (error) {
+      const targetClosed = error instanceof Error && /Target (?:page, context or browser has been closed|page closed|closed)/i.test(error.message);
+      if (!tab.page.isClosed() || !targetClosed)
+        throw error;
+    }
+  }
+}
 
 export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>): Promise<R> {
   const settleMs = tab.context.config.timeouts.settle ?? 500;
   const requests = new Set<playwright.Request>();
   let requestSeen = false;
   let frameNavigated = false;
+  let childFrameNavigated = false;
   let waitCallback: () => void = () => {};
   const waitBarrier = new Promise<void>(f => { waitCallback = f; });
-  // Resolves on the first sign of page work, whenever it arrives.
-  let signalCallback: () => void = () => {};
-  const firstSignal = new Promise<void>(f => { signalCallback = f; });
 
   const requestListener = (request: playwright.Request) => {
     requestSeen = true;
     requests.add(request);
-    signalCallback();
   };
   // A request that fails - offline, blocked by CORS, aborted - emits
   // `requestfailed` and never `requestfinished`. Without the same removal path
@@ -54,11 +120,13 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   };
 
   const frameNavigateListener = (frame: playwright.Frame) => {
-    signalCallback();
     if (frame.parentFrame()) {
       // A child frame swapping documents is page work too, and it can issue no
       // request at all. It must not gate the barrier on a top-level load state
-      // that this navigation will never produce.
+      // that this navigation will never produce - but it must still earn the
+      // post-work settle below: the DOM-quiet observer watches the top
+      // document only and cannot see the new frame's contents initializing.
+      childFrameNavigated = true;
       return;
     }
     frameNavigated = true;
@@ -88,25 +156,22 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
 
   try {
     const result = await callback();
-    // Nothing has happened yet, which is not the same as nothing being about to:
-    // watch briefly for work the action scheduled instead of started.
-    if (!requestSeen && !frameNavigated)
-      await raceTimeout(firstSignal, Math.min(quietWindowMs, settleMs));
+    // An action that finished quietly may still be about to do work - a click
+    // handler whose fetch fires from a timer has issued nothing by the time its
+    // own promise resolves. The DOM-quiet settle doubles as that watch: it
+    // lasts at least the quiet threshold with the request listeners still
+    // armed, so work the action scheduled is seen either as a request (awaited
+    // through the barrier below) or as the DOM mutations it makes.
+    if (!requestSeen && !frameNavigated && !childFrameNavigated && !tab.page.isClosed())
+      await settleAfterAction(tab, settleMs);
     if (!requests.size && !frameNavigated)
       waitCallback();
     await waitBarrier;
-    // Timers can schedule DOM-only work without producing any observable page
-    // signal. Preserve the configured settle delay so the returned snapshot
-    // includes those updates too.
-    if (!tab.page.isClosed()) {
-      try {
-        await tab.waitForTimeout(settleMs);
-      } catch (error) {
-        const targetClosed = error instanceof Error && /Target (?:page, context or browser has been closed|page closed|closed)/i.test(error.message);
-        if (!tab.page.isClosed() || !targetClosed)
-          throw error;
-      }
-    }
+    // Requests and navigations usually finish in DOM updates. Settle again so
+    // the returned snapshot includes them - but end as soon as the DOM goes
+    // quiet rather than sleeping the full budget.
+    if ((requestSeen || frameNavigated || childFrameNavigated) && !tab.page.isClosed())
+      await settleAfterAction(tab, settleMs);
     return result;
   } finally {
     dispose();

--- a/tests/tools-auditSite.integration.test.ts
+++ b/tests/tools-auditSite.integration.test.ts
@@ -131,4 +131,92 @@ describe('audit_site integration', () => {
     expect(report.summary.violations[0].pagesAffected.length).toBe(2);
     expect(response.result()).toContain(reportPath);
   });
+
+  it('crawls pages in parallel worker tabs when concurrency > 1', async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'audit-site-it-'));
+    const reportPath = path.join(tempDir, 'audit-site-report.json');
+
+    const urls = Array.from({ length: 6 }, (_, index) => `https://example.com/page-${index}`);
+    let activeNavigations = 0;
+    let maxActiveNavigations = 0;
+
+    const makeCrawlTab = () => {
+      let currentUrl = 'about:blank';
+      const page = {
+        context: () => ({ cookies: async () => [] }),
+        url: () => currentUrl,
+        evaluate: async () => ({ title: `Title for ${currentUrl}`, links: [] }),
+      };
+      const crawlTab: any = {
+        page,
+        navigate: async (url: string) => {
+          activeNavigations++;
+          maxActiveNavigations = Math.max(maxActiveNavigations, activeNavigations);
+          await new Promise(resolve => setTimeout(resolve, 10));
+          currentUrl = url;
+          activeNavigations--;
+        },
+        waitForTimeout: async () => undefined,
+      };
+      return crawlTab;
+    };
+
+    const originalTab: any = {
+      page: { url: () => 'https://example.com/' },
+      modalStates: () => [],
+    };
+
+    const tabs: any[] = [originalTab];
+    const context = {
+      currentTabOrDie: () => originalTab,
+      tabs: () => tabs,
+      newTab: vi.fn(async () => {
+        const crawlTab = makeCrawlTab();
+        crawlTab.context = context;
+        tabs.push(crawlTab);
+        return crawlTab;
+      }),
+      closeTab: vi.fn(async (index: number) => {
+        tabs.splice(index, 1);
+        return '';
+      }),
+      selectTab: vi.fn(async () => undefined),
+      outputFile: vi.fn(async () => reportPath),
+      config: {},
+    };
+    originalTab.context = context;
+
+    const response = new Response(context as any, 'audit_site', {});
+    vi.spyOn(axe, 'runAxeScan').mockImplementation(async (page: any) =>
+      createAxeResult(page.url(), [createViolation('color-contrast', `<button>${page.url()}</button>`)]));
+
+    await tool.handle(context as any, {
+      strategy: 'provided',
+      urls,
+      maxPages: 10,
+      maxDepth: 2,
+      sameOriginOnly: true,
+      includeSubdomains: false,
+      excludePathPatterns: [],
+      ignoreQueryParams: [],
+      violationsTag: ['wcag2aa'],
+      maxNodesPerViolation: 10,
+      waitAfterNavigationMs: 0,
+      concurrency: 3,
+      reportFile: 'audit-site-report.json',
+    } as any, response);
+
+    const report = JSON.parse(await fs.promises.readFile(reportPath, 'utf-8'));
+    // Three worker tabs were opened, used concurrently, and all closed again.
+    expect(context.newTab).toHaveBeenCalledTimes(3);
+    expect(maxActiveNavigations).toBeGreaterThan(1);
+    expect(tabs).toEqual([originalTab]);
+    // Every page was scanned exactly once and attributed to its own URL.
+    expect(report.pages).toHaveLength(6);
+    expect(report.summary.totals.scannedPages).toBe(6);
+    expect(new Set(report.pages.map((page: any) => page.url)).size).toBe(6);
+    expect(report.metadata.options.concurrency).toBe(3);
+    for (const page of report.pages)
+      expect(page.violations[0].nodes[0].html).toBe(`<button>${page.url}</button>`);
+  });
 });

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -127,7 +127,7 @@ describe('Tool Utils', () => {
       vi.useRealTimers();
     });
 
-    it('should use the configured settle delay after a request', async () => {
+    it('should settle via the in-page DOM-quiet wait, capped at the configured delay', async () => {
       mockTab.context.config.timeouts.settle = 25;
       const callback = vi.fn().mockImplementation(() => {
         const request = { url: 'https://api.example.com' };
@@ -138,29 +138,44 @@ describe('Tool Utils', () => {
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+      // The quiet threshold never exceeds the settle budget itself.
+      expect(mockPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { quietMs: 25, maxMs: 25 });
+      expect(mockTab.waitForTimeout).not.toHaveBeenCalled();
     });
 
-    it('should preserve the settle delay for delayed DOM-only work', async () => {
-      // A timer can update the DOM without a request or navigation signal.
+    it('should keep a settle window for delayed DOM-only work', async () => {
+      // A timer can update the DOM without a request or navigation signal; the
+      // in-page observer wait is what gives that work time to land.
       mockTab.context.config.timeouts.settle = 5;
       const callback = vi.fn().mockResolvedValue('result');
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(5);
+      expect(mockPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { quietMs: 5, maxMs: 5 });
+    });
+
+    it('should fall back to the fixed delay when the page cannot host the observer', async () => {
+      mockTab.context.config.timeouts.settle = 25;
+      mockPage.evaluate = vi.fn().mockRejectedValue(new Error('Execution context was destroyed'));
+      const callback = vi.fn().mockResolvedValue('result');
+
+      await waitForCompletion(mockTab, callback);
+
+      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(expect.any(Number));
     });
 
     it('should not fail when the action closes its page before settling', async () => {
-      mockTab.waitForTimeout = vi.fn().mockImplementation(async () => {
+      mockPage.evaluate = vi.fn().mockImplementation(async () => {
         mockPage.isClosed.mockReturnValue(true);
         throw new Error('page._wrapApiCall: Target page, context or browser has been closed');
       });
 
       await expect(waitForCompletion(mockTab, vi.fn().mockResolvedValue('result'))).resolves.toBe('result');
+      expect(mockTab.waitForTimeout).not.toHaveBeenCalled();
     });
 
     it('should not hide an unrelated settle error when the page also closes', async () => {
+      mockPage.evaluate = vi.fn().mockRejectedValue(new Error('Execution context was destroyed'));
       mockTab.waitForTimeout = vi.fn().mockImplementation(async () => {
         mockPage.isClosed.mockReturnValue(true);
         throw new Error('Protocol failure');
@@ -171,8 +186,13 @@ describe('Tool Utils', () => {
 
     it('should settle for work the action scheduled rather than started', async () => {
       // A click handler whose fetch fires from a timer has issued no request by
-      // the time its own promise resolves; the quiet window still catches it.
+      // the time its own promise resolves; the DOM-quiet watch still catches it
+      // because it lasts at least the quiet threshold with listeners armed. The
+      // mock must take that long too, or the scheduled request would be missed
+      // only in the test.
       mockTab.context.config.timeouts.settle = 25;
+      mockPage.evaluate = vi.fn().mockImplementation((_fn: unknown, { quietMs }: { quietMs: number }) =>
+        new Promise(resolve => setTimeout(resolve, quietMs)));
       const request = { url: 'https://api.example.com' };
       const callback = vi.fn().mockImplementation(() => {
         setTimeout(() => {
@@ -184,7 +204,9 @@ describe('Tool Utils', () => {
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+      expect(mockPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { quietMs: 25, maxMs: 25 });
+      // Once as the scheduled-work watch, once to settle after the request.
+      expect(mockPage.evaluate).toHaveBeenCalledTimes(2);
     });
 
     it('should settle after a main-frame navigation', async () => {
@@ -196,7 +218,7 @@ describe('Tool Utils', () => {
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+      expect(mockPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { quietMs: 25, maxMs: 25 });
     });
 
     it('should settle after a sub-frame navigation that issued no request', async () => {
@@ -212,7 +234,7 @@ describe('Tool Utils', () => {
 
       await waitForCompletion(mockTab, callback);
 
-      expect(mockTab.waitForTimeout).toHaveBeenCalledWith(25);
+      expect(mockPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { quietMs: 25, maxMs: 25 });
       // Still no top-level load state: a sub-frame navigation never produces one.
       expect(mockTab.waitForLoadState).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Two changes that together roughly halve total tool latency on the MCP
benchmark and cut interactive-action latency by 3-4x:

1. Adaptive settle after actions. waitForCompletion slept a fixed 500ms
   (plus a 100ms quiet window) after every action, even on a page that
   did nothing. The settle is now an in-page MutationObserver wait that
   ends once the DOM has been mutation-free for 100ms, with the
   configured settle timeout as the unchanged ceiling; the quiet window
   is folded into it, since the settle lasts at least the quiet
   threshold with the request listeners still armed. Child-frame
   navigations are tracked explicitly so a srcdoc/data: frame swap
   still earns a post-work settle the top-document observer cannot see.
   Falls back to the fixed delay when the page cannot host the observer.

2. Parallel audit_site crawl. Pages are crawled by a pool of worker
   tabs (new `concurrency` parameter, default 4, max 8) instead of one
   tab in series, overlapping navigation, settle and scan time.
   maxPages accounting and per-page error handling are unchanged;
   cookie-loss monitoring is serialized under a lock, so under
   concurrency a loss is attributed to the page whose check first
   observed it, and `concurrency: 1` restores exact attribution (the
   MCP harness session-loss scenarios pin that).

bench/mcp-bench.mjs medians, before -> after (3 iterations, local
fixtures): browser_click 752 -> 210ms, browser_type 688 -> 167ms,
browser_press_key 677 -> 155ms, audit_keyboard (12 tabs) 7425 ->
1381ms, audit_site (6 pages) 2809 -> 1282ms; total end-to-end tool
latency 21540 -> 9934ms. audit_keyboard with its default of 50 tab
stops and audit_site on real (non-localhost) sites gain the most, since
the removed fixed sleeps and the overlapped navigations dominate there.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wqxm62TvhTxCndqSFLMdP1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit crawls now support configurable concurrency from 1–8, with parallel page scanning and recorded concurrency details.
  * Crawl results continue to enforce page limits and unique URL coverage.
  * Post-action waiting can finish early when the page’s DOM becomes quiet while still observing scheduled activity.

* **Bug Fixes**
  * Improved session-loss attribution in sequential crawl scenarios.
  * Added safer handling for navigation, closed pages, and settling failures.

* **Documentation**
  * Updated usage guidance for settling behavior, crawl concurrency, and attribution accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->