### PR TITLE
fix: harden extension relay connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ npx mcp-accessibility-scanner --extension
 ```
 
 Set `PLAYWRIGHT_MCP_EXTENSION_TOKEN` to the token shown by the extension to bypass the connection approval dialog.
+Set `PLAYWRIGHT_MCP_EXECUTABLE_PATH` or pass `--executable-path` when the browser is not installed at a standard location.
 When `--user-data-dir` contains multiple Chrome profiles, the profile with the extension installed is selected automatically, preferring Chrome's last-used profile.
 
 ### Discovering available tools (`list-tools` subcommand)

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -28,7 +28,7 @@ import http from 'node:http';
 import path from 'node:path';
 import debug from 'debug';
 import { WebSocket, WebSocketServer } from 'ws';
-import { httpAddressToString } from '../mcp/http.js';
+import { httpAddressToString, validateWebSocketUpgradeHeaders } from '../mcp/http.js';
 import { logUnhandledError } from '../utils/log.js';
 import { ManualPromise } from '../mcp/manualPromise.js';
 import { ExtensionProtocolV2 } from './cdpRelayV2.js';
@@ -82,7 +82,18 @@ export class CDPRelayServer {
     this._connectPagePrefix = connectPageUrl.toString();
 
     this._resetExtensionConnection();
-    this._wss = new WebSocketServer({ server });
+    this._wss = new WebSocketServer({
+      server,
+      verifyClient: ({ req }, callback) => {
+        const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+        if (pathname !== this._cdpPath && pathname !== this._extensionPath) {
+          callback(false, 400, 'Bad Request');
+          return;
+        }
+        const error = validateWebSocketUpgradeHeaders(server, req);
+        callback(!error, error?.statusCode, error?.message);
+      },
+    });
     this._wss.on('connection', this._onConnection.bind(this));
   }
 
@@ -140,7 +151,7 @@ export class CDPRelayServer {
         throw new Error(`Unsupported channel: "${this._browserChannel}"`);
       executablePath = executableInfo.executablePath();
       if (!executablePath)
-        throw new Error(`"${this._browserChannel}" executable not found. Make sure it is installed at a standard location.`);
+        throw new Error(`"${this._browserChannel}" executable not found. Make sure it is installed at a standard location, or set PLAYWRIGHT_MCP_EXECUTABLE_PATH to use a browser at a custom location.`);
     }
 
     const args: string[] = [];

--- a/src/extension/extensionContextFactory.ts
+++ b/src/extension/extensionContextFactory.ts
@@ -51,7 +51,7 @@ export class ExtensionContextFactory implements BrowserContextFactory {
   private async _obtainBrowser(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<playwright.Browser> {
     const relay = await this._startRelay(abortSignal);
     await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
-    return await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
+    return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { noDefaults: true });
   }
 
   private async _startRelay(abortSignal: AbortSignal) {

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -149,7 +149,11 @@ function decorateServer(server: net.Server) {
   };
 }
 
-function validateRequestHeaders(httpServer: http.Server, req: http.IncomingMessage): { statusCode: number, message: string } | undefined {
+export function validateWebSocketUpgradeHeaders(httpServer: http.Server, req: http.IncomingMessage): { statusCode: number, message: string } | undefined {
+  return validateRequestHeaders(httpServer, req, true);
+}
+
+function validateRequestHeaders(httpServer: http.Server, req: http.IncomingMessage, allowNonWebOrigin = false): { statusCode: number, message: string } | undefined {
   const allowedHosts = allowedHostnamesForServer(httpServer);
   const hostHeader = req.headers.host;
   const host = typeof hostHeader === 'string' ? parseAuthority(hostHeader) : undefined;
@@ -167,6 +171,15 @@ function validateRequestHeaders(httpServer: http.Server, req: http.IncomingMessa
     return;
 
   const origin = parseOriginAuthority(originHeader);
+  if (!origin && allowNonWebOrigin) {
+    try {
+      const protocol = new URL(originHeader).protocol;
+      if (protocol !== 'http:' && protocol !== 'https:')
+        return;
+    } catch {
+      // Report malformed origins below.
+    }
+  }
   if (!origin) {
     testDebug('reject request with invalid origin header: %o', originHeader);
     return { statusCode: 400, message: 'Invalid Origin header' };

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -229,6 +229,26 @@ describe('extension protocol v2', () => {
     }
   });
 
+  it('rejects relay WebSocket upgrades with forged host or origin', async () => {
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
+    try {
+      const invalidPath = new URL(relay.extensionEndpoint());
+      invalidPath.pathname = '/unexpected';
+      await expect(wsUpgradeResult(invalidPath.toString(), {})).resolves.toBe(400);
+      await expect(wsUpgradeResult(relay.extensionEndpoint(), { host: 'evil.example' })).resolves.toBe(403);
+      await expect(wsUpgradeResult(relay.extensionEndpoint(), { origin: 'https://evil.example' })).resolves.toBe(403);
+      await expect(wsUpgradeResult(relay.extensionEndpoint(), { origin: `chrome-extension://${EXTENSION_ID}` })).resolves.toBe('connected');
+    } finally {
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
   it('waits for extension approval and forwards the configured token', async () => {
     vi.mocked(spawn).mockClear();
     vi.stubEnv('PLAYWRIGHT_MCP_EXTENSION_TOKEN', 'test-token');
@@ -342,3 +362,18 @@ describe('extension protocol v2', () => {
     }
   });
 });
+
+function wsUpgradeResult(url: string, headers: Record<string, string>): Promise<number | 'connected'> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, { headers });
+    ws.on('open', () => {
+      ws.close();
+      resolve('connected');
+    });
+    ws.on('unexpected-response', (request, response) => {
+      request.destroy();
+      resolve(response.statusCode ?? 0);
+    });
+    ws.on('error', reject);
+  });
+}


### PR DESCRIPTION
## Upstream changes

- [Playwright #42103](https://github.com/microsoft/playwright/pull/42103) / [commit 40d39ac](https://github.com/microsoft/playwright/commit/40d39ac89ace291dc25572f2b14988e786323db5) rejects extension relay WebSocket upgrades with forged Host or web Origin headers and limits upgrades to relay paths.
- [Playwright #42119](https://github.com/microsoft/playwright/pull/42119) / [commit 539fd2c](https://github.com/microsoft/playwright/commit/539fd2c1047eeff2c7bffbf15acc736fd3b6a42a) connects extension-backed browsers with `noDefaults` so existing browser state is preserved.
- [Playwright #42122](https://github.com/microsoft/playwright/pull/42122) / [commit b637a5a](https://github.com/microsoft/playwright/commit/b637a5a4098789da917a4605d1966bd3f9528d63) points custom browser installations to `PLAYWRIGHT_MCP_EXECUTABLE_PATH`.

## Why it matters here

This package has the same extension relay paths. Before this change, its relay completed WebSocket upgrades before checking the route and accepted forged Host or web Origin headers. Extension CDP attachment also omitted `noDefaults`, and the custom-browser error did not identify the existing environment setting.

## Implemented

- Reuse the existing HTTP Host/Origin validation for relay WebSocket upgrades while allowing non-web extension origins.
- Reject unknown relay paths before the WebSocket connection is accepted.
- Preserve extension browser defaults during CDP attachment.
- Improve and document the custom executable hint.

## Validation

- `npm test -- tests/extension-protocol.test.ts tests/mcp-http.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (40 files, 798 tests)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser extension mode now supports custom browser executable locations through `PLAYWRIGHT_MCP_EXECUTABLE_PATH` or `--executable-path`.
* **Bug Fixes**
  * Improved WebSocket connection validation to reject invalid paths, forged hosts, unauthorized origins, and malformed upgrade requests.
  * Extension connections from approved origins continue to work as expected.
  * Browser launch errors now provide guidance for configuring a custom executable path.
* **Documentation**
  * Updated browser extension setup instructions with custom executable configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->