### PR TITLE
Tear down CDP relay on unexpected browser disconnect

### DIFF
--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -55,6 +55,7 @@ type CDPCommand = {
 type CDPResponse = CDPMessage;
 
 export class CDPRelayServer {
+  private _server: http.Server;
   private _wsHost: string;
   private _browserChannel: string;
   private _userDataDir?: string;
@@ -69,6 +70,7 @@ export class CDPRelayServer {
   private _extensionConnectionPromise!: ManualPromise<void>;
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
+    this._server = server;
     this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
     this._browserChannel = browserChannel;
     this._userDataDir = userDataDir;
@@ -164,6 +166,9 @@ export class CDPRelayServer {
   stop(): void {
     this.closeConnections('Server stopped');
     this._wss.close();
+    // ws only closes the HTTP server it created itself; ours is passed in,
+    // so close it explicitly or the relay port stays bound after stop().
+    this._server.close();
   }
 
   closeConnections(reason: string) {

--- a/src/extension/extensionContextFactory.ts
+++ b/src/extension/extensionContextFactory.ts
@@ -51,7 +51,10 @@ export class ExtensionContextFactory implements BrowserContextFactory {
   private async _obtainBrowser(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<playwright.Browser> {
     const relay = await this._startRelay(abortSignal);
     await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
-    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
+    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint()).catch((error: unknown) => {
+      relay.stop();
+      throw error;
+    });
     browser.on('disconnected', () => relay.stop());
     return browser;
   }

--- a/src/extension/extensionContextFactory.ts
+++ b/src/extension/extensionContextFactory.ts
@@ -52,10 +52,6 @@ export class ExtensionContextFactory implements BrowserContextFactory {
     const relay = await this._startRelay(abortSignal);
     await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
     const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
-    // Release the relay's HTTP/WebSocket server as soon as the browser goes
-    // away (e.g. the user closes the attached browser), rather than holding
-    // its port until the MCP context is disposed. stop() is idempotent, so
-    // the extra call on normal close/abort is harmless.
     browser.on('disconnected', () => relay.stop());
     return browser;
   }

--- a/src/extension/extensionContextFactory.ts
+++ b/src/extension/extensionContextFactory.ts
@@ -51,7 +51,13 @@ export class ExtensionContextFactory implements BrowserContextFactory {
   private async _obtainBrowser(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<playwright.Browser> {
     const relay = await this._startRelay(abortSignal);
     await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
-    return await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
+    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
+    // Release the relay's HTTP/WebSocket server as soon as the browser goes
+    // away (e.g. the user closes the attached browser), rather than holding
+    // its port until the MCP context is disposed. stop() is idempotent, so
+    // the extra call on normal close/abort is harmless.
+    browser.on('disconnected', () => relay.stop());
+    return browser;
   }
 
   private async _startRelay(abortSignal: AbortSignal) {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -21,8 +21,10 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { WebSocket } from 'ws';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
+import * as playwright from 'playwright';
 import { CDPRelayServer } from '../src/extension/cdpRelay.js';
+import { ExtensionContextFactory } from '../src/extension/extensionContextFactory.js';
 import { ExtensionProtocolV2 } from '../src/extension/cdpRelayV2.js';
 import { EXTENSION_ID, VERSION } from '../src/extension/protocol.js';
 
@@ -235,12 +237,26 @@ describe('extension protocol v2', () => {
       server.once('error', reject);
       server.listen(0, '127.0.0.1', resolve);
     });
+    onTestFinished(() => new Promise<void>(resolve => server.close(() => resolve())));
     const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
     expect(server.listening).toBe(true);
 
     relay.stop();
     expect(server.listening).toBe(false);
     expect(() => relay.stop()).not.toThrow();
+  });
+
+  it('stops the relay when CDP attachment fails', async () => {
+    onTestFinished(() => vi.restoreAllMocks());
+    const ensure = vi.spyOn(CDPRelayServer.prototype, 'ensureExtensionConnectionForMCPContext').mockResolvedValue(undefined);
+    const stop = vi.spyOn(CDPRelayServer.prototype, 'stop');
+    vi.spyOn(playwright.chromium, 'connectOverCDP').mockRejectedValue(new Error('attach failed'));
+    onTestFinished(() => (ensure.mock.instances[0] as CDPRelayServer | undefined)?.stop());
+
+    const factory = new ExtensionContextFactory('chrome', undefined, '/tmp/chrome');
+    await expect(factory.createContext(
+        { name: 'test-client', version: '1.0.0' }, new AbortController().signal, undefined)).rejects.toThrow('attach failed');
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   it('waits for extension approval and forwards the configured token', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -229,6 +229,20 @@ describe('extension protocol v2', () => {
     }
   });
 
+  it('releases the relay HTTP server port on stop, and stop is idempotent', async () => {
+    const server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
+    expect(server.listening).toBe(true);
+
+    relay.stop();
+    expect(server.listening).toBe(false);
+    expect(() => relay.stop()).not.toThrow();
+  });
+
   it('waits for extension approval and forwards the configured token', async () => {
     vi.mocked(spawn).mockClear();
     vi.stubEnv('PLAYWRIGHT_MCP_EXTENSION_TOKEN', 'test-token');


### PR DESCRIPTION
Mirror upstream playwright#41966: attach a 'disconnected' listener after
connectOverCDP in extension mode so the relay server is released as soon
as the attached browser closes or crashes, instead of lingering until the
MCP context is disposed.

Unlike upstream's premise, stop() alone did not actually free the relay
port: ws's WebSocketServer.close() only closes an HTTP server it created
itself, and ours is passed in. stop() now closes the HTTP server too, so
the port is released on both the disconnect and abort paths.

Closes #163

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JgJ634drvHpyvQCRPGe5PQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when the connected browser disconnects.
  * Ensured relay services shut down completely, including their HTTP server.
  * Made shutdown safe to call repeatedly without errors.

* **Tests**
  * Added coverage verifying reliable and repeatable relay server shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->