### PR TITLE
fix: keep POST-only HTTP sessions alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-a
 
 #### HTTP Heartbeat
 
-When the server runs with `--port`, it sends MCP heartbeat pings for Streamable HTTP sessions. Set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to override the default `5000` ms timeout. Set it to `0` or any negative value to disable heartbeat pings for clients or proxies that do not answer server-initiated pings.
+When the server runs with `--port`, it sends MCP heartbeat pings after a Streamable HTTP client opens the optional event stream. POST-only clients stay connected without heartbeat because server-initiated requests cannot reach them. Set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to override the default `5000` ms timeout, or to `0` or any negative value to disable heartbeat pings.
 
 ## Auditing pages behind a login
 

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -29,7 +29,7 @@ import type { ServerBackendFactory } from './server.js';
 
 const testDebug = debug('pw:mcp:test');
 const allowedLoopbackHostnamePattern = /^127(?:\.\d{1,3}){3}$/;
-type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void>, fallbackStarted: boolean };
+type StreamableSessionInfo = { transport: StreamableHTTPServerTransport, transportInitialized: ManualPromise<void> };
 
 export async function startHttpServer(config: { host?: string, port?: number }, abortSignal?: AbortSignal): Promise<http.Server> {
   const host = config.host ?? 'localhost';
@@ -93,12 +93,8 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       res.end('Session not found');
       return;
     }
-    if (req.method === 'GET' && acceptsEventStream(req)) {
+    if (req.method === 'GET' && acceptsEventStream(req))
       sessionInfo.transportInitialized.resolve();
-    } else if (req.method === 'POST' && !sessionInfo.fallbackStarted) {
-      sessionInfo.fallbackStarted = true;
-      setTimeout(() => sessionInfo.transportInitialized.resolve(), 5000);
-    }
     return await sessionInfo.transport.handleRequest(req, res);
   }
 
@@ -107,7 +103,7 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>(), fallbackStarted: false };
+        const sessionInfo = { transport, transportInitialized: new ManualPromise<void>() };
         sessions.set(sessionId, sessionInfo);
         await mcpServer.connect(serverBackendFactory, transport, sessionInfo.transportInitialized, true);
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -92,7 +92,7 @@ export function createServer(name: string, version: string, backend: ServerBacke
 
     if (runHeartbeat && !heartbeatRunning) {
       heartbeatRunning = true;
-      startHeartbeat(server);
+      void transportInitialized.then(() => startHeartbeat(server)).catch(errorsDebug);
     }
 
     try {
@@ -113,12 +113,11 @@ export function createServer(name: string, version: string, backend: ServerBacke
       const capabilities = server.getClientCapabilities();
       let clientRoots: Root[] = [];
       if (capabilities?.roots) {
-        const { roots } = await transportInitialized
-            .then(() => server.listRoots(undefined, { timeout: 2_000 }))
-            .catch(e => {
-              serverDebug(e);
-              return { roots: [] };
-            });
+        await raceTimeout(transportInitialized, 5000);
+        const { roots } = await server.listRoots(undefined, { timeout: 2_000 }).catch(e => {
+          serverDebug(e);
+          return { roots: [] };
+        });
         clientRoots = roots;
       }
       const clientVersion = server.getClientVersion() ?? { name: 'unknown', version: 'unknown' };
@@ -175,6 +174,18 @@ const pingTimeout = (): number => {
     return defaultPingTimeout;
   return parsed;
 };
+
+async function raceTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<void>(resolve => timeoutId = setTimeout(resolve, timeoutMs)),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 function addServerListener(server: Server, event: 'close' | 'initialized', listener: () => void) {
   const oldListener = server[`on${event}`];

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -271,7 +271,7 @@ describe('mcp http transport hardening', () => {
     }
   });
 
-  it('falls back when the streamable HTTP event stream never opens', async () => {
+  it('keeps POST-only sessions alive while root discovery falls back', async () => {
     let initializedRoots: unknown[] | undefined;
     const callTool = vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
     const listRoots = vi.fn(() => ({ roots: [{ uri: 'file:///workspace' }] }));
@@ -301,11 +301,13 @@ describe('mcp http transport hardening', () => {
     client.setRequestHandler(ListRootsRequestSchema, listRoots);
     client.setRequestHandler(PingRequestSchema, () => ({}));
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
-    let fallbackTimerCount = 0;
+    const previousPingTimeout = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+    process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = '20';
+    let rootFallbackTimerCount = 0;
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
       if (timeout === 5000) {
-        if (new Error().stack?.includes('/src/mcp/http.ts'))
-          ++fallbackTimerCount;
+        if (new Error().stack?.includes('/src/mcp/server.ts'))
+          ++rootFallbackTimerCount;
         return originalSetTimeout(handler, 0, ...args);
       }
       if (timeout === 2000)
@@ -316,13 +318,19 @@ describe('mcp http transport hardening', () => {
     try {
       await client.connect(transport);
       await client.callTool({ name: 'probe', arguments: {} });
+      await new Promise(resolve => originalSetTimeout(resolve, 50));
+      await client.callTool({ name: 'probe', arguments: {} });
 
-      expect(fallbackTimerCount).toBe(1);
+      expect(rootFallbackTimerCount).toBe(1);
       expect(initializedRoots).toEqual([]);
       expect(listRoots).not.toHaveBeenCalled();
-      expect(callTool).toHaveBeenCalledTimes(1);
+      expect(callTool).toHaveBeenCalledTimes(2);
     } finally {
       setTimeoutSpy.mockRestore();
+      if (previousPingTimeout === undefined)
+        delete process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+      else
+        process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = previousPingTimeout;
       await client.close();
     }
   });


### PR DESCRIPTION
## Upstream change

- Playwright [PR #42189](https://github.com/microsoft/playwright/pull/42189) and [commit 43a9121](https://github.com/microsoft/playwright/commit/43a9121961cb7dacd753133a6b5765bc00289d53) stop heartbeat pings until a Streamable HTTP client opens the optional event stream. POST-only clients cannot receive server-initiated pings, so the old behavior closed healthy sessions after the ping timeout.

## Why it matters here

This repository had the same lifecycle. Its first HTTP tool call started heartbeat pings even when the client never opened the event stream. A POST-only client could complete one call, then lose its session before the next call.

## Implemented

- Start heartbeat only after the event stream opens.
- Keep the five-second roots-readiness cap without marking POST-only transports as event-stream ready.
- Document the behavior and cover a second POST-only tool call after the old timeout.

## Validation

- npm test -- tests/mcp-http.test.ts tests/mcp-server-errors.test.ts (21 tests)
- npm run lint
- npm run build
- npm test (40 files, 799 tests)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Streamable HTTP session handling for POST-only clients.
  * Delayed heartbeat startup until transport initialization completes.
  * Added a timeout for client root discovery to improve connection reliability.
  * Ensured POST-only sessions remain usable during fallback behavior.

* **Documentation**
  * Clarified when HTTP heartbeat pings begin and how they apply to POST-only clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->