### PR TITLE
Recover the tab after an involuntary target_closed debugger detach

### DIFF
--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -30,6 +30,18 @@ export type CDPMessage = {
 export type SendCommand = (method: string, params: any) => Promise<any>;
 export type SendToCDPClient = (message: CDPMessage) => void;
 
+// Chrome force-detaches chrome.debugger from the whole tab (onDetach reason
+// "target_closed") when a frame navigates to a scheme it cannot attach to,
+// even though the tab stays open and re-attachable. Mirroring the recovery
+// upstream added to the extension in microsoft/playwright#42221, wait for the
+// navigation to settle before re-attaching, and refuse to recover again within
+// the cooldown so a page that keeps triggering the condition cannot cause a
+// tight re-attach loop.
+/** @public */
+export const REATTACH_DELAY_MS = 500;
+/** @public */
+export const REATTACH_COOLDOWN_MS = 10_000;
+
 type TabSession = {
   tabId: number;
   sessionId: string;
@@ -43,6 +55,8 @@ export class BrowserModel {
   private _knownTabs = new Map<number, Tab>();
   private _tabSessions = new Map<number, TabSession>();
   private _tabAttachmentPromises = new Map<number, Promise<TabSession>>();
+  private _reattachTimers = new Map<number, NodeJS.Timeout>();
+  private _lastReattachAttempt = new Map<number, number>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _nextSessionId = 1;
@@ -69,6 +83,8 @@ export class BrowserModel {
 
   onTabRemoved(tabId: number): void {
     this._knownTabs.delete(tabId);
+    this._cancelReattach(tabId);
+    this._lastReattachAttempt.delete(tabId);
     this._detachTab(tabId);
   }
 
@@ -86,9 +102,56 @@ export class BrowserModel {
     this._emit({ sessionId: source.sessionId || tabSession.sessionId, method, params });
   }
 
-  onDebuggerDetach(source: Debuggee): void {
-    if (source.tabId !== undefined)
+  onDebuggerDetach(source: Debuggee, reason?: string): void {
+    if (source.tabId === undefined)
+      return;
+    if (reason === 'target_closed') {
+      this._recoverAfterInvoluntaryDetach(source.tabId);
+    } else {
+      // A voluntary detach is terminal: make sure no recovery re-attaches
+      // the tab behind the client's back.
+      this._cancelReattach(source.tabId);
       this._detachTab(source.tabId);
+    }
+  }
+
+  // The extension connection is gone; this model is about to be replaced and
+  // must not fire a re-attach over whatever connection the relay holds next.
+  dispose(): void {
+    for (const tabId of [...this._reattachTimers.keys()])
+      this._cancelReattach(tabId);
+  }
+
+  // "target_closed" is an involuntary detach: Chrome dropped the debugger
+  // session, but the tab may still be open (chrome.tabs.onRemoved tells us
+  // when it actually closes). The old CDP session is gone either way — its
+  // enabled domains and child sessions do not survive a re-attach — so tear
+  // it down for the client, then re-attach the tab under a fresh session.
+  private _recoverAfterInvoluntaryDetach(tabId: number): void {
+    if (!this._tabSessions.has(tabId))
+      return;
+    this._detachTab(tabId);
+    const now = Date.now();
+    const lastAttempt = this._lastReattachAttempt.get(tabId);
+    if (lastAttempt !== undefined && now - lastAttempt < REATTACH_COOLDOWN_MS)
+      return;
+    this._lastReattachAttempt.set(tabId, now);
+    const timer = setTimeout(() => {
+      this._reattachTimers.delete(tabId);
+      if (!this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
+        return;
+      void this._attachTab(tabId, { tolerateAlreadyAttached: true }).catch(logUnhandledError);
+    }, REATTACH_DELAY_MS);
+    timer.unref?.();
+    this._reattachTimers.set(tabId, timer);
+  }
+
+  private _cancelReattach(tabId: number): void {
+    const timer = this._reattachTimers.get(tabId);
+    if (timer === undefined)
+      return;
+    clearTimeout(timer);
+    this._reattachTimers.delete(tabId);
   }
 
   enableAutoAttach(): Promise<void> {
@@ -101,6 +164,8 @@ export class BrowserModel {
   disableAutoAttach(): Promise<void> {
     return this._runAutoAttachOperation(async () => {
       this._autoAttach = false;
+      for (const tabId of [...this._reattachTimers.keys()])
+        this._cancelReattach(tabId);
       await Promise.allSettled(this._tabAttachmentPromises.values());
       await Promise.all([...this._tabSessions.keys()].map(async tabId => {
         await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
@@ -168,14 +233,14 @@ export class BrowserModel {
     return await this._sendToExtension('chrome.debugger.sendCommand', command);
   }
 
-  private _attachTab(tabId: number): Promise<TabSession> {
+  private _attachTab(tabId: number, options?: { tolerateAlreadyAttached?: boolean }): Promise<TabSession> {
     const existing = this._tabSessions.get(tabId);
     if (existing)
       return Promise.resolve(existing);
     const inFlight = this._tabAttachmentPromises.get(tabId);
     if (inFlight)
       return inFlight;
-    const promise = Promise.resolve().then(() => this._attachTabImpl(tabId));
+    const promise = Promise.resolve().then(() => this._attachTabImpl(tabId, options));
     this._tabAttachmentPromises.set(tabId, promise);
     return promise.finally(() => {
       if (this._tabAttachmentPromises.get(tabId) === promise)
@@ -189,8 +254,19 @@ export class BrowserModel {
     return result;
   }
 
-  private async _attachTabImpl(tabId: number): Promise<TabSession> {
-    await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
+  private async _attachTabImpl(tabId: number, options?: { tolerateAlreadyAttached?: boolean }): Promise<TabSession> {
+    try {
+      await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
+    } catch (error) {
+      // The published extension recovers from involuntary detaches on its own
+      // (microsoft/playwright#42221); if it re-attached before our recovery
+      // fired, the attach fails with "already attached" while the debugger is
+      // in fact attached — proceed and rebuild the session instead of losing
+      // the tab.
+      const alreadyAttached = error instanceof Error && /already attached/i.test(error.message);
+      if (!options?.tolerateAlreadyAttached || !alreadyAttached)
+        throw error;
+    }
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },
       'Target.getTargetInfo',

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -34,8 +34,8 @@ export type SendToCDPClient = (message: CDPMessage) => void;
 // "target_closed") when a frame navigates to a scheme it cannot attach to,
 // even though the tab stays open and re-attachable. Mirroring the recovery
 // upstream added to the extension in microsoft/playwright#42221, wait for the
-// navigation to settle before re-attaching, and refuse to recover again within
-// the cooldown so a page that keeps triggering the condition cannot cause a
+// navigation to settle before re-attaching, and space attempts at least the
+// cooldown apart so a page that keeps triggering the condition cannot cause a
 // tight re-attach loop.
 /** @public */
 export const REATTACH_DELAY_MS = 500;
@@ -59,6 +59,7 @@ export class BrowserModel {
   private _lastReattachAttempt = new Map<number, number>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
+  private _disposed = false;
   private _nextSessionId = 1;
 
   constructor(sendToExtension: SendCommand, private _connectPagePrefix?: string) {
@@ -116,8 +117,11 @@ export class BrowserModel {
   }
 
   // The extension connection is gone; this model is about to be replaced and
-  // must not fire a re-attach over whatever connection the relay holds next.
+  // must not act over whatever connection the relay holds next — the send
+  // closure resolves the relay's current connection at each call, so pending
+  // timers and in-flight attach operations both have to stand down.
   dispose(): void {
+    this._disposed = true;
     for (const tabId of [...this._reattachTimers.keys()])
       this._cancelReattach(tabId);
   }
@@ -128,20 +132,43 @@ export class BrowserModel {
   // enabled domains and child sessions do not survive a re-attach — so tear
   // it down for the client, then re-attach the tab under a fresh session.
   private _recoverAfterInvoluntaryDetach(tabId: number): void {
+    if (this._disposed)
+      return;
+    const inFlightAttach = this._tabAttachmentPromises.get(tabId);
+    if (inFlightAttach) {
+      // The debugger detached while an attach was still completing. If that
+      // attach fails against the now-detached debugger there is no session to
+      // observe the detach, so recover once the attempt settles instead of
+      // losing the tab.
+      void inFlightAttach.then(
+          () => this._recoverAfterInvoluntaryDetach(tabId),
+          () => this._scheduleReattach(tabId),
+      );
+      return;
+    }
     if (!this._tabSessions.has(tabId))
       return;
     this._detachTab(tabId);
-    const now = Date.now();
-    const lastAttempt = this._lastReattachAttempt.get(tabId);
-    if (lastAttempt !== undefined && now - lastAttempt < REATTACH_COOLDOWN_MS)
+    this._scheduleReattach(tabId);
+  }
+
+  private _scheduleReattach(tabId: number): void {
+    if (this._disposed || !this._knownTabs.has(tabId) || this._reattachTimers.has(tabId))
       return;
-    this._lastReattachAttempt.set(tabId, now);
+    // Wait out whatever remains of the cooldown since the last attempt, so a
+    // page that keeps forcing detaches is retried at most once per cooldown
+    // instead of in a tight loop.
+    const lastAttempt = this._lastReattachAttempt.get(tabId);
+    const cooldownRemaining = lastAttempt === undefined
+      ? 0
+      : Math.max(0, lastAttempt + REATTACH_COOLDOWN_MS - Date.now());
     const timer = setTimeout(() => {
       this._reattachTimers.delete(tabId);
-      if (!this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
+      if (this._disposed || !this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
         return;
+      this._lastReattachAttempt.set(tabId, Date.now());
       void this._attachTab(tabId, { tolerateAlreadyAttached: true }).catch(logUnhandledError);
-    }, REATTACH_DELAY_MS);
+    }, Math.max(REATTACH_DELAY_MS, cooldownRemaining));
     timer.unref?.();
     this._reattachTimers.set(tabId, timer);
   }
@@ -171,6 +198,10 @@ export class BrowserModel {
         await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
         this._detachTab(tabId);
       }));
+      // A target_closed event arriving during the awaits above can schedule a
+      // new recovery, so cancel once more now that the operation has settled.
+      for (const tabId of [...this._reattachTimers.keys()])
+        this._cancelReattach(tabId);
     });
   }
 
@@ -267,10 +298,17 @@ export class BrowserModel {
       if (!options?.tolerateAlreadyAttached || !alreadyAttached)
         throw error;
     }
+    // Re-check after every await: the model may have been disposed while the
+    // extension round trip was in flight, and the send closure would other-
+    // wise act over whatever connection replaced the one that disconnected.
+    if (this._disposed)
+      throw new Error('Browser model was disposed while attaching');
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },
       'Target.getTargetInfo',
     ]);
+    if (this._disposed)
+      throw new Error('Browser model was disposed while attaching');
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -165,6 +165,8 @@ export class BrowserModel {
   private _scheduleReattach(tabId: number): void {
     if (this._disposed || !this._knownTabs.has(tabId) || this._reattachTimers.has(tabId))
       return;
+    if (this._reattachBudgetSpent(tabId))
+      return;
     // Wait out whatever remains of the cooldown since the last attempt, so a
     // page that keeps forcing detaches is retried at most once per cooldown
     // instead of in a tight loop.
@@ -176,23 +178,30 @@ export class BrowserModel {
       this._reattachTimers.delete(tabId);
       if (this._disposed || !this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
         return;
+      // The budget can run out after this timer was scheduled — a detach
+      // event racing a failing attempt schedules the next timer before that
+      // attempt's failure is counted — so re-check at fire time.
+      if (this._reattachBudgetSpent(tabId))
+        return;
       this._lastReattachAttempt.set(tabId, Date.now());
       void this._attachTab(tabId, { tolerateAlreadyAttached: true }).then(
           () => this._reattachFailures.delete(tabId),
           error => {
             logUnhandledError(error);
-            const failures = (this._reattachFailures.get(tabId) ?? 0) + 1;
-            this._reattachFailures.set(tabId, failures);
+            this._reattachFailures.set(tabId, (this._reattachFailures.get(tabId) ?? 0) + 1);
             // A failed attempt may be transient (e.g. another navigation raced
             // the re-attach), so retry after the cooldown until the budget for
-            // this recovery episode is spent.
-            if (failures < REATTACH_MAX_ATTEMPTS)
-              this._scheduleReattach(tabId);
+            // this recovery episode is spent (_scheduleReattach enforces it).
+            this._scheduleReattach(tabId);
           },
       );
     }, Math.max(REATTACH_DELAY_MS, cooldownRemaining));
     timer.unref?.();
     this._reattachTimers.set(tabId, timer);
+  }
+
+  private _reattachBudgetSpent(tabId: number): boolean {
+    return (this._reattachFailures.get(tabId) ?? 0) >= REATTACH_MAX_ATTEMPTS;
   }
 
   private _cancelReattach(tabId: number): void {
@@ -218,8 +227,13 @@ export class BrowserModel {
       await Promise.allSettled(this._tabAttachmentPromises.values());
       try {
         await Promise.all([...this._tabSessions.keys()].map(async tabId => {
-          await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
-          this._detachTab(tabId);
+          try {
+            await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
+          } finally {
+            // The detach RPC rejects when Chrome already force-detached; the
+            // session is dead either way, so tell the client and drop it.
+            this._detachTab(tabId);
+          }
         }));
       } finally {
         // A target_closed event arriving during the awaits above can schedule
@@ -335,9 +349,10 @@ export class BrowserModel {
       // The debugger is attached but no session tracks it, so nothing would
       // ever detach it or observe its detach events. Roll the attach back
       // (unless disposed — then no RPC may leave this model) so the tab stays
-      // re-attachable.
+      // re-attachable, and await it so no retry can adopt the half-attached
+      // debugger before the detach has settled.
       if (!this._disposed)
-        void this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(logUnhandledError);
+        await this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(logUnhandledError);
       throw error;
     }
   }

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -63,6 +63,11 @@ export class BrowserModel {
   private _reattachTimers = new Map<number, NodeJS.Timeout>();
   private _lastReattachAttempt = new Map<number, number>();
   private _reattachFailures = new Map<number, number>();
+  // Bumped when disableAutoAttach completes: it deliberately detaches every
+  // tab, so recovery callbacks captured before that (deferred .then handlers
+  // and retry handlers that outlive the timer-cancellation passes) must not
+  // resurrect tabs afterwards.
+  private _recoveryEpoch = 0;
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _disposed = false;
@@ -141,6 +146,7 @@ export class BrowserModel {
   private _recoverAfterInvoluntaryDetach(tabId: number): void {
     if (this._disposed)
       return;
+    const epoch = this._recoveryEpoch;
     const inFlightAttach = this._tabAttachmentPromises.get(tabId);
     if (inFlightAttach) {
       // The debugger detached while an attach was still completing. If that
@@ -148,8 +154,14 @@ export class BrowserModel {
       // observe the detach, so recover once the attempt settles instead of
       // losing the tab.
       void inFlightAttach.then(
-          () => this._recoverAfterInvoluntaryDetach(tabId),
-          () => this._scheduleReattach(tabId),
+          () => {
+            if (epoch === this._recoveryEpoch)
+              this._recoverAfterInvoluntaryDetach(tabId);
+          },
+          () => {
+            if (epoch === this._recoveryEpoch)
+              this._scheduleReattach(tabId);
+          },
       );
       return;
     }
@@ -174,9 +186,12 @@ export class BrowserModel {
     const cooldownRemaining = lastAttempt === undefined
       ? 0
       : Math.max(0, lastAttempt + REATTACH_COOLDOWN_MS - Date.now());
+    const epoch = this._recoveryEpoch;
     const timer = setTimeout(() => {
       this._reattachTimers.delete(tabId);
-      if (this._disposed || !this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
+      if (this._disposed || epoch !== this._recoveryEpoch)
+        return;
+      if (!this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
         return;
       // The budget can run out after this timer was scheduled — a detach
       // event racing a failing attempt schedules the next timer before that
@@ -191,13 +206,22 @@ export class BrowserModel {
             this._reattachFailures.set(tabId, (this._reattachFailures.get(tabId) ?? 0) + 1);
             // A failed attempt may be transient (e.g. another navigation raced
             // the re-attach), so retry after the cooldown until the budget for
-            // this recovery episode is spent (_scheduleReattach enforces it).
-            this._scheduleReattach(tabId);
+            // this recovery episode is spent (_scheduleReattach enforces it) —
+            // unless the episode ended (auto-attach was disabled) meanwhile.
+            if (epoch === this._recoveryEpoch)
+              this._scheduleReattach(tabId);
           },
       );
     }, Math.max(REATTACH_DELAY_MS, cooldownRemaining));
     timer.unref?.();
     this._reattachTimers.set(tabId, timer);
+  }
+
+  private _throwIfAttachInvalidated(tabId: number): void {
+    if (this._disposed)
+      throw new Error('Browser model was disposed while attaching');
+    if (!this._knownTabs.has(tabId))
+      throw new Error(`Tab ${tabId} was removed while attaching`);
   }
 
   private _reattachBudgetSpent(tabId: number): boolean {
@@ -241,6 +265,11 @@ export class BrowserModel {
         // force-detached — so cancel once more however the operation settles.
         for (const tabId of [...this._reattachTimers.keys()])
           this._cancelReattach(tabId);
+        // Recovery callbacks can outlive both cancellation passes (they chain
+        // on the attach wrapper, which settles after the raw promise this
+        // operation awaited); ending the epoch makes them stand down instead
+        // of re-attaching a tab the client just tore down.
+        this._recoveryEpoch++;
       }
     });
   }
@@ -339,11 +368,12 @@ export class BrowserModel {
         throw error;
     }
     try {
-      // Re-check after every await: the model may have been disposed while
-      // the extension round trip was in flight, and the send closure would
-      // otherwise act over whatever connection replaced the disconnected one.
-      if (this._disposed)
-        throw new Error('Browser model was disposed while attaching');
+      // Re-check after every await: the model may have been disposed (the
+      // send closure would otherwise act over whatever connection replaced
+      // the disconnected one) or the tab removed (chrome.tabs.onRemoved
+      // cannot cancel an operation already past its timer) while the
+      // extension round trip was in flight.
+      this._throwIfAttachInvalidated(tabId);
       return await this._createTabSession(tabId);
     } catch (error) {
       // The debugger is attached but no session tracks it, so nothing would
@@ -362,8 +392,7 @@ export class BrowserModel {
       { tabId },
       'Target.getTargetInfo',
     ]);
-    if (this._disposed)
-      throw new Error('Browser model was disposed while attaching');
+    this._throwIfAttachInvalidated(tabId);
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -41,6 +41,11 @@ export type SendToCDPClient = (message: CDPMessage) => void;
 export const REATTACH_DELAY_MS = 500;
 /** @public */
 export const REATTACH_COOLDOWN_MS = 10_000;
+// Consecutive failed recovery attempts before a tab is given up on, so a tab
+// that can no longer be attached at all does not keep the model retrying
+// forever in the background.
+/** @public */
+export const REATTACH_MAX_ATTEMPTS = 3;
 
 type TabSession = {
   tabId: number;
@@ -57,6 +62,7 @@ export class BrowserModel {
   private _tabAttachmentPromises = new Map<number, Promise<TabSession>>();
   private _reattachTimers = new Map<number, NodeJS.Timeout>();
   private _lastReattachAttempt = new Map<number, number>();
+  private _reattachFailures = new Map<number, number>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _disposed = false;
@@ -86,6 +92,7 @@ export class BrowserModel {
     this._knownTabs.delete(tabId);
     this._cancelReattach(tabId);
     this._lastReattachAttempt.delete(tabId);
+    this._reattachFailures.delete(tabId);
     this._detachTab(tabId);
   }
 
@@ -148,6 +155,9 @@ export class BrowserModel {
     }
     if (!this._tabSessions.has(tabId))
       return;
+    // A live session proves the last attach succeeded, so this is a fresh
+    // recovery episode with a fresh attempt budget.
+    this._reattachFailures.delete(tabId);
     this._detachTab(tabId);
     this._scheduleReattach(tabId);
   }
@@ -167,7 +177,19 @@ export class BrowserModel {
       if (this._disposed || !this._knownTabs.has(tabId) || this._tabSessions.has(tabId))
         return;
       this._lastReattachAttempt.set(tabId, Date.now());
-      void this._attachTab(tabId, { tolerateAlreadyAttached: true }).catch(logUnhandledError);
+      void this._attachTab(tabId, { tolerateAlreadyAttached: true }).then(
+          () => this._reattachFailures.delete(tabId),
+          error => {
+            logUnhandledError(error);
+            const failures = (this._reattachFailures.get(tabId) ?? 0) + 1;
+            this._reattachFailures.set(tabId, failures);
+            // A failed attempt may be transient (e.g. another navigation raced
+            // the re-attach), so retry after the cooldown until the budget for
+            // this recovery episode is spent.
+            if (failures < REATTACH_MAX_ATTEMPTS)
+              this._scheduleReattach(tabId);
+          },
+      );
     }, Math.max(REATTACH_DELAY_MS, cooldownRemaining));
     timer.unref?.();
     this._reattachTimers.set(tabId, timer);
@@ -194,14 +216,18 @@ export class BrowserModel {
       for (const tabId of [...this._reattachTimers.keys()])
         this._cancelReattach(tabId);
       await Promise.allSettled(this._tabAttachmentPromises.values());
-      await Promise.all([...this._tabSessions.keys()].map(async tabId => {
-        await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
-        this._detachTab(tabId);
-      }));
-      // A target_closed event arriving during the awaits above can schedule a
-      // new recovery, so cancel once more now that the operation has settled.
-      for (const tabId of [...this._reattachTimers.keys()])
-        this._cancelReattach(tabId);
+      try {
+        await Promise.all([...this._tabSessions.keys()].map(async tabId => {
+          await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
+          this._detachTab(tabId);
+        }));
+      } finally {
+        // A target_closed event arriving during the awaits above can schedule
+        // a new recovery, and a detach RPC can reject when Chrome already
+        // force-detached — so cancel once more however the operation settles.
+        for (const tabId of [...this._reattachTimers.keys()])
+          this._cancelReattach(tabId);
+      }
     });
   }
 
@@ -298,11 +324,25 @@ export class BrowserModel {
       if (!options?.tolerateAlreadyAttached || !alreadyAttached)
         throw error;
     }
-    // Re-check after every await: the model may have been disposed while the
-    // extension round trip was in flight, and the send closure would other-
-    // wise act over whatever connection replaced the one that disconnected.
-    if (this._disposed)
-      throw new Error('Browser model was disposed while attaching');
+    try {
+      // Re-check after every await: the model may have been disposed while
+      // the extension round trip was in flight, and the send closure would
+      // otherwise act over whatever connection replaced the disconnected one.
+      if (this._disposed)
+        throw new Error('Browser model was disposed while attaching');
+      return await this._createTabSession(tabId);
+    } catch (error) {
+      // The debugger is attached but no session tracks it, so nothing would
+      // ever detach it or observe its detach events. Roll the attach back
+      // (unless disposed — then no RPC may leave this model) so the tab stays
+      // re-attachable.
+      if (!this._disposed)
+        void this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(logUnhandledError);
+      throw error;
+    }
+  }
+
+  private async _createTabSession(tabId: number): Promise<TabSession> {
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },
       'Target.getTargetInfo',

--- a/src/extension/cdpRelayV2.ts
+++ b/src/extension/cdpRelayV2.ts
@@ -39,6 +39,7 @@ export class ExtensionProtocolV2 {
   }
 
   onExtensionDisconnect(reason: string): void {
+    this._model.dispose();
     if (!this._ready.isDone())
       this._ready.reject(new Error(`Extension disconnected before initialization: ${reason}`));
   }
@@ -51,8 +52,8 @@ export class ExtensionProtocolV2 {
         break;
       }
       case 'chrome.debugger.onDetach': {
-        const [source] = params as ExtensionEventsV2['chrome.debugger.onDetach']['params'];
-        this._model.onDebuggerDetach(source);
+        const [source, reason] = params as ExtensionEventsV2['chrome.debugger.onDetach']['params'];
+        this._model.onDebuggerDetach(source, reason);
         break;
       }
       case 'chrome.tabs.onCreated': {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -594,7 +594,7 @@ describe('involuntary debugger detach recovery', () => {
     let failDetach!: () => void;
     const detachGate = new Promise<void>((_, reject) =>
       failDetach = () => reject(new Error('Debugger is not attached to the tab with id: 7.')));
-    const { handler, sendCommand } = await createAttachedHandler({ detach: () => detachGate });
+    const { handler, sendCommand, messages } = await createAttachedHandler({ detach: () => detachGate });
 
     const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
     await flushMicrotasks();
@@ -605,10 +605,32 @@ describe('involuntary debugger detach recovery', () => {
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
     failDetach();
     await expect(disabling).rejects.toThrow('Debugger is not attached');
+    expect(messages.filter(message => message.method === 'Target.detachedFromTarget'))
+        .toEqual([expect.objectContaining({ params: expect.objectContaining({ sessionId: 'pw-tab-1' }) })]);
 
     await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
     await flushMicrotasks();
     expect(attachCount(sendCommand)).toBe(1);
+  });
+
+  it('drops the local session even when the voluntary detach RPC rejects', async () => {
+    const { handler, messages } = await createAttachedHandler({
+      detach: async () => {
+        throw new Error('Debugger is not attached to the tab with id: 7.');
+      },
+    });
+
+    // No detach event arrives — Chrome force-detached earlier without the
+    // extension noticing — so only the RPC failure reveals the dead session.
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined))
+        .rejects.toThrow('Debugger is not attached');
+
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+    await expect(handler.forwardToExtension('Runtime.evaluate', {}, 'pw-tab-1'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-1');
   });
 
   it('rolls back and retries when recovery attaches but session setup fails', async () => {
@@ -637,6 +659,34 @@ describe('involuntary debugger detach recovery', () => {
       method: 'Target.attachedToTarget',
       params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
     });
+  });
+
+  it('enforces the retry budget when detaches race each failing attempt', async () => {
+    let failAttach!: () => void;
+    const { handler, sendCommand } = await createAttachedHandler({
+      attach: call => {
+        if (call === 1)
+          return undefined;
+        return new Promise<void>((_, reject) =>
+          failAttach = () => reject(new Error('No tab with given id 7.')));
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    for (let attempt = 1; attempt <= REATTACH_MAX_ATTEMPTS; attempt++) {
+      await vi.advanceTimersByTimeAsync(attempt === 1 ? REATTACH_DELAY_MS : REATTACH_COOLDOWN_MS);
+      await flushMicrotasks();
+      expect(attachCount(sendCommand)).toBe(1 + attempt);
+      // Another force-detach lands while the failing attach is still in
+      // flight, so the deferred recovery races the failure accounting.
+      handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+      failAttach();
+      await flushMicrotasks();
+    }
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS * 2);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1 + REATTACH_MAX_ATTEMPTS);
   });
 
   it('stops retrying recovery once the attempt budget is spent', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -26,6 +26,7 @@ import * as playwright from 'playwright';
 import { CDPRelayServer } from '../src/extension/cdpRelay.js';
 import { ExtensionContextFactory } from '../src/extension/extensionContextFactory.js';
 import { ExtensionProtocolV2 } from '../src/extension/cdpRelayV2.js';
+import { REATTACH_COOLDOWN_MS, REATTACH_DELAY_MS } from '../src/extension/browserModel.js';
 import { EXTENSION_ID, VERSION } from '../src/extension/protocol.js';
 
 import type { CDPMessage } from '../src/extension/browserModel.js';
@@ -370,6 +371,201 @@ describe('extension protocol v2', () => {
       relay.stop();
       await new Promise<void>(resolve => server.close(() => resolve()));
     }
+  });
+});
+
+describe('involuntary debugger detach recovery', () => {
+  // Drains the microtask chain of an in-flight async attach without relying
+  // on real timers (the tests below run under fake timers).
+  async function flushMicrotasks() {
+    for (let i = 0; i < 20; i++)
+      await Promise.resolve();
+  }
+
+  function attachCount(sendCommand: ReturnType<typeof vi.fn>) {
+    return sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach').length;
+  }
+
+  // Creates a handler with tab 7 attached under sessionId pw-tab-1, so each
+  // test starts from a live debugger session it can then knock out.
+  async function createAttachedHandler(overrides: { attach?: (call: number) => void } = {}) {
+    vi.useFakeTimers();
+    onTestFinished(() => vi.useRealTimers());
+    let attachCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        attachCalls++;
+        overrides.attach?.(attachCalls);
+        return undefined;
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    expect(messages.at(-1)).toMatchObject({ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } });
+    return { handler, sendCommand, messages };
+  }
+
+  it('still tears down the session on a voluntary detach', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'canceled_by_user']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+    await expect(handler.forwardToExtension('Runtime.evaluate', {}, 'pw-tab-1'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-1');
+  });
+
+  it('re-attaches the tab under a fresh session after a target_closed detach', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+    expect(attachCount(sendCommand)).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+
+    await handler.forwardToExtension('Runtime.evaluate', { expression: '1 + 1' }, 'pw-tab-2');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Runtime.evaluate',
+      { expression: '1 + 1' },
+    ]);
+  });
+
+  it('treats "already attached" during recovery as the extension having recovered on its own', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler({
+      attach: call => {
+        if (call === 2)
+          throw new Error('Another debugger is already attached to the tab with id: 7.');
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+
+    expect(attachCount(sendCommand)).toBe(2);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
+  it('keeps "already attached" fatal outside of recovery', async () => {
+    vi.useFakeTimers();
+    onTestFinished(() => vi.useRealTimers());
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === 'chrome.debugger.attach')
+        throw new Error('Another debugger is already attached to the tab with id: 7.');
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+
+    await expect(handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined))
+        .rejects.toThrow('already attached');
+  });
+
+  it('gives up instead of looping when the page keeps forcing detaches within the cooldown', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-2' },
+    });
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
+
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    expect(attachCount(sendCommand)).toBe(3);
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(4);
+  });
+
+  it('does not re-attach when the tab closes before the recovery delay elapses', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    handler.handleExtensionEvent('chrome.tabs.onRemoved', [7, { windowId: 1, isWindowClosing: false }]);
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+    expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
+  });
+
+  it('cancels a pending recovery when auto-attach is disabled', async () => {
+    const { handler, sendCommand } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+  });
+
+  it('cancels a pending recovery when the extension disconnects', async () => {
+    const { handler, sendCommand } = await createAttachedHandler();
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    handler.onExtensionDisconnect('extension websocket closed');
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+  });
+
+  it('drops the session when the recovery attach fails for another reason', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler({
+      attach: call => {
+        if (call === 2)
+          throw new Error('No tab with given id 7.');
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+
+    expect(attachCount(sendCommand)).toBe(2);
+    expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
+    await expect(handler.forwardToExtension('Runtime.evaluate', {}, 'pw-tab-1'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-1');
   });
 });
 

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -391,7 +391,7 @@ describe('involuntary debugger detach recovery', () => {
   async function createAttachedHandler(overrides: {
     attach?: (call: number) => void | Promise<void>,
     detach?: () => Promise<void>,
-    targetInfo?: (call: number) => void,
+    targetInfo?: (call: number) => void | Promise<void>,
   } = {}) {
     vi.useFakeTimers();
     onTestFinished(() => vi.useRealTimers());
@@ -407,7 +407,7 @@ describe('involuntary debugger detach recovery', () => {
         await overrides.detach?.();
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
         targetInfoCalls++;
-        overrides.targetInfo?.(targetInfoCalls);
+        await overrides.targetInfo?.(targetInfoCalls);
         return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
       }
       return {};
@@ -659,6 +659,60 @@ describe('involuntary debugger detach recovery', () => {
       method: 'Target.attachedToTarget',
       params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
     });
+  });
+
+  it('does not adopt a tab removed while its recovery attach is in flight', async () => {
+    let releaseTargetInfo!: () => void;
+    const targetInfoGate = new Promise<void>(resolve => releaseTargetInfo = resolve);
+    const { handler, sendCommand, messages } = await createAttachedHandler({
+      targetInfo: call => call === 2 ? targetInfoGate : undefined,
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    expect(attachCount(sendCommand)).toBe(2);
+
+    // The tab closes while the recovery's Target.getTargetInfo is pending;
+    // onTabRemoved can no longer cancel the timer (it already fired), so the
+    // in-flight operation itself must notice and abort.
+    handler.handleExtensionEvent('chrome.tabs.onRemoved', [7, { windowId: 1, isWindowClosing: false }]);
+    releaseTargetInfo();
+    await flushMicrotasks();
+
+    expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
+    await expect(handler.forwardToExtension('Runtime.evaluate', {}, 'pw-tab-2'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-2');
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
+  });
+
+  it('does not schedule recovery after auto-attach is disabled mid-attempt', async () => {
+    let failAttach!: () => void;
+    const { handler, sendCommand } = await createAttachedHandler({
+      attach: call => {
+        if (call === 1)
+          return undefined;
+        return new Promise<void>((_, reject) =>
+          failAttach = () => reject(new Error('No tab with given id 7.')));
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    expect(attachCount(sendCommand)).toBe(2);
+
+    // Disable while the recovery attach is in flight; its rejection handler
+    // runs after the disable's cancellation passes and must not schedule a
+    // retry into the ended episode.
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+    failAttach();
+    await expect(disabling).resolves.toEqual({ result: {} });
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS * 2);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
   });
 
   it('enforces the retry budget when detaches race each failing attempt', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -26,7 +26,7 @@ import * as playwright from 'playwright';
 import { CDPRelayServer } from '../src/extension/cdpRelay.js';
 import { ExtensionContextFactory } from '../src/extension/extensionContextFactory.js';
 import { ExtensionProtocolV2 } from '../src/extension/cdpRelayV2.js';
-import { REATTACH_COOLDOWN_MS, REATTACH_DELAY_MS } from '../src/extension/browserModel.js';
+import { REATTACH_COOLDOWN_MS, REATTACH_DELAY_MS, REATTACH_MAX_ATTEMPTS } from '../src/extension/browserModel.js';
 import { EXTENSION_ID, VERSION } from '../src/extension/protocol.js';
 
 import type { CDPMessage } from '../src/extension/browserModel.js';
@@ -391,10 +391,12 @@ describe('involuntary debugger detach recovery', () => {
   async function createAttachedHandler(overrides: {
     attach?: (call: number) => void | Promise<void>,
     detach?: () => Promise<void>,
+    targetInfo?: (call: number) => void,
   } = {}) {
     vi.useFakeTimers();
     onTestFinished(() => vi.useRealTimers());
     let attachCalls = 0;
+    let targetInfoCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.debugger.attach') {
         attachCalls++;
@@ -403,8 +405,11 @@ describe('involuntary debugger detach recovery', () => {
       }
       if (method === 'chrome.debugger.detach')
         await overrides.detach?.();
-      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        targetInfoCalls++;
+        overrides.targetInfo?.(targetInfoCalls);
         return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      }
       return {};
     });
     const messages: CDPMessage[] = [];
@@ -585,6 +590,79 @@ describe('involuntary debugger detach recovery', () => {
     expect(attachCount(sendCommand)).toBe(1);
   });
 
+  it('does not recover a tab when the voluntary detach round trip fails', async () => {
+    let failDetach!: () => void;
+    const detachGate = new Promise<void>((_, reject) =>
+      failDetach = () => reject(new Error('Debugger is not attached to the tab with id: 7.')));
+    const { handler, sendCommand } = await createAttachedHandler({ detach: () => detachGate });
+
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+    await flushMicrotasks();
+
+    // Chrome force-detached on its own while disableAutoAttach was mid-round
+    // trip, so the voluntary detach RPC rejects — the cleanup pass must still
+    // run and drop the recovery the event scheduled.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    failDetach();
+    await expect(disabling).rejects.toThrow('Debugger is not attached');
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+  });
+
+  it('rolls back and retries when recovery attaches but session setup fails', async () => {
+    const { handler, sendCommand, messages } = await createAttachedHandler({
+      targetInfo: call => {
+        if (call === 2)
+          throw new Error('Detached while handling command');
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+
+    // chrome.debugger.attach succeeded but Target.getTargetInfo failed, so the
+    // partial attachment is rolled back instead of leaving Chrome attached to
+    // a tab no session tracks.
+    expect(attachCount(sendCommand)).toBe(2);
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.detach', [{ tabId: 7 }]);
+    expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(3);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
+  it('stops retrying recovery once the attempt budget is spent', async () => {
+    const { handler, sendCommand } = await createAttachedHandler({
+      attach: call => {
+        if (call >= 2)
+          throw new Error('No tab with given id 7.');
+      },
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(2);
+
+    for (let attempt = 2; attempt <= REATTACH_MAX_ATTEMPTS; attempt++) {
+      await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+      await flushMicrotasks();
+      expect(attachCount(sendCommand)).toBe(1 + attempt);
+    }
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS * 2);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1 + REATTACH_MAX_ATTEMPTS);
+  });
+
   it('does not re-attach when the tab closes before the recovery delay elapses', async () => {
     const { handler, sendCommand, messages } = await createAttachedHandler();
 
@@ -640,9 +718,12 @@ describe('involuntary debugger detach recovery', () => {
     expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
     expect(sendCommand.mock.calls.filter(([method, params]) =>
       method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')).toHaveLength(1);
+    // A disposed model must not send a rollback detach either — no RPC may go
+    // over whatever connection replaced the disconnected one.
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(0);
   });
 
-  it('drops the session when the recovery attach fails for another reason', async () => {
+  it('drops the session when the recovery attach fails, then retries after the cooldown', async () => {
     const { handler, sendCommand, messages } = await createAttachedHandler({
       attach: call => {
         if (call === 2)
@@ -658,6 +739,14 @@ describe('involuntary debugger detach recovery', () => {
     expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
     await expect(handler.forwardToExtension('Runtime.evaluate', {}, 'pw-tab-1'))
         .rejects.toThrow('No tab found for sessionId: pw-tab-1');
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(3);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    });
   });
 });
 

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -388,16 +388,21 @@ describe('involuntary debugger detach recovery', () => {
 
   // Creates a handler with tab 7 attached under sessionId pw-tab-1, so each
   // test starts from a live debugger session it can then knock out.
-  async function createAttachedHandler(overrides: { attach?: (call: number) => void } = {}) {
+  async function createAttachedHandler(overrides: {
+    attach?: (call: number) => void | Promise<void>,
+    detach?: () => Promise<void>,
+  } = {}) {
     vi.useFakeTimers();
     onTestFinished(() => vi.useRealTimers());
     let attachCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.debugger.attach') {
         attachCalls++;
-        overrides.attach?.(attachCalls);
+        await overrides.attach?.(attachCalls);
         return undefined;
       }
+      if (method === 'chrome.debugger.detach')
+        await overrides.detach?.();
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
         return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
       return {};
@@ -491,7 +496,7 @@ describe('involuntary debugger detach recovery', () => {
         .rejects.toThrow('already attached');
   });
 
-  it('gives up instead of looping when the page keeps forcing detaches within the cooldown', async () => {
+  it('defers repeated recovery until the cooldown expires instead of looping', async () => {
     const { handler, sendCommand, messages } = await createAttachedHandler();
 
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
@@ -499,21 +504,85 @@ describe('involuntary debugger detach recovery', () => {
     await flushMicrotasks();
     expect(attachCount(sendCommand)).toBe(2);
 
+    // The page keeps forcing detaches right after each recovery: the next
+    // attempt must wait out the cooldown, not fire after the short delay.
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
     expect(messages.at(-1)).toMatchObject({
       method: 'Target.detachedFromTarget',
       params: { sessionId: 'pw-tab-2' },
     });
-    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
     await flushMicrotasks();
     expect(attachCount(sendCommand)).toBe(2);
 
-    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
     expect(attachCount(sendCommand)).toBe(3);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-3', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
+  it('recovers when target_closed arrives while an attach is still in flight', async () => {
+    vi.useFakeTimers();
+    onTestFinished(() => vi.useRealTimers());
+    let rejectTargetInfo!: (error: Error) => void;
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        targetInfoCalls++;
+        if (targetInfoCalls === 1)
+          return new Promise((_, reject) => rejectTargetInfo = reject);
+        return { targetInfo: { targetId: `target-${params[0].tabId}`, type: 'page' } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+
+    const enabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
+
+    // Chrome force-detaches after chrome.debugger.attach succeeded but before
+    // Target.getTargetInfo completed, so no TabSession exists yet and the
+    // in-flight attach fails against the detached debugger.
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    rejectTargetInfo(new Error('Detached while handling command'));
+    await expect(enabling).rejects.toThrow('Detached while handling command');
+
     await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
     await flushMicrotasks();
-    expect(attachCount(sendCommand)).toBe(4);
+    expect(attachCount(sendCommand)).toBe(2);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
+  it('does not recover a tab detached while auto-attach is being disabled', async () => {
+    let releaseDetach!: () => void;
+    const detachGate = new Promise<void>(resolve => releaseDetach = resolve);
+    const { handler, sendCommand } = await createAttachedHandler({ detach: () => detachGate });
+
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+    await flushMicrotasks();
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.detach', [{ tabId: 7 }]);
+
+    // A force-detach races with the voluntary detach round trip and schedules
+    // a recovery after disableAutoAttach's first cancellation pass ran.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    releaseDetach();
+    await expect(disabling).resolves.toEqual({ result: {} });
+
+    await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
+    await flushMicrotasks();
+    expect(attachCount(sendCommand)).toBe(1);
   });
 
   it('does not re-attach when the tab closes before the recovery delay elapses', async () => {
@@ -548,6 +617,29 @@ describe('involuntary debugger detach recovery', () => {
     await vi.advanceTimersByTimeAsync(REATTACH_COOLDOWN_MS);
     await flushMicrotasks();
     expect(attachCount(sendCommand)).toBe(1);
+  });
+
+  it('abandons a recovery already in flight when the extension disconnects', async () => {
+    let releaseAttach!: () => void;
+    const attachGate = new Promise<void>(resolve => releaseAttach = resolve);
+    const { handler, sendCommand, messages } = await createAttachedHandler({
+      attach: call => call === 2 ? attachGate : undefined,
+    });
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    await vi.advanceTimersByTimeAsync(REATTACH_DELAY_MS);
+    expect(attachCount(sendCommand)).toBe(2);
+
+    // The recovery timer already fired, so dispose() has no timer left to
+    // cancel — the in-flight attach itself must stand down instead of
+    // rebuilding state over whatever connection replaces this one.
+    handler.onExtensionDisconnect('extension websocket closed');
+    releaseAttach();
+    await flushMicrotasks();
+
+    expect(messages.filter(message => message.method === 'Target.attachedToTarget')).toHaveLength(1);
+    expect(sendCommand.mock.calls.filter(([method, params]) =>
+      method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')).toHaveLength(1);
   });
 
   it('drops the session when the recovery attach fails for another reason', async () => {


### PR DESCRIPTION
When a frame navigates to a scheme the extension cannot attach to
(chrome://, view-source:, some PDF/download flows), Chrome force-detaches
chrome.debugger from the whole tab while the tab stays open. The relay
previously discarded the onDetach reason and treated every detach as
terminal, permanently dropping the TabSession for a tab that is still
alive and re-attachable (upstream fix: microsoft/playwright#42221).

Thread the onDetach reason from the extension event into
BrowserModel.onDebuggerDetach. On reason "target_closed", tear down the
dead CDP session for the client (its enabled domains and child sessions
do not survive), then re-attach the tab under a fresh session after a
short delay, emitting a new Target.attachedToTarget. A per-tab cooldown
stops a page that keeps triggering the condition from causing a tight
re-attach loop. An "already attached" error during recovery is treated
as the published extension having recovered on its own, so host-side and
extension-side recovery compose instead of conflicting. All other detach
reasons stay on the existing terminal path.

Pending recoveries are cancelled when the tab actually closes, when
auto-attach is disabled, and when the extension connection goes away, so
a stale timer can never re-attach a tab over a replacement connection.

Fixes #178

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017eSrNHh4ywRkLCxKD1mupo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when browser debugging sessions disconnect unexpectedly.
  - Automatically retries connections after brief, controlled delays with a limited retry budget.
  - Prevents unnecessary retries after intentional disconnects, closed tabs, or disabled auto-attach.
  - Handles overlapping connections and repeated failures more reliably.
  - Cleans up stale sessions and pending recovery activity when setup fails or the extension disconnects.
  - Ensures local sessions are removed even when disconnect operations encounter errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->