### PR TITLE
Handle tab detach during attachment and re-attachment

### DIFF
--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -175,7 +175,8 @@ export class BrowserModel {
     const inFlight = this._tabAttachmentPromises.get(tabId);
     if (inFlight)
       return inFlight;
-    const promise = Promise.resolve().then(() => this._attachTabImpl(tabId));
+    const promise: Promise<TabSession> = Promise.resolve().then(() =>
+      this._attachTabImpl(tabId, () => this._tabAttachmentPromises.get(tabId) === promise));
     this._tabAttachmentPromises.set(tabId, promise);
     return promise.finally(() => {
       if (this._tabAttachmentPromises.get(tabId) === promise)
@@ -189,12 +190,18 @@ export class BrowserModel {
     return result;
   }
 
-  private async _attachTabImpl(tabId: number): Promise<TabSession> {
+  private async _attachTabImpl(tabId: number, isCurrentAttempt: () => boolean): Promise<TabSession> {
     await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },
       'Target.getTargetInfo',
     ]);
+    // A detach can land between the attach and this reply, either because the
+    // tab went away or because Chrome force-detached the debugger. Installing
+    // the session now would hide a dead debuggee behind a live-looking one and
+    // short-circuit the re-attach the extension is about to ask for.
+    if (!isCurrentAttempt())
+      throw new Error(`Tab ${tabId} was detached while attaching`);
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };
@@ -211,6 +218,7 @@ export class BrowserModel {
   }
 
   private _detachTab(tabId: number): void {
+    this._tabAttachmentPromises.delete(tabId);
     const tabSession = this._tabSessions.get(tabId);
     if (!tabSession)
       return;

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -193,6 +193,80 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
   });
 
+  it('re-attaches the tab when the extension recovers from an involuntary detach', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+    await expect(handler.forwardToExtension('Page.enable', undefined, 'pw-tab-1'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-1');
+
+    // The extension re-attaches an involuntarily detached tab by replaying
+    // chrome.tabs.onCreated for it, so recovery runs through the normal
+    // auto-attach path rather than anything keyed off the detach reason.
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    }));
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toEqual([
+      ['chrome.debugger.attach', [{ tabId: 7 }, '1.3']],
+      ['chrome.debugger.attach', [{ tabId: 7 }, '1.3']],
+    ]);
+    await handler.forwardToExtension('Page.enable', undefined, 'pw-tab-2');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Page.enable',
+    ]);
+  });
+
+  it('discards an attach that a detach cancelled while it was in flight', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let resolveTargetInfo!: () => void;
+    const targetInfo = new Promise<void>(resolve => resolveTargetInfo = resolve);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        await targetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7 },
+      'Target.getTargetInfo',
+    ]));
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    resolveTargetInfo();
+    await expect(autoAttach).rejects.toThrow('Tab 7 was detached while attaching');
+    expect(messages).toEqual([]);
+
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages).toHaveLength(1));
+    expect(messages[0]).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
   it('accepts a replacement extension connection after disconnect', async () => {
     vi.mocked(spawn).mockClear();
     const server = http.createServer();


### PR DESCRIPTION
## Summary
Fixes race conditions in tab attachment handling where a tab could be detached by the browser while an attachment was in flight, or between the debugger attach and the Target.getTargetInfo call. The extension protocol now properly detects these scenarios and allows the extension to recover through its normal re-attachment flow.

## Key Changes
- **Detect mid-flight detaches**: Added an `isCurrentAttempt()` callback to `_attachTabImpl()` that checks if the attachment attempt is still current after `Target.getTargetInfo` completes. If a detach occurred during the call, the promise is rejected with a clear error message rather than installing a dead session.
- **Clear pending attachments on detach**: Modified `_detachTab()` to remove the tab from `_tabAttachmentPromises` when detached, ensuring subsequent re-attachment attempts don't reuse a stale promise.
- **Test coverage**: Added two comprehensive test cases:
  - "re-attaches the tab when the extension recovers from an involuntary detach" - verifies that replaying `chrome.tabs.onCreated` after a detach triggers a new attachment with a fresh session ID
  - "discards an attach that a detach cancelled while it was in flight" - verifies that a detach during the `Target.getTargetInfo` call properly cancels the attachment and prevents a dead session from being installed

## Implementation Details
The fix leverages the fact that the extension re-attaches involuntarily detached tabs by replaying `chrome.tabs.onCreated`, which goes through the normal auto-attach path. By detecting and rejecting in-flight attachments that have been superseded by a detach, we ensure clean recovery without special-case handling for different detach reasons.

https://claude.ai/code/session_01VZFN8UECpaLBvPZc4LKJmn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when tabs detach unexpectedly during debugger attachment.
  * Automatically retries eligible attachment attempts after interruptions or transient failures.
  * Prevented stale attachment sessions from being retained after detachment.
  * Avoided unnecessary retries and messages for unrelated attachment errors.
  * Improved reliability when creating and attaching to new browser targets.

* **Tests**
  * Expanded coverage for detach-related failures, retries, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->