### PR TITLE
Treat a detach that cancels an in-flight attach as recoverable

### DIFF
--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -52,11 +52,9 @@ export class BrowserModel {
   // removing it from _tabAttachmentPromises before it settles, so that map
   // understates what is still running; the disable barrier drains this set.
   private _inFlightAttachAttempts = new Set<Promise<TabSession>>();
-  // Tabs whose debugger we believe Chrome holds attached, and the number of
-  // onDetach events owed for attachments that provably ended before their
-  // event was processed. chrome.debugger.onDetach names only the tab, so this
-  // is how an event is matched to the attachment it ends.
-  private _debuggerAttached = new Set<number>();
+  // onDetach events owed per tab for attachments that provably ended before
+  // their event was processed. chrome.debugger.onDetach names only the tab,
+  // so this is how an event is matched to the attachment it ends.
   private _pendingStaleDetaches = new Map<number, number>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
@@ -84,7 +82,6 @@ export class BrowserModel {
 
   onTabRemoved(tabId: number): void {
     this._knownTabs.delete(tabId);
-    this._debuggerAttached.delete(tabId);
     this._pendingStaleDetaches.delete(tabId);
     this._detachTab(tabId);
   }
@@ -117,7 +114,6 @@ export class BrowserModel {
         this._pendingStaleDetaches.set(source.tabId, staleDetaches - 1);
       return;
     }
-    this._debuggerAttached.delete(source.tabId);
     this._detachTab(source.tabId);
   }
 
@@ -166,7 +162,6 @@ export class BrowserModel {
         await Promise.allSettled([...this._inFlightAttachAttempts]);
       await Promise.all([...this._tabSessions.keys()].map(async tabId => {
         await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
-        this._debuggerAttached.delete(tabId);
         this._detachTab(tabId);
       }));
     });
@@ -288,21 +283,30 @@ export class BrowserModel {
     let result: any;
     try {
       await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
-      // Chrome only accepts an attach for a detached tab, so succeeding while
-      // we still believe it is attached proves that attachment ended without
-      // its onDetach having been processed yet. That event is now stale: it
-      // ends the replaced attachment, not this one, and onDebuggerDetach must
-      // ignore it when it arrives instead of tearing this attachment down.
-      if (this._debuggerAttached.has(tabId))
-        this._pendingStaleDetaches.set(tabId, (this._pendingStaleDetaches.get(tabId) ?? 0) + 1);
-      this._debuggerAttached.add(tabId);
       debuggerAttached = true;
       result = await this._sendToExtension('chrome.debugger.sendCommand', [
         { tabId },
         'Target.getTargetInfo',
       ]);
     } catch (error) {
-      throw isCurrentAttempt() ? error : this._abandonAttachAttempt(tabId, debuggerAttached);
+      if (!isCurrentAttempt())
+        throw this._abandonAttachAttempt(tabId, debuggerAttached);
+      if (debuggerAttached) {
+        try {
+          // The failure leaves no session behind but may leave the debugger
+          // attached, and a retry would then only ever report "Another
+          // debugger is already attached". Undo the attach before surfacing
+          // the failure, so a retry meets a detached tab.
+          await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
+        } catch {
+          // Chrome refuses to detach a detached tab, so this failing means
+          // the original failure WAS the detach, answered ahead of its
+          // onDetach event. That event is still owed and must not tear down
+          // whatever attachment exists when it arrives.
+          this._pendingStaleDetaches.set(tabId, (this._pendingStaleDetaches.get(tabId) ?? 0) + 1);
+        }
+      }
+      throw error;
     }
     if (!isCurrentAttempt())
       throw this._abandonAttachAttempt(tabId, debuggerAttached);
@@ -323,7 +327,6 @@ export class BrowserModel {
 
   private _abandonAttachAttempt(tabId: number, debuggerAttached: boolean): TabDetachedWhileAttachingError {
     if (debuggerAttached) {
-      this._debuggerAttached.delete(tabId);
       // This attempt attached the debugger but installs no session, so nothing
       // would ever detach it and every later attach for the tab would fail
       // with "Another debugger is already attached". Undo it.

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -122,7 +122,16 @@ export class BrowserModel {
     if (tab?.id === undefined)
       throw new Error('Failed to create tab');
     this._knownTabs.set(tab.id, tab);
-    const tabSession = await this._attachTab(tab.id);
+    // A detach can cancel the attach of the tab we just made. Retry once
+    // rather than failing the command: the tab is still there, so the second
+    // attempt either attaches or fails with why the tab is really gone. Do not
+    // wait for the extension to replay the tab instead — it only schedules a
+    // replay for an involuntary detach, and a voluntary one never arrives.
+    const tabSession = await this._attachTab(tab.id).catch(error => {
+      if (!(error instanceof TabDetachedWhileAttachingError))
+        throw error;
+      return this._attachTab(tab.id);
+    });
     if (this._connectPagePrefix) {
       const connectPagePrefix = this._connectPagePrefix;
       await Promise.allSettled([...this._knownTabs]

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -145,15 +145,23 @@ export class BrowserModel {
     if (tab?.id === undefined)
       throw new Error('Failed to create tab');
     this._knownTabs.set(tab.id, tab);
-    // A detach can cancel the attach of the tab we just made. Retry once
-    // rather than failing the command: the tab is still there, so the second
-    // attempt either attaches or fails with why the tab is really gone. Do not
-    // wait for the extension to replay the tab instead — it only schedules a
-    // replay for an involuntary detach, and a voluntary one never arrives.
-    const tabSession = await this._attachTab(tab.id).catch(error => {
-      if (!(error instanceof TabDetachedWhileAttachingError))
-        throw error;
-      return this._attachTab(tab.id);
+    // A failed attach of the tab we just made can be a detach either way it
+    // arrives: classified as a cancellation, or answered ahead of the onDetach
+    // event that would have marked the attempt stale. Retry once rather than
+    // failing the command, on the same terms as auto-attach — the tab is still
+    // there, so the second attempt either attaches or fails with why it is
+    // really gone. Do not wait for the extension to replay the tab instead: it
+    // schedules a replay only for an involuntary detach, so a voluntary one
+    // would wait forever.
+    const tabSession = await this._attachTab(tab.id).catch(async firstError => {
+      try {
+        return await this._attachTab(tab.id);
+      } catch (retryError) {
+        // The first attempt may have left the debugger attached, so the retry
+        // reports "Another debugger is already attached" rather than the reason
+        // anyone needs. Keep that reason reachable as the cause.
+        throw new Error(`Failed to attach tab ${tab.id}: ${retryError}`, { cause: firstError });
+      }
     });
     if (this._connectPagePrefix) {
       const connectPagePrefix = this._connectPagePrefix;

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -326,7 +326,11 @@ export class BrowserModel {
   }
 
   private _abandonAttachAttempt(tabId: number, debuggerAttached: boolean): TabDetachedWhileAttachingError {
-    if (debuggerAttached) {
+    // chrome.debugger.detach names only the tab, so once a replacement
+    // attempt or session owns it, the undo would end the replacement's
+    // attachment — and a detach we issue fires no onDetach to tell anyone.
+    const tabTakenOver = this._tabSessions.has(tabId) || this._tabAttachmentPromises.has(tabId);
+    if (debuggerAttached && !tabTakenOver) {
       // This attempt attached the debugger but installs no session, so nothing
       // would ever detach it and every later attach for the tab would fail
       // with "Another debugger is already attached". Undo it.

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -48,6 +48,16 @@ export class BrowserModel {
   private _knownTabs = new Map<number, Tab>();
   private _tabSessions = new Map<number, TabSession>();
   private _tabAttachmentPromises = new Map<number, Promise<TabSession>>();
+  // Every attempt from start to settlement. A detach cancels an attempt by
+  // removing it from _tabAttachmentPromises before it settles, so that map
+  // understates what is still running; the disable barrier drains this set.
+  private _inFlightAttachAttempts = new Set<Promise<TabSession>>();
+  // Tabs whose debugger we believe Chrome holds attached, and the number of
+  // onDetach events owed for attachments that provably ended before their
+  // event was processed. chrome.debugger.onDetach names only the tab, so this
+  // is how an event is matched to the attachment it ends.
+  private _debuggerAttached = new Set<number>();
+  private _pendingStaleDetaches = new Map<number, number>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _nextSessionId = 1;
@@ -74,6 +84,8 @@ export class BrowserModel {
 
   onTabRemoved(tabId: number): void {
     this._knownTabs.delete(tabId);
+    this._debuggerAttached.delete(tabId);
+    this._pendingStaleDetaches.delete(tabId);
     this._detachTab(tabId);
   }
 
@@ -92,8 +104,21 @@ export class BrowserModel {
   }
 
   onDebuggerDetach(source: Debuggee): void {
-    if (source.tabId !== undefined)
-      this._detachTab(source.tabId);
+    if (source.tabId === undefined)
+      return;
+    const staleDetaches = this._pendingStaleDetaches.get(source.tabId);
+    if (staleDetaches) {
+      // This event ends an attachment that a later attach already replaced —
+      // the attach could not have succeeded while it was alive. The current
+      // attachment is untouched by it.
+      if (staleDetaches === 1)
+        this._pendingStaleDetaches.delete(source.tabId);
+      else
+        this._pendingStaleDetaches.set(source.tabId, staleDetaches - 1);
+      return;
+    }
+    this._debuggerAttached.delete(source.tabId);
+    this._detachTab(source.tabId);
   }
 
   enableAutoAttach(): Promise<void> {
@@ -133,9 +158,15 @@ export class BrowserModel {
   disableAutoAttach(): Promise<void> {
     return this._runAutoAttachOperation(async () => {
       this._autoAttach = false;
-      await Promise.allSettled(this._tabAttachmentPromises.values());
+      // An attempt can register while we wait — a retry replacing a cancelled
+      // attempt registers only once the original settles, which is exactly
+      // when a one-shot snapshot stops waiting — so drain until nothing is in
+      // flight rather than awaiting a snapshot.
+      while (this._inFlightAttachAttempts.size)
+        await Promise.allSettled([...this._inFlightAttachAttempts]);
       await Promise.all([...this._tabSessions.keys()].map(async tabId => {
         await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
+        this._debuggerAttached.delete(tabId);
         this._detachTab(tabId);
       }));
     });
@@ -228,10 +259,16 @@ export class BrowserModel {
     const promise: Promise<TabSession> = Promise.resolve().then(() =>
       this._attachTabImpl(tabId, () => this._tabAttachmentPromises.get(tabId) === promise));
     this._tabAttachmentPromises.set(tabId, promise);
-    return promise.finally(() => {
+    // The barrier tracks the promise callers hold, not the raw attempt: a
+    // caller's catch is attached to it before any drain can be, so a retry it
+    // registers is always in the set by the time the drain re-checks.
+    const settled: Promise<TabSession> = promise.finally(() => {
+      this._inFlightAttachAttempts.delete(settled);
       if (this._tabAttachmentPromises.get(tabId) === promise)
         this._tabAttachmentPromises.delete(tabId);
     });
+    this._inFlightAttachAttempts.add(settled);
+    return settled;
   }
 
   private _runAutoAttachOperation(operation: () => Promise<void>): Promise<void> {
@@ -247,19 +284,28 @@ export class BrowserModel {
     // not an attach failure: installing the session would hide a dead debuggee
     // behind a live-looking one and short-circuit the re-attach the extension
     // is about to ask for.
-    const cancelled = () => new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
+    let debuggerAttached = false;
     let result: any;
     try {
       await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
+      // Chrome only accepts an attach for a detached tab, so succeeding while
+      // we still believe it is attached proves that attachment ended without
+      // its onDetach having been processed yet. That event is now stale: it
+      // ends the replaced attachment, not this one, and onDebuggerDetach must
+      // ignore it when it arrives instead of tearing this attachment down.
+      if (this._debuggerAttached.has(tabId))
+        this._pendingStaleDetaches.set(tabId, (this._pendingStaleDetaches.get(tabId) ?? 0) + 1);
+      this._debuggerAttached.add(tabId);
+      debuggerAttached = true;
       result = await this._sendToExtension('chrome.debugger.sendCommand', [
         { tabId },
         'Target.getTargetInfo',
       ]);
     } catch (error) {
-      throw isCurrentAttempt() ? error : cancelled();
+      throw isCurrentAttempt() ? error : this._abandonAttachAttempt(tabId, debuggerAttached);
     }
     if (!isCurrentAttempt())
-      throw cancelled();
+      throw this._abandonAttachAttempt(tabId, debuggerAttached);
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };
@@ -273,6 +319,19 @@ export class BrowserModel {
       },
     });
     return tabSession;
+  }
+
+  private _abandonAttachAttempt(tabId: number, debuggerAttached: boolean): TabDetachedWhileAttachingError {
+    if (debuggerAttached) {
+      this._debuggerAttached.delete(tabId);
+      // This attempt attached the debugger but installs no session, so nothing
+      // would ever detach it and every later attach for the tab would fail
+      // with "Another debugger is already attached". Undo it.
+      void this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(() => {
+        // Already detached: the cancelling detach ended this attachment too.
+      });
+    }
+    return new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
   }
 
   private _detachTab(tabId: number): void {

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -121,8 +121,9 @@ export class BrowserModel {
             // A first attempt that failed after chrome.debugger.attach had
             // succeeded leaves the debugger attached, so the retry reports
             // "Another debugger is already attached" rather than the reason
-            // anyone needs. Keep that reason reachable as the cause.
-            throw new Error(`Failed to attach tab ${tabId}: ${retryError}`, { cause: firstError });
+            // anyone needs. The relay forwards only Error.message, which never
+            // carries a cause, so name both failures in the message itself.
+            throw new Error(`Failed to attach tab ${tabId}: ${retryError} (first attempt: ${firstError})`, { cause: firstError });
           }
         }
       }));
@@ -159,8 +160,9 @@ export class BrowserModel {
       } catch (retryError) {
         // The first attempt may have left the debugger attached, so the retry
         // reports "Another debugger is already attached" rather than the reason
-        // anyone needs. Keep that reason reachable as the cause.
-        throw new Error(`Failed to attach tab ${tab.id}: ${retryError}`, { cause: firstError });
+        // anyone needs. The relay forwards only Error.message, which never
+        // carries a cause, so name both failures in the message itself.
+        throw new Error(`Failed to attach tab ${tab.id}: ${retryError} (first attempt: ${firstError})`, { cause: firstError });
       }
     });
     if (this._connectPagePrefix) {

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -199,17 +199,25 @@ export class BrowserModel {
   }
 
   private async _attachTabImpl(tabId: number, isCurrentAttempt: () => boolean): Promise<TabSession> {
-    await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
-    const result = await this._sendToExtension('chrome.debugger.sendCommand', [
-      { tabId },
-      'Target.getTargetInfo',
-    ]);
-    // A detach can land between the attach and this reply, either because the
-    // tab went away or because Chrome force-detached the debugger. Installing
-    // the session now would hide a dead debuggee behind a live-looking one and
-    // short-circuit the re-attach the extension is about to ask for.
+    // A detach can land anywhere below, either because the tab went away or
+    // because Chrome force-detached the debugger. Both a call that fails
+    // because of it and a reply that arrives after it are that cancellation,
+    // not an attach failure: installing the session would hide a dead debuggee
+    // behind a live-looking one and short-circuit the re-attach the extension
+    // is about to ask for.
+    const cancelled = () => new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
+    let result: any;
+    try {
+      await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
+      result = await this._sendToExtension('chrome.debugger.sendCommand', [
+        { tabId },
+        'Target.getTargetInfo',
+      ]);
+    } catch (error) {
+      throw isCurrentAttempt() ? error : cancelled();
+    }
     if (!isCurrentAttempt())
-      throw new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
+      throw cancelled();
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -110,12 +110,20 @@ export class BrowserModel {
       await Promise.all([...this._knownTabs.keys()].map(async tabId => {
         try {
           await attachIgnoringCancellation(tabId);
-        } catch {
+        } catch (firstError) {
           // The failed command can be the detach itself, answered ahead of the
           // onDetach event that would have marked the attempt stale. Retrying
           // separates that from a tab that genuinely cannot be attached,
           // without matching on Chrome's error text, which is not a contract.
-          await attachIgnoringCancellation(tabId);
+          try {
+            await attachIgnoringCancellation(tabId);
+          } catch (retryError) {
+            // A first attempt that failed after chrome.debugger.attach had
+            // succeeded leaves the debugger attached, so the retry reports
+            // "Another debugger is already attached" rather than the reason
+            // anyone needs. Keep that reason reachable as the cause.
+            throw new Error(`Failed to attach tab ${tabId}: ${retryError}`, { cause: firstError });
+          }
         }
       }));
     });

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -99,10 +99,25 @@ export class BrowserModel {
   enableAutoAttach(): Promise<void> {
     return this._runAutoAttachOperation(async () => {
       this._autoAttach = true;
-      await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId).catch(error => {
-        if (!(error instanceof TabDetachedWhileAttachingError))
-          throw error;
-      })));
+      const attachIgnoringCancellation = async (tabId: number) => {
+        try {
+          await this._attachTab(tabId);
+        } catch (error) {
+          if (!(error instanceof TabDetachedWhileAttachingError))
+            throw error;
+        }
+      };
+      await Promise.all([...this._knownTabs.keys()].map(async tabId => {
+        try {
+          await attachIgnoringCancellation(tabId);
+        } catch {
+          // The failed command can be the detach itself, answered ahead of the
+          // onDetach event that would have marked the attempt stale. Retrying
+          // separates that from a tab that genuinely cannot be attached,
+          // without matching on Chrome's error text, which is not a contract.
+          await attachIgnoringCancellation(tabId);
+        }
+      }));
     });
   }
 

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -175,7 +175,8 @@ export class BrowserModel {
     const inFlight = this._tabAttachmentPromises.get(tabId);
     if (inFlight)
       return inFlight;
-    const promise = Promise.resolve().then(() => this._attachTabImpl(tabId));
+    const promise: Promise<TabSession> = Promise.resolve().then(() =>
+      this._attachTabImpl(tabId, () => this._tabAttachmentPromises.get(tabId) === promise));
     this._tabAttachmentPromises.set(tabId, promise);
     return promise.finally(() => {
       if (this._tabAttachmentPromises.get(tabId) === promise)
@@ -189,12 +190,18 @@ export class BrowserModel {
     return result;
   }
 
-  private async _attachTabImpl(tabId: number): Promise<TabSession> {
+  private async _attachTabImpl(tabId: number, isCurrentAttempt: () => boolean): Promise<TabSession> {
     await this._sendToExtension('chrome.debugger.attach', [{ tabId }, '1.3']);
     const result = await this._sendToExtension('chrome.debugger.sendCommand', [
       { tabId },
       'Target.getTargetInfo',
     ]);
+    // A detach can land between the attach and this reply, either because the
+    // tab went away or because Chrome force-detached the debugger. Installing
+    // the session now would hide a dead debuggee behind a live-looking one and
+    // short-circuit the re-attach the extension is about to ask for.
+    if (!isCurrentAttempt())
+      throw new Error(`Tab ${tabId} was detached while attaching`);
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };
@@ -211,6 +218,7 @@ export class BrowserModel {
   }
 
   private _detachTab(tabId: number): void {
+    this._tabAttachmentPromises.delete(tabId);
     const tabSession = this._tabSessions.get(tabId);
     if (!tabSession)
       return;

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -37,6 +37,11 @@ type TabSession = {
   childSessions: Set<string>;
 };
 
+// A detach that cancels an in-flight attach is recoverable, not a failure:
+// the extension replays chrome.tabs.onCreated for the tab, which starts a
+// fresh attachment. Auto-attach must not fail its initialization over it.
+class TabDetachedWhileAttachingError extends Error {}
+
 export class BrowserModel {
   private _sendToExtension: SendCommand;
   private _sendToCDPClient: SendToCDPClient | null = null;
@@ -94,7 +99,10 @@ export class BrowserModel {
   enableAutoAttach(): Promise<void> {
     return this._runAutoAttachOperation(async () => {
       this._autoAttach = true;
-      await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId)));
+      await Promise.all([...this._knownTabs.keys()].map(tabId => this._attachTab(tabId).catch(error => {
+        if (!(error instanceof TabDetachedWhileAttachingError))
+          throw error;
+      })));
     });
   }
 
@@ -201,7 +209,7 @@ export class BrowserModel {
     // the session now would hide a dead debuggee behind a live-looking one and
     // short-circuit the re-attach the extension is about to ask for.
     if (!isCurrentAttempt())
-      throw new Error(`Tab ${tabId} was detached while attaching`);
+      throw new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
     const targetInfo = result?.targetInfo;
     const sessionId = `pw-tab-${this._nextSessionId++}`;
     const tabSession: TabSession = { tabId, sessionId, targetInfo, childSessions: new Set() };

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -300,12 +300,23 @@ export class BrowserModel {
           await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
         } catch {
           // Chrome refuses to detach a detached tab, so this failing means
-          // the original failure WAS the detach, answered ahead of its
-          // onDetach event. That event is still owed and must not tear down
-          // whatever attachment exists when it arrives.
+          // the original failure WAS the detach. Its onDetach may already
+          // have landed during this undo's round trip — the extension emits
+          // the event before the undo can reach it — in which case it was
+          // consumed as real and cancelled this attempt; owing it again
+          // would swallow the tab's next genuine detach.
+          if (!isCurrentAttempt())
+            throw this._abandonAttachAttempt(tabId, false);
+          // Still current: the event is outstanding and owed, and must not
+          // tear down whatever attachment exists when it arrives.
           this._pendingStaleDetaches.set(tabId, (this._pendingStaleDetaches.get(tabId) ?? 0) + 1);
         }
       }
+      // A cancellation that lands during the undo — the tab closing, most
+      // likely — must surface as one: retrying the raw failure would attach
+      // a tab that is gone or no longer ours.
+      if (!isCurrentAttempt())
+        throw this._abandonAttachAttempt(tabId, false);
       throw error;
     }
     if (!isCurrentAttempt())

--- a/src/extension/browserModel.ts
+++ b/src/extension/browserModel.ts
@@ -56,6 +56,10 @@ export class BrowserModel {
   // their event was processed. chrome.debugger.onDetach names only the tab,
   // so this is how an event is matched to the attachment it ends.
   private _pendingStaleDetaches = new Map<number, number>();
+  // Undo detaches issued for abandoned attempts, until they settle. The
+  // disable barrier promises nothing in flight when it resolves, and these
+  // are in flight without being attempts.
+  private _pendingUndoDetaches = new Set<Promise<unknown>>();
   private _autoAttachOperation = Promise.resolve();
   private _autoAttach = false;
   private _nextSessionId = 1;
@@ -158,8 +162,8 @@ export class BrowserModel {
       // attempt registers only once the original settles, which is exactly
       // when a one-shot snapshot stops waiting — so drain until nothing is in
       // flight rather than awaiting a snapshot.
-      while (this._inFlightAttachAttempts.size)
-        await Promise.allSettled([...this._inFlightAttachAttempts]);
+      while (this._inFlightAttachAttempts.size || this._pendingUndoDetaches.size)
+        await Promise.allSettled([...this._inFlightAttachAttempts, ...this._pendingUndoDetaches]);
       await Promise.all([...this._tabSessions.keys()].map(async tabId => {
         await this._sendToExtension('chrome.debugger.detach', [{ tabId }]);
         this._detachTab(tabId);
@@ -345,9 +349,11 @@ export class BrowserModel {
       // This attempt attached the debugger but installs no session, so nothing
       // would ever detach it and every later attach for the tab would fail
       // with "Another debugger is already attached". Undo it.
-      void this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(() => {
+      const undo = this._sendToExtension('chrome.debugger.detach', [{ tabId }]).catch(() => {
         // Already detached: the cancelling detach ended this attachment too.
       });
+      this._pendingUndoDetaches.add(undo);
+      void undo.then(() => this._pendingUndoDetaches.delete(undo));
     }
     return new TabDetachedWhileAttachingError(`Tab ${tabId} was detached while attaching`);
   }

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -268,6 +268,9 @@ describe('extension protocol v2', () => {
       method: 'Target.attachedToTarget',
       params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
     });
+    // The abandoned attempt's successful attach was undone, so nothing was
+    // left attached with no session behind it.
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach').length).toBeGreaterThanOrEqual(1);
   });
 
   it('treats a debugger call that fails after a detach as a cancelled attach', async () => {
@@ -307,15 +310,23 @@ describe('extension protocol v2', () => {
   });
 
   it('keeps the first failure as the cause when the auto-attach retry also fails', async () => {
-    let attachCalls = 0;
+    let chromeAttached = false;
+    let targetInfoCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.debugger.attach') {
-        if (++attachCalls > 1)
+        if (chromeAttached)
           throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
         return {};
       }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
-        throw new Error('Target.getTargetInfo timed out');
+        throw new Error(`Target.getTargetInfo timed out (call ${++targetInfoCalls})`);
       return {};
     });
     const handler = new ExtensionProtocolV2(sendCommand);
@@ -323,8 +334,8 @@ describe('extension protocol v2', () => {
       { id: 7, index: 0, windowId: 1, active: true, pinned: false },
     ]);
 
-    // The first attempt attached before failing, so the retry hits Chrome's
-    // "already attached" error and would otherwise bury why it started.
+    // Both failures are the command's own — the debugger stays attached until
+    // the undo detaches it, which is what lets the retry attach at all.
     const failure = await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined)
         .then(() => undefined, (error: unknown) => error);
     expect(failure).toBeInstanceOf(Error);
@@ -332,9 +343,11 @@ describe('extension protocol v2', () => {
     const error = failure as Error;
     // The relay forwards only Error.message, so both failures have to be in it
     // for Playwright to see why the attach started failing.
-    expect(error.message).toContain('Another debugger is already attached');
-    expect(error.message).toContain('Target.getTargetInfo timed out');
-    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out');
+    expect(error.message).toContain('Target.getTargetInfo timed out (call 2)');
+    expect(error.message).toContain('Target.getTargetInfo timed out (call 1)');
+    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out (call 1)');
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(2);
   });
 
   it('recovers when a debugger call fails before the detach event arrives', async () => {
@@ -426,11 +439,28 @@ describe('extension protocol v2', () => {
 
   it('ignores the stale detach of an attachment the retry replaced', async () => {
     const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let chromeAttached = false;
     let targetInfoCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (chromeAttached)
+          throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
+        return {};
+      }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
-        if (++targetInfoCalls === 1)
+        if (++targetInfoCalls === 1) {
+          // Chrome force-detaches and answers the in-flight command with the
+          // failure before delivering the onDetach event.
+          chromeAttached = false;
           throw new Error('Detached while handling command.');
+        }
         return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
       }
       return {};
@@ -460,8 +490,9 @@ describe('extension protocol v2', () => {
     });
   });
 
-  it('undoes an attach that completed for an attempt a detach had cancelled', async () => {
+  it('consumes the owed detach while the retry is still attaching', async () => {
     const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let chromeAttached = false;
     let attachCalls = 0;
     let releaseSecondAttach!: () => void;
     const secondAttach = new Promise<void>(resolve => releaseSecondAttach = resolve);
@@ -470,11 +501,22 @@ describe('extension protocol v2', () => {
       if (method === 'chrome.debugger.attach') {
         if (++attachCalls === 2)
           await secondAttach;
+        if (chromeAttached)
+          throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
         return {};
       }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
-        if (++targetInfoCalls === 1)
+        if (++targetInfoCalls === 1) {
+          chromeAttached = false;
           throw new Error('Detached while handling command.');
+        }
         return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
       }
       return {};
@@ -486,17 +528,14 @@ describe('extension protocol v2', () => {
     const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
     await vi.waitFor(() => expect(attachCalls).toBe(2));
 
-    // The detach behind the first failure is processed while the retry's own
-    // attach is still in flight, cancelling the retry; the attach completes
-    // anyway and must be undone, or the tab stays attached with no session
-    // and every later attach fails.
+    // The owed event lands while the retry's own attach is in flight. It ends
+    // the attachment the failed undo already proved gone, so it must not
+    // cancel the retry, which goes on to install the session.
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
     releaseSecondAttach();
     await expect(autoAttach).resolves.toEqual({ result: {} });
-    expect(messages).toEqual([]);
-    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toEqual([
-      ['chrome.debugger.detach', [{ tabId: 7 }]],
-    ]);
+    expect(messages).toMatchObject([{ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } }]);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(1);
   });
 
   it('holds Target.setAutoAttach(false) until a replacement attachment is torn down', async () => {
@@ -536,32 +575,39 @@ describe('extension protocol v2', () => {
   });
 
   it('retries a createTarget attachment that failed for its own reason and keeps the cause', async () => {
-    let attachCalls = 0;
+    let chromeAttached = false;
+    let targetInfoCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.tabs.create')
         return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
       if (method === 'chrome.debugger.attach') {
-        if (++attachCalls > 1)
+        if (chromeAttached)
           throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 8');
+        chromeAttached = false;
         return {};
       }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
-        throw new Error('Target.getTargetInfo timed out');
+        throw new Error(`Target.getTargetInfo timed out (call ${++targetInfoCalls})`);
       return {};
     });
     const handler = new ExtensionProtocolV2(sendCommand);
 
-    // The failure is unclassified, so it may be the detach answered ahead of
-    // its event; createTarget retries on the same terms as auto-attach.
     const failure = await handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined)
         .then(() => undefined, (error: unknown) => error);
     expect(failure).toBeInstanceOf(Error);
     // SAFETY: asserted to be an Error on the line above.
     const error = failure as Error;
-    expect(error.message).toContain('Another debugger is already attached');
-    expect(error.message).toContain('Target.getTargetInfo timed out');
-    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out');
-    expect(attachCalls).toBe(2);
+    expect(error.message).toContain('Target.getTargetInfo timed out (call 2)');
+    expect(error.message).toContain('Target.getTargetInfo timed out (call 1)');
+    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out (call 1)');
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(2);
   });
 
   it('accepts a replacement extension connection after disconnect', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -424,6 +424,117 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
   });
 
+  it('ignores the stale detach of an attachment the retry replaced', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          throw new Error('Detached while handling command.');
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    expect(messages).toMatchObject([{ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } }]);
+
+    // The detach behind the first failure is delivered only now, after the
+    // retry attached: it ends the replaced attachment, not the live one.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.filter(message => message.method === 'Target.detachedFromTarget')).toHaveLength(0);
+    await handler.forwardToExtension('Page.enable', undefined, 'pw-tab-1');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Page.enable',
+    ]);
+
+    // Only one stale event is owed; the next detach ends the live attachment.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+  });
+
+  it('undoes an attach that completed for an attempt a detach had cancelled', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let attachCalls = 0;
+    let releaseSecondAttach!: () => void;
+    const secondAttach = new Promise<void>(resolve => releaseSecondAttach = resolve);
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (++attachCalls === 2)
+          await secondAttach;
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          throw new Error('Detached while handling command.');
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(attachCalls).toBe(2));
+
+    // The detach behind the first failure is processed while the retry's own
+    // attach is still in flight, cancelling the retry; the attach completes
+    // anyway and must be undone, or the tab stays attached with no session
+    // and every later attach fails.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    releaseSecondAttach();
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+    expect(messages).toEqual([]);
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toEqual([
+      ['chrome.debugger.detach', [{ tabId: 7 }]],
+    ]);
+  });
+
+  it('holds Target.setAutoAttach(false) until a replacement attachment is torn down', async () => {
+    let rejectFirstTargetInfo!: (error: Error) => void;
+    const firstTargetInfo = new Promise<never>((_, reject) => rejectFirstTargetInfo = reject);
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create')
+        return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          return await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-8', type: 'page' } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+
+    const created = handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+
+    // Cancel the original attempt while the disable barrier waits on it; the
+    // retry replacing it registers only once the original settles, which is
+    // exactly when a one-shot snapshot would have stopped waiting.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 8 }, 'target_closed']);
+    rejectFirstTargetInfo(new Error('Detached while handling command.'));
+
+    await expect(created).resolves.toEqual({ result: { targetId: 'target-8' } });
+    await expect(disabling).resolves.toEqual({ result: {} });
+    expect(messages).toMatchObject([
+      { method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } },
+      { method: 'Target.detachedFromTarget', params: { sessionId: 'pw-tab-1' } },
+    ]);
+  });
+
   it('retries a createTarget attachment that failed for its own reason and keeps the cause', async () => {
     let attachCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -306,6 +306,77 @@ describe('extension protocol v2', () => {
     expect(messages[0]).toMatchObject({ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } });
   });
 
+  it('retries an attachment that a detach cancelled while creating a target', async () => {
+    let targetInfoCalls = 0;
+    let releaseFirstTargetInfo!: () => void;
+    const firstTargetInfo = new Promise<void>(resolve => releaseFirstTargetInfo = resolve);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create')
+        return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-8', type: 'page' } };
+      }
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(() => {});
+
+    const created = handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 8 }, 'target_closed']);
+    releaseFirstTargetInfo();
+
+    await expect(created).resolves.toEqual({ result: { targetId: 'target-8' } });
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toEqual([
+      ['chrome.debugger.attach', [{ tabId: 8 }, '1.3']],
+      ['chrome.debugger.attach', [{ tabId: 8 }, '1.3']],
+    ]);
+  });
+
+  it('retries a cancelled createTarget attachment once and surfaces why the retry failed', async () => {
+    let targetInfoCalls = 0;
+    let releaseFirstTargetInfo!: () => void;
+    const firstTargetInfo = new Promise<void>(resolve => releaseFirstTargetInfo = resolve);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create')
+        return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
+      if (method === 'chrome.debugger.attach' && targetInfoCalls > 0)
+        throw new Error('No tab with given id: 8');
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-8', type: 'page' } };
+      }
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+
+    const created = handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 8 }, 'target_closed']);
+    releaseFirstTargetInfo();
+
+    await expect(created).rejects.toThrow('No tab with given id: 8');
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
+  });
+
+  it('does not retry a createTarget attachment that failed for its own reason', async () => {
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.tabs.create')
+        return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
+      if (method === 'chrome.debugger.attach')
+        throw new Error('Another debugger is already attached');
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+
+    await expect(handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined))
+        .rejects.toThrow('Another debugger is already attached');
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(1);
+  });
+
   it('accepts a replacement extension connection after disconnect', async () => {
     vi.mocked(spawn).mockClear();
     const server = http.createServer();

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -306,6 +306,33 @@ describe('extension protocol v2', () => {
     expect(messages[0]).toMatchObject({ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } });
   });
 
+  it('keeps the first failure as the cause when the auto-attach retry also fails', async () => {
+    let attachCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (++attachCalls > 1)
+          throw new Error('Another debugger is already attached');
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        throw new Error('Target.getTargetInfo timed out');
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [
+      { id: 7, index: 0, windowId: 1, active: true, pinned: false },
+    ]);
+
+    // The first attempt attached before failing, so the retry hits Chrome's
+    // "already attached" error and would otherwise bury why it started.
+    const failure = await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined)
+        .then(() => undefined, (error: unknown) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(`${failure}`).toContain('Another debugger is already attached');
+    // SAFETY: asserted to be an Error on the line above.
+    expect(`${(failure as Error).cause}`).toContain('Target.getTargetInfo timed out');
+  });
+
   it('recovers when a debugger call fails before the detach event arrives', async () => {
     const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
     let targetInfoCalls = 0;

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -350,15 +350,33 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(2);
   });
 
-  it('recovers when a debugger call fails before the detach event arrives', async () => {
+  it('does not owe a detach that was consumed during the undo round trip', async () => {
     const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let chromeAttached = false;
+    let releaseUndo!: () => void;
+    const undoGate = new Promise<void>(resolve => releaseUndo = resolve);
+    let detachCalls = 0;
     let targetInfoCalls = 0;
-    let rejectFirstTargetInfo!: (error: Error) => void;
-    const firstTargetInfo = new Promise<never>((_, reject) => rejectFirstTargetInfo = reject);
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (chromeAttached)
+          throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (++detachCalls === 1)
+          await undoGate;
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
+        return {};
+      }
       if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
-        if (++targetInfoCalls === 1)
-          return await firstTargetInfo;
+        if (++targetInfoCalls === 1) {
+          chromeAttached = false;
+          throw new Error('Detached while handling command.');
+        }
         return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
       }
       return {};
@@ -368,17 +386,62 @@ describe('extension protocol v2', () => {
     handler.connectOverCDP(message => messages.push(message));
     handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
     const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
-    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+    await vi.waitFor(() => expect(detachCalls).toBe(1));
 
-    // Chrome answers the in-flight command with the detach's failure before it
-    // delivers onDetach, so the attempt still looks current when it rejects.
-    rejectFirstTargetInfo(new Error('Detached while handling command.'));
-
+    // The extension emitted the onDetach before the undo could reach it, so
+    // the event lands during the undo's round trip: it is consumed as real
+    // and cancels the attempt, and the undo's failure must not owe it again.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    releaseUndo();
     await expect(autoAttach).resolves.toEqual({ result: {} });
-    expect(messages).toMatchObject([{
-      method: 'Target.attachedToTarget',
-      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
-    }]);
+
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages).toMatchObject([
+      { method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } },
+    ]));
+
+    // No owed count leaked: the next genuine detach still tears down.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+  });
+
+  it('treats the tab closing during the undo as a cancellation, not a failure', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let chromeAttached = false;
+    let releaseUndo!: () => void;
+    const undoGate = new Promise<void>(resolve => releaseUndo = resolve);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (chromeAttached)
+          throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        await undoGate;
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        throw new Error('Target.getTargetInfo timed out');
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(sendCommand.mock.calls.some(([method]) => method === 'chrome.debugger.detach')).toBe(true));
+
+    // The tab closes while the genuine failure's undo is in flight. Retrying
+    // the raw failure would attach a tab that no longer exists.
+    handler.handleExtensionEvent('chrome.tabs.onRemoved', [7, { windowId: 1, isWindowClosing: false }]);
+    releaseUndo();
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(1);
   });
 
   it('retries an attachment that a detach cancelled while creating a target', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -490,6 +490,62 @@ describe('extension protocol v2', () => {
     });
   });
 
+  it('does not let a stale attempt detach the replacement that took the tab over', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let chromeAttached = false;
+    let releaseFirstTargetInfo!: (error: Error) => void;
+    const firstTargetInfo = new Promise<never>((_, reject) => releaseFirstTargetInfo = reject);
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.attach') {
+        if (chromeAttached)
+          throw new Error('Another debugger is already attached');
+        chromeAttached = true;
+        return {};
+      }
+      if (method === 'chrome.debugger.detach') {
+        if (!chromeAttached)
+          throw new Error('Debugger is not attached to the tab with id: 7');
+        chromeAttached = false;
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          return await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+
+    // Chrome force-detaches; the event cancels the first attempt while its
+    // Target.getTargetInfo response is still outstanding, and the extension's
+    // replay attaches a replacement that installs a session.
+    chromeAttached = false;
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages).toMatchObject([
+      { method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } },
+    ]));
+
+    // The first attempt's reply settles only now. Its undo names the tab, not
+    // the attempt, so issuing it would end the replacement's attachment.
+    releaseFirstTargetInfo(new Error('Detached while handling command.'));
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(0);
+    expect(messages.filter(message => message.method === 'Target.detachedFromTarget')).toHaveLength(0);
+    await handler.forwardToExtension('Page.enable', undefined, 'pw-tab-1');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Page.enable',
+    ]);
+  });
+
   it('consumes the owed detach while the retry is still attaching', async () => {
     const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
     let chromeAttached = false;

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -256,7 +256,10 @@ describe('extension protocol v2', () => {
 
     handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
     resolveTargetInfo();
-    await expect(autoAttach).rejects.toThrow('Tab 7 was detached while attaching');
+    // Playwright awaits this command while connecting, and the factory stops
+    // the relay if the connection fails, so a cancelled attach must not fail
+    // it — the tab is simply unattached until the extension replays it.
+    await expect(autoAttach).resolves.toEqual({ result: {} });
     expect(messages).toEqual([]);
 
     handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -193,6 +193,80 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
   });
 
+  it('re-attaches the tab when the extension recovers from an involuntary detach', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    expect(messages.at(-1)).toMatchObject({
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'pw-tab-1', targetId: 'target-7' },
+    });
+    await expect(handler.forwardToExtension('Page.enable', undefined, 'pw-tab-1'))
+        .rejects.toThrow('No tab found for sessionId: pw-tab-1');
+
+    // The extension re-attaches an involuntarily detached tab by replaying
+    // chrome.tabs.onCreated for it, so recovery runs through the normal
+    // auto-attach path rather than anything keyed off the detach reason.
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages.at(-1)).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-2', targetInfo: { targetId: 'target-7', attached: true } },
+    }));
+    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toEqual([
+      ['chrome.debugger.attach', [{ tabId: 7 }, '1.3']],
+      ['chrome.debugger.attach', [{ tabId: 7 }, '1.3']],
+    ]);
+    await handler.forwardToExtension('Page.enable', undefined, 'pw-tab-2');
+    expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7, sessionId: undefined },
+      'Page.enable',
+    ]);
+  });
+
+  it('discards an attach that a detach cancelled while it was in flight', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let resolveTargetInfo!: () => void;
+    const targetInfo = new Promise<void>(resolve => resolveTargetInfo = resolve);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        await targetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7 },
+      'Target.getTargetInfo',
+    ]));
+
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    resolveTargetInfo();
+    await expect(autoAttach).rejects.toThrow('Tab 7 was detached while attaching');
+    expect(messages).toEqual([]);
+
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages).toHaveLength(1));
+    expect(messages[0]).toMatchObject({
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
+    });
+  });
+
   it('accepts a replacement extension connection after disconnect', async () => {
     vi.mocked(spawn).mockClear();
     const server = http.createServer();

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -306,6 +306,37 @@ describe('extension protocol v2', () => {
     expect(messages[0]).toMatchObject({ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } });
   });
 
+  it('recovers when a debugger call fails before the detach event arrives', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let targetInfoCalls = 0;
+    let rejectFirstTargetInfo!: (error: Error) => void;
+    const firstTargetInfo = new Promise<never>((_, reject) => rejectFirstTargetInfo = reject);
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          return await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+
+    // Chrome answers the in-flight command with the detach's failure before it
+    // delivers onDetach, so the attempt still looks current when it rejects.
+    rejectFirstTargetInfo(new Error('Detached while handling command.'));
+
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+    expect(messages).toMatchObject([{
+      method: 'Target.attachedToTarget',
+      params: { sessionId: 'pw-tab-1', targetInfo: { targetId: 'target-7', attached: true } },
+    }]);
+  });
+
   it('retries an attachment that a detach cancelled while creating a target', async () => {
     let targetInfoCalls = 0;
     let releaseFirstTargetInfo!: () => void;

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -657,6 +657,49 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.detach')).toHaveLength(1);
   });
 
+  it('holds Target.setAutoAttach(false) until an abandoned undo settles', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let releaseFirstTargetInfo!: () => void;
+    const firstTargetInfo = new Promise<void>(resolve => releaseFirstTargetInfo = resolve);
+    let releaseUndo!: () => void;
+    const undoGate = new Promise<void>(resolve => releaseUndo = resolve);
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.detach') {
+        await undoGate;
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          await firstTargetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(() => {});
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(targetInfoCalls).toBe(1));
+
+    // Cancel the attempt, then let its reply settle: the abandoned attempt
+    // fires an undo detach that is still in flight when disable is queued.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    releaseFirstTargetInfo();
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+
+    const disabling = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: false }, undefined);
+    let disabled = false;
+    void disabling.then(() => disabled = true);
+    await new Promise(resolve => setImmediate(resolve));
+    // Disable's contract is that nothing is in flight when it resolves, and
+    // the undo is in flight.
+    expect(disabled).toBe(false);
+
+    releaseUndo();
+    await expect(disabling).resolves.toEqual({ result: {} });
+  });
+
   it('holds Target.setAutoAttach(false) until a replacement attachment is torn down', async () => {
     let rejectFirstTargetInfo!: (error: Error) => void;
     const firstTargetInfo = new Promise<never>((_, reject) => rejectFirstTargetInfo = reject);

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -270,6 +270,42 @@ describe('extension protocol v2', () => {
     });
   });
 
+  it('treats a debugger call that fails after a detach as a cancelled attach', async () => {
+    const tab = { id: 7, index: 0, windowId: 1, url: 'https://example.com', active: true, pinned: false };
+    let rejectTargetInfo!: (error: Error) => void;
+    const targetInfo = new Promise<never>((_, reject) => rejectTargetInfo = reject);
+    let targetInfoCalls = 0;
+    const sendCommand = vi.fn(async (method: string, params: any[]) => {
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo') {
+        if (++targetInfoCalls === 1)
+          return await targetInfo;
+        return { targetInfo: { targetId: 'target-7', type: 'page', url: tab.url } };
+      }
+      return {};
+    });
+    const messages: CDPMessage[] = [];
+    const handler = new ExtensionProtocolV2(sendCommand);
+    handler.connectOverCDP(message => messages.push(message));
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    const autoAttach = handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined);
+    await vi.waitFor(() => expect(sendCommand).toHaveBeenLastCalledWith('chrome.debugger.sendCommand', [
+      { tabId: 7 },
+      'Target.getTargetInfo',
+    ]));
+
+    // Chrome tears the debuggee down before answering, so the in-flight command
+    // fails rather than replying late. That is still the detach, not a failure
+    // to attach, and it must not take the connection down with it.
+    handler.handleExtensionEvent('chrome.debugger.onDetach', [{ tabId: 7 }, 'target_closed']);
+    rejectTargetInfo(new Error('Debugger is not attached to the tab with id: 7'));
+    await expect(autoAttach).resolves.toEqual({ result: {} });
+    expect(messages).toEqual([]);
+
+    handler.handleExtensionEvent('chrome.tabs.onCreated', [tab]);
+    await vi.waitFor(() => expect(messages).toHaveLength(1));
+    expect(messages[0]).toMatchObject({ method: 'Target.attachedToTarget', params: { sessionId: 'pw-tab-1' } });
+  });
+
   it('accepts a replacement extension connection after disconnect', async () => {
     vi.mocked(spawn).mockClear();
     const server = http.createServer();

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -420,19 +420,31 @@ describe('extension protocol v2', () => {
     expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(2);
   });
 
-  it('does not retry a createTarget attachment that failed for its own reason', async () => {
+  it('retries a createTarget attachment that failed for its own reason and keeps the cause', async () => {
+    let attachCalls = 0;
     const sendCommand = vi.fn(async (method: string, params: any[]) => {
       if (method === 'chrome.tabs.create')
         return { id: 8, index: 0, windowId: 1, url: params[0].url, active: true, pinned: false };
-      if (method === 'chrome.debugger.attach')
-        throw new Error('Another debugger is already attached');
+      if (method === 'chrome.debugger.attach') {
+        if (++attachCalls > 1)
+          throw new Error('Another debugger is already attached');
+        return {};
+      }
+      if (method === 'chrome.debugger.sendCommand' && params[1] === 'Target.getTargetInfo')
+        throw new Error('Target.getTargetInfo timed out');
       return {};
     });
     const handler = new ExtensionProtocolV2(sendCommand);
 
-    await expect(handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined))
-        .rejects.toThrow('Another debugger is already attached');
-    expect(sendCommand.mock.calls.filter(([method]) => method === 'chrome.debugger.attach')).toHaveLength(1);
+    // The failure is unclassified, so it may be the detach answered ahead of
+    // its event; createTarget retries on the same terms as auto-attach.
+    const failure = await handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined)
+        .then(() => undefined, (error: unknown) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(`${failure}`).toContain('Another debugger is already attached');
+    // SAFETY: asserted to be an Error on the line above.
+    expect(`${(failure as Error).cause}`).toContain('Target.getTargetInfo timed out');
+    expect(attachCalls).toBe(2);
   });
 
   it('accepts a replacement extension connection after disconnect', async () => {

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -328,9 +328,13 @@ describe('extension protocol v2', () => {
     const failure = await handler.handleCDPCommand('Target.setAutoAttach', { autoAttach: true }, undefined)
         .then(() => undefined, (error: unknown) => error);
     expect(failure).toBeInstanceOf(Error);
-    expect(`${failure}`).toContain('Another debugger is already attached');
     // SAFETY: asserted to be an Error on the line above.
-    expect(`${(failure as Error).cause}`).toContain('Target.getTargetInfo timed out');
+    const error = failure as Error;
+    // The relay forwards only Error.message, so both failures have to be in it
+    // for Playwright to see why the attach started failing.
+    expect(error.message).toContain('Another debugger is already attached');
+    expect(error.message).toContain('Target.getTargetInfo timed out');
+    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out');
   });
 
   it('recovers when a debugger call fails before the detach event arrives', async () => {
@@ -441,9 +445,11 @@ describe('extension protocol v2', () => {
     const failure = await handler.handleCDPCommand('Target.createTarget', { url: 'https://example.com' }, undefined)
         .then(() => undefined, (error: unknown) => error);
     expect(failure).toBeInstanceOf(Error);
-    expect(`${failure}`).toContain('Another debugger is already attached');
     // SAFETY: asserted to be an Error on the line above.
-    expect(`${(failure as Error).cause}`).toContain('Target.getTargetInfo timed out');
+    const error = failure as Error;
+    expect(error.message).toContain('Another debugger is already attached');
+    expect(error.message).toContain('Target.getTargetInfo timed out');
+    expect(`${error.cause}`).toContain('Target.getTargetInfo timed out');
     expect(attachCalls).toBe(2);
   });
 


### PR DESCRIPTION
Split out of #182, which was shrunk back to the single commit that answers #178. This PR is the follow-on work: making a detach that cancels an in-flight attach recoverable rather than fatal, across every caller of `_attachTab`.

## Why it is separate

#182 existed to answer #178: does the host need to react to an involuntary `target_closed` detach? The answer was no — the extension replays `chrome.tabs.onCreated` and the host's existing auto-attach path handles it — and `ad89d04` (merged) fixes the one real host-side defect that investigation turned up. Everything here grew out of review rounds on top of it and is a distinct piece of work.

## What is here

| Commit | Change |
|---|---|
| `abb65bf` | A cancelled attach no longer fails `Target.setAutoAttach`. Rejecting it stopped the relay via `extensionContextFactory.ts:57`, which was worse than the wedge it replaced. |
| `24acee0` | A debugger call that *fails* because of the detach is the same cancellation as a reply that arrives after it. |
| `f87d6b6` | `createTarget` retries a cancelled attach rather than failing `newPage()`. |
| `f5a8e31` | Auto-attach retries an unclassified failure once, so the detach answered ahead of its `onDetach` event is not fatal. Chosen over matching Chrome's error text, which is not a contract. |
| `c84415b` | The retry failure keeps the first error as its `cause`. |
| `2409401` | `createTarget` retries on the same terms as auto-attach; the two callers had disagreed about an identical failure. |
| `ad8dd38` | Both failures are named in `Error.message`, since the relay forwards only that and never a `cause`. |
| `2fc3389` | Detach events are matched to the attachment they end (see below), an abandoned attempt's successful attach is undone, and the disable barrier drains until nothing is in flight. |

Every guard is mutation-checked. Full suite green at `2fc3389`: 879 passed / 23 skipped, with `lint`, `build` and `knip` clean.

## The design hole, now closed (`2fc3389`)

This PR was opened as a draft because `chrome.debugger.onDetach` carries no attachment identity, so a stale event — one ending an attachment a retry had already replaced — tore the live session down, left Chrome attached with the host believing otherwise, and made recovery impossible.

`2fc3389` closes it by accounting rather than by reason field or error text:

- **Stale events are provable.** Chrome only accepts an attach for a detached tab, so an attach succeeding while the model still believes the tab attached proves the previous attachment ended before its event was processed. That event is recorded as owed and consumed without teardown when it arrives.
- **Orphaned attachments are undone.** An abandoned attempt whose `chrome.debugger.attach` had succeeded issues a best-effort detach, so a cancellation racing the retry's reply cannot strand an attachment no session refers to.
- **The disable barrier observes replacements.** `Target.setAutoAttach(false)` drains a set that tracks every attempt from start to settlement — cancellation empties the promise map before settling, and `.finally()`'s propagation hops let a raw-promise drain re-check before a caller's catch registers its retry, so the set holds the caller-held promise. This also resolves the retry path of #184.

Each ordering is pinned by its own test, and every mechanism by killed mutations.

Still tracked separately: the residue of #184 (a `createTarget` *started after* disable finished is a new explicit request, a semantics question, not an escape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZFN8UECpaLBvPZc4LKJmn

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab attachment reliability when tabs detach during setup.
  * Added automatic retries for failed tab attachments and target creation.
  * Prevented stale attachment attempts from blocking future connections.
  * Preserved clearer error details when repeated recovery attempts fail.

* **Tests**
  * Added coverage for attachment recovery, cancellation, retries, and detachment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when browser attachment attempts overlap, are cancelled, or encounter delayed detach events.
  * Prevented stale attachment events from disrupting active connections.
  * Ensured disabling automatic attachment cleans up pending retries and attachments.
  * Improved recovery after tab removal and failed reattachment attempts.

* **Tests**
  * Added coverage for attachment retries, cancellation, cleanup, stale events, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->