### PR TITLE
refactor: share frame work pool for axe installs

### DIFF
--- a/src/tools/auditScreenReader.ts
+++ b/src/tools/auditScreenReader.ts
@@ -899,7 +899,7 @@ const auditScreenReader = defineTabTool({
       }
       let settled = false;
       let timedOut = false;
-      const work = Promise.resolve().then(start).then(value => {
+      const work = Promise.resolve().then(start).catch(() => fallback).then(value => {
         settled = true;
         frameWork.inFlight--;
         if (timedOut)
@@ -907,14 +907,6 @@ const auditScreenReader = defineTabTool({
         wakeFrameWork(frameWork);
         onSettled?.(value, timedOut);
         return value;
-      }, () => {
-        settled = true;
-        frameWork.inFlight--;
-        if (timedOut)
-          frameWork.timedOut--;
-        wakeFrameWork(frameWork);
-        onSettled?.(fallback, timedOut);
-        return fallback;
       });
       const value = await withFrameTimeout(work, fallback, frameReadTimeoutMs(frame));
       if (!settled) {
@@ -927,32 +919,6 @@ const auditScreenReader = defineTabTool({
 
     const disposeHandles = (handles: readonly playwright.ElementHandle[]) => {
       void Promise.all(handles.map(handle => handle.dispose().catch(() => undefined)));
-    };
-
-    const injectFrameAxe = async (
-      frame: playwright.Frame,
-      onSettled?: (installed: boolean, timedOut: boolean) => void,
-    ) => {
-      if (!await reserveFrameWork(frameWork)) {
-        frameWorkSaturated = true;
-        return { value: false, timedOut: false, started: false };
-      }
-      let settled = false;
-      let timedOut = false;
-      const value = await injectAxeForNames(frame, installed => {
-        settled = true;
-        frameWork.inFlight--;
-        if (timedOut)
-          frameWork.timedOut--;
-        wakeFrameWork(frameWork);
-        onSettled?.(installed, timedOut);
-      });
-      if (!settled) {
-        timedOut = true;
-        frameWork.timedOut++;
-        wakeFrameWork(frameWork);
-      }
-      return { value, timedOut: !settled, started: true };
     };
 
     // maxElements budgets the elements a screen reader can actually reach: the
@@ -994,9 +960,7 @@ const auditScreenReader = defineTabTool({
       const byFrame = new Map<playwright.Frame, Measured[]>();
       for (const [position, handle] of handles.entries()) {
         const frame = owners[position];
-        if (!handle)
-          continue;
-        if (!frame)
+        if (!handle || !frame)
           continue;
         const batch = byFrame.get(frame);
         if (batch)
@@ -1013,12 +977,14 @@ const auditScreenReader = defineTabTool({
         if (measureNames) {
           let installed = axeByFrame.get(frame);
           if (installed === undefined) {
-            const installation = await injectFrameAxe(frame, (installed, timedOut) => {
-              if (timedOut) {
-                axeByFrame.set(frame, installed);
-                unavailableFrames.delete(frame);
-              }
-            });
+            const installation = await runFrameWork(
+                () => injectAxeForNames(frame), false, frame,
+                (installed, timedOut) => {
+                  if (timedOut) {
+                    axeByFrame.set(frame, installed);
+                    unavailableFrames.delete(frame);
+                  }
+                });
             if (!installation.started || installation.timedOut) {
               if (installation.timedOut)
                 unavailableFrames.add(frame);

--- a/src/tools/axe.ts
+++ b/src/tools/axe.ts
@@ -248,24 +248,13 @@ export function frameReadTimeoutMs(frame: playwright.Frame): number {
 
 /**
  * Installs the audit's own axe copy in a frame, once per frame the audit
- * measures. Resolves false when the frame refused or never answered within
- * its budget; names there stay unmeasured, which the audit reports.
+ * measures. Resolves false when the frame refused it; names there stay
+ * unmeasured, which the audit reports. Unbounded on purpose: the caller runs
+ * it through the frame-work pool, which owns the budget and needs to see the
+ * install actually settle, not a timeout resolving in its place.
  */
-export async function injectAxeForNames(frame: playwright.Frame, onSettled?: (installed: boolean) => void): Promise<boolean> {
-  return withFrameTimeout(
-      injectAxe(frame, axeForNamesSource).then(
-          () => {
-            onSettled?.(true);
-            return true;
-          },
-          () => {
-            onSettled?.(false);
-            return false;
-          },
-      ),
-      false,
-      frameReadTimeoutMs(frame),
-  );
+export async function injectAxeForNames(frame: playwright.Frame): Promise<boolean> {
+  return injectAxe(frame, axeForNamesSource).then(() => true, () => false);
 }
 
 // A child frame that never answers must not hang the scan. It goes unscanned

--- a/tests/tools-auditScreenReader.test.ts
+++ b/tests/tools-auditScreenReader.test.ts
@@ -901,6 +901,35 @@ describe('audit_screen_reader tool measurement', () => {
       vi.useRealTimers();
     }
   });
+
+  it('gives a hanging main-frame installation the main frame\'s budget, not a child\'s', async () => {
+    // The installation carries no timeout of its own: the frame-work pool
+    // supplies it, from the frame the call names. Named the wrong frame, a
+    // main frame that is merely slow to install would be abandoned after the
+    // child budget and its names reported unmeasured.
+    vi.useFakeTimers();
+    try {
+      const harness = createToolHarness({
+        snapshot: snapshotOf([{ role: 'button', ref: 'b1' }]),
+        installAxe: 'hang',
+      });
+
+      const audit = run(harness, 50);
+      let settled = false;
+      const outcome = audit.then(() => 'resolved', () => 'rejected').then(value => {
+        settled = true;
+        return value;
+      });
+      // Well past the child budget, still waiting on the installation alone.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect([settled, harness.installs.count]).toEqual([false, 1]);
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(await outcome).toBe('rejected');
+      await expect(audit).rejects.toThrow('None of the 1 accessibility tree elements could be resolved');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('collectElementFacts in a real page', () => {


### PR DESCRIPTION
## Summary
- run Axe installs through the shared bounded frame-work pool
- use each frame's correct read timeout
- add a regression test for the main-frame timeout budget

## Checks
- npm run lint
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility audits by applying the correct time budget when axe installation hangs in the main frame.
  * Streamlined failure handling for frame accessibility checks.

* **Tests**
  * Added coverage confirming audits continue appropriately during a stalled main-frame installation and eventually report the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->