### PR TITLE
docs: warn about extension token focus behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ npx mcp-accessibility-scanner --extension
 ```
 
 Set `PLAYWRIGHT_MCP_EXTENSION_TOKEN` to the token shown by the extension to bypass the connection approval dialog.
+Token-bypass connections are not background-safe: Chrome focuses the connection tab and window, and client-created tabs remain open after disconnect ([upstream limitation](https://github.com/microsoft/playwright/issues/42343)).
 When `--user-data-dir` contains multiple Chrome profiles, the profile with the extension installed is selected automatically, preferring Chrome's last-used profile.
 
 ### Discovering available tools (`list-tools` subcommand)


### PR DESCRIPTION
## Summary

- warn that token-bypass extension connections focus Chrome's connection tab and window
- document that client-created tabs remain open after disconnect
- link the upstream limitation, which Playwright closed as not planned

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying browser extension connection behavior, including tab focusing and tabs remaining open after disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->