### PR TITLE
feat: add snapshot bounding boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Create a `config.json` file with the following options:
   "network": {
     "allowedOrigins": ["example.com", "trusted-site.com"],
     "blockedOrigins": ["ads.example.com"]
+  },
+  "snapshot": {
+    "boxes": true
   }
 }
 ```
@@ -226,6 +229,7 @@ Create a `config.json` file with the following options:
 - `timeouts.settle`: How long to wait after every action before responding (default: `500`). An action that finishes quietly is first watched for up to 100ms (or the settle delay, whichever is shorter) so scheduled network work can still be awaited before the settle delay.
 - `network.allowedOrigins`: List of origins to allow (blocks all others if specified)
 - `network.blockedOrigins`: List of origins to block
+- `snapshot.boxes`: Include each element's viewport-relative bounding box as `[box=x,y,width,height]` in snapshots (default: `false`; CLI: `--snapshot-boxes`, env: `PLAYWRIGHT_MCP_SNAPSHOT_BOXES=1`)
 - `outputDir`: Directory for output files — reports, screenshots, traces, and session logs (CLI: `--output-dir`, env: `PLAYWRIGHT_MCP_OUTPUT_DIR`). Defaults to a fresh directory under the system temp folder, resolved once per server run so all of a run's artifacts land together. The output location is always server configuration; the deprecated MCP roots capability (client workspace folders) is no longer consulted.
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
@@ -497,9 +501,10 @@ Set default operation timeout for existing tabs.
 Capture accessibility snapshot of the current page (better than screenshot for analysis).
 Large `data:` URL payloads in snapshot output are truncated to their media type prefix.
 AI snapshots mark a visually present subtree excluded from accessibility queries with `[aria-hidden]` on its boundary element. Descendants are not marked again.
-- Parameters: `compress` (optional boolean, default false)
-  - When true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response when a repeated structural pattern appears more than 100 times. The first 10 examples of each collapsed pattern are kept.
+- Parameters: `compress` (optional boolean, default false), `boxes` (optional boolean; overrides `snapshot.boxes` for this call)
+  - When `compress` is true, repeated non-interactive ARIA snapshot nodes are collapsed in the rendered response when a repeated structural pattern appears more than 100 times. The first 10 examples of each collapsed pattern are kept.
   - Use `browser_evaluate()` to retrieve the full uncompressed list when needed.
+  - When `boxes` is true, each element includes `[box=x,y,width,height]` in viewport-relative CSS pixels.
 
 #### `browser_find`
 Search the current page accessibility snapshot without returning the full snapshot.

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,6 +80,7 @@ npx mcp-accessibility-scanner --headless --browser chrome
 | `--default-timeout <ms>` | Default Playwright operation timeout (default: 5000) |
 | `--save-session` | Save session to output directory |
 | `--save-trace` | Save Playwright trace to output directory |
+| `--snapshot-boxes` | Include viewport-relative `[box=x,y,width,height]` metadata in snapshots |
 | `--no-sandbox` | Disable browser sandboxing |
 | `--image-responses <mode>` | `"allow"` or `"omit"` image responses (default: allow) |
 
@@ -194,7 +195,7 @@ These tools are always available and work in the interactive REPL.
 | `browser_navigate_back` | Go back to previous page |
 | `browser_close` | Close the page |
 | `browser_resize` | Resize window: `{"width": 1280, "height": 720}` |
-| `browser_snapshot` | Capture accessibility snapshot |
+| `browser_snapshot` | Capture accessibility snapshot; pass `{"boxes": true}` to include element bounds |
 | `browser_take_screenshot` | Take screenshot (png/jpeg/webp, fullPage option) |
 | `browser_wait_for` | Wait for text/time: `{"text": "loaded"}` or `{"time": 5}` |
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -167,6 +167,14 @@ export type Config = {
    */
   imageResponses?: 'allow' | 'omit' | 'auto';
 
+  snapshot?: {
+    /**
+     * Include each element's bounding box as [box=x,y,width,height] in snapshots.
+     * Coordinates are viewport-relative CSS pixels.
+     */
+    boxes?: boolean;
+  };
+
   /**
    * Timeout settings for Playwright operations.
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export type CLIOptions = {
     proxyServer?: string;
     saveSession?: boolean;
     saveTrace?: boolean;
+    snapshotBoxes?: boolean;
     storageState?: string;
     userAgent?: string;
     userDataDir?: string;
@@ -272,6 +273,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config {
     },
     saveSession: cliOptions.saveSession,
     saveTrace: cliOptions.saveTrace,
+    snapshot: cliOptions.snapshotBoxes !== undefined ? { boxes: cliOptions.snapshotBoxes } : undefined,
     outputDir: cliOptions.outputDir,
     imageResponses: cliOptions.imageResponses,
     timeouts: {
@@ -313,6 +315,7 @@ function cliOptionsFromEnv(): CLIOptions {
   options.proxyBypass = envToString(process.env.PLAYWRIGHT_MCP_PROXY_BYPASS);
   options.proxyServer = envToString(process.env.PLAYWRIGHT_MCP_PROXY_SERVER);
   options.saveTrace = envToBoolean(process.env.PLAYWRIGHT_MCP_SAVE_TRACE);
+  options.snapshotBoxes = envToBoolean(process.env.PLAYWRIGHT_MCP_SNAPSHOT_BOXES);
   options.storageState = envToString(process.env.PLAYWRIGHT_MCP_STORAGE_STATE);
   options.userAgent = envToString(process.env.PLAYWRIGHT_MCP_USER_AGENT);
   options.userDataDir = envToString(process.env.PLAYWRIGHT_MCP_USER_DATA_DIR);

--- a/src/program.ts
+++ b/src/program.ts
@@ -133,6 +133,7 @@ function configureBaseProgram() {
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--save-trace', 'Whether to save the Playwright Trace of the session into the output directory.')
+      .option('--snapshot-boxes', 'include each element\'s bounding box as [box=x,y,width,height] in snapshots. Coordinates are viewport-relative, in CSS pixels.')
       .option('--storage-state <path>', 'path to the storage state file to start the session from; applied in every mode except --extension (reused contexts receive it via setStorageState, which first clears their cookies and storage).')
       .option('--user-agent <ua string>', 'specify user agent string')
       .option('--user-data-dir <path>', 'path to the user data directory. If not specified, a temporary directory will be created.')

--- a/src/response.ts
+++ b/src/response.ts
@@ -43,6 +43,7 @@ export class Response {
   private _context: Context;
   private _includeSnapshot = false;
   private _includeSnapshotCompress: boolean | undefined;
+  private _includeSnapshotBoxes: boolean | undefined;
   private _includeTabs = false;
   private _tabSnapshot: TabSnapshot | undefined;
   private _requestContext: CallToolRequestContext | undefined;
@@ -134,9 +135,10 @@ export class Response {
     return this._structuredContent;
   }
 
-  setIncludeSnapshot(compress?: boolean) {
+  setIncludeSnapshot(compress?: boolean, boxes?: boolean) {
     this._includeSnapshot = true;
     this._includeSnapshotCompress = compress;
+    this._includeSnapshotBoxes = boxes ?? this._context.config.snapshot?.boxes;
   }
 
   setIncludeTabs() {
@@ -173,7 +175,7 @@ export class Response {
       ? this._context.tabs().filter(tab => !this._includeSnapshot || tab !== currentTab)
       : currentTab && !this._includeSnapshot ? [currentTab] : [];
     const [snapshot] = await Promise.all([
-      this._includeSnapshot && currentTab ? currentTab.captureSnapshot() : undefined,
+      this._includeSnapshot && currentTab ? currentTab.captureSnapshot(this._includeSnapshotBoxes) : undefined,
       Promise.allSettled(tabsToUpdate.map(tab => tab.updateTitle())),
     ]);
     this._tabSnapshot = snapshot;

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -305,14 +305,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     return this._withPageStateTimeout(promise, description);
   }
 
-  async captureSnapshot(): Promise<TabSnapshot> {
+  async captureSnapshot(boxes?: boolean): Promise<TabSnapshot> {
     let tabSnapshot: TabSnapshot | undefined;
     const capture = { valid: true };
     const snapshotGeneration = this._ariaSnapshotGeneration;
     const modalStates = await this._raceAgainstModalStates(async () => {
       const [snapshot, title] = await Promise.all([
         this._withPageStateTimeout(
-            this._captureAriaSnapshot(capture),
+            this._captureAriaSnapshot(capture, boxes),
             'capturing page accessibility snapshot',
         ).catch(error => {
           // Nothing describes the page any more, and the refs of an older
@@ -445,14 +445,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
           .catch(() => '');
       // Refs are assigned from the full role and name before long names are
       // omitted from rendering, so a semantic change still changes this line.
-      return current.split('\n', 1)[0]?.trim() === cached.trim();
+      return withoutSnapshotBox(current.split('\n', 1)[0]?.trim() ?? '') === withoutSnapshotBox(cached.trim());
     }));
     return pageGeneration === this._pageGeneration && matches.every(Boolean);
   }
 
-  private async _captureAriaSnapshot(capture = { valid: true }): Promise<string> {
+  private async _captureAriaSnapshot(capture = { valid: true }, boxes?: boolean): Promise<string> {
     const pageGeneration = this._pageGeneration;
-    const snapshot = await this.page.ariaSnapshot({ mode: 'ai' });
+    const snapshot = await this.page.ariaSnapshot({ mode: 'ai', boxes });
     if (!capture.valid || pageGeneration !== this._pageGeneration)
       throw new StaleAriaSnapshotError('Page changed while capturing accessibility snapshot.');
     ++this._ariaSnapshotGeneration;
@@ -468,6 +468,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     await callOnPageNoTrace(this.page, page => page.waitForTimeout(time));
   }
+}
+
+function withoutSnapshotBox(line: string): string {
+  return line.replace(/ \[box=[^\]]+\](?='?(?::|$))/, '');
 }
 
 export type ConsoleMessage = {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -58,6 +58,7 @@ const scanPageSchema = z.object({
 
 const snapshotSchema = z.object({
   compress: z.boolean().optional().describe('Collapse repeated non-interactive ARIA nodes in large snapshots when a repeated structural pattern appears more than 100 times. Keeps the first 10 examples of each collapsed pattern. Use browser_evaluate() to retrieve the full list if needed.'),
+  boxes: z.boolean().optional().describe('Include each element\'s bounding box as [box=x,y,width,height]. Coordinates are viewport-relative, in CSS pixels (Element.getBoundingClientRect). Overrides snapshot.boxes for this call.'),
 });
 
 const findSchema = z.object({
@@ -327,7 +328,7 @@ const snapshot = defineTool({
 
   handle: async (context, params, response) => {
     await context.ensureTab();
-    response.setIncludeSnapshot(params.compress);
+    response.setIncludeSnapshot(params.compress, params.boxes);
   },
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -125,6 +125,30 @@ describe('Config', () => {
     }
   });
 
+  describe('snapshot boxes', () => {
+    const saved = process.env.PLAYWRIGHT_MCP_SNAPSHOT_BOXES;
+
+    afterEach(() => {
+      if (saved === undefined)
+        delete process.env.PLAYWRIGHT_MCP_SNAPSHOT_BOXES;
+      else
+        process.env.PLAYWRIGHT_MCP_SNAPSHOT_BOXES = saved;
+    });
+
+    it('accepts a default in the config object', async () => {
+      expect((await resolveConfig({ snapshot: { boxes: true } })).snapshot?.boxes).toBe(true);
+    });
+
+    it('applies config file, environment, and CLI precedence', async () => {
+      const configFile = await writeConfigFile({ snapshot: { boxes: true } });
+      expect((await resolveCLIConfig({ config: configFile })).snapshot?.boxes).toBe(true);
+
+      process.env.PLAYWRIGHT_MCP_SNAPSHOT_BOXES = '0';
+      expect((await resolveCLIConfig({ config: configFile })).snapshot?.boxes).toBe(false);
+      expect((await resolveCLIConfig({ config: configFile, snapshotBoxes: true })).snapshot?.boxes).toBe(true);
+    });
+  });
+
   describe('parseCdpHeaders', () => {
     it('parses "Name: Value" entries, keeping colons inside the value', () => {
       expect(parseCdpHeaders(['X-Forwarded-Proto: value:with:colons'])).toEqual({

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -68,6 +68,7 @@ describe('CLI command dispatch contract', () => {
       expect(help).toContain('--config');
       expect(help).toContain('--headless');
       expect(help).toContain('--mobile');
+      expect(help).toContain('--snapshot-boxes');
       expect(help).toContain('--timeout-settle');
     });
   });

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -150,6 +150,19 @@ describe('Response', () => {
       expect(mockTab.captureSnapshot).toHaveBeenCalled();
     });
 
+    it('uses configured boxes unless the tool explicitly disables them', async () => {
+      mockContext.config.snapshot = { boxes: true };
+      const configured = new Response(mockContext, 'test_tool', {});
+      configured.setIncludeSnapshot();
+      await configured.finish();
+      expect(mockTab.captureSnapshot).toHaveBeenLastCalledWith(true);
+
+      const disabled = new Response(mockContext, 'test_tool', {});
+      disabled.setIncludeSnapshot(undefined, false);
+      await disabled.finish();
+      expect(mockTab.captureSnapshot).toHaveBeenLastCalledWith(false);
+    });
+
     it('renders non-2xx HTTP status in page state only', async () => {
       mockTab.captureSnapshot = vi.fn().mockResolvedValue({
         url: 'https://example.com/locked',

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -450,7 +450,15 @@ describe('Tab', () => {
       expect(snapshot.url).toBe('https://example.com');
       expect(snapshot.title).toBe('Example Page');
       expect(snapshot.ariaSnapshot).toBe('button "Submit" [ref=1]');
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: undefined });
+    });
+
+    it('should include element boxes when requested', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+
+      await tab.captureSnapshot(true);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: true });
     });
 
     it('should include console messages in snapshot', async () => {
@@ -640,7 +648,7 @@ describe('Tab', () => {
       const tab = new Tab(mockContext, mockPage as any, onPageClose);
       await tab.refLocator({ element: 'Submit button', ref: '1' });
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=1');
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: undefined });
     });
 
     it('should throw error if ref not found', async () => {
@@ -650,7 +658,7 @@ describe('Tab', () => {
       await expect(
           tab.refLocator({ element: 'Submit button', ref: '999' })
       ).rejects.toThrow('Ref 999 not found');
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: undefined });
     });
   });
 
@@ -667,7 +675,7 @@ describe('Tab', () => {
       expect(locators).toHaveLength(2);
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=1');
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=2');
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: undefined });
     });
 
     it('resolves refs against the snapshot already returned to the caller', async () => {
@@ -681,6 +689,28 @@ describe('Tab', () => {
       // The ref came from that snapshot, so re-reading the page adds nothing.
       expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=1');
+    });
+
+    it('reuses refs from boxed snapshots without treating geometry as semantics', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- 'button "Submit" [ref=1] [box=10,20,80,30]'`);
+      locatorSnapshot = `- 'button "Submit" [ref=1]'`;
+      await tab.captureSnapshot(true);
+
+      await tab.refLocators([{ element: 'Submit', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses a boxed ref whose YAML key has an inline value', async () => {
+      const tab = new Tab(mockContext, mockPage as any, onPageClose);
+      mockPage.ariaSnapshot = vi.fn().mockResolvedValue(`- 'heading "Welcome" [ref=1] [box=10,20,80,30]': Label`);
+      locatorSnapshot = `- 'heading "Welcome" [ref=1]': Label`;
+      await tab.captureSnapshot(true);
+
+      await tab.refLocators([{ element: 'Welcome', ref: '1' }]);
+
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledTimes(1);
     });
 
     it('re-captures when a cached ref no longer resolves to an element', async () => {
@@ -807,7 +837,7 @@ describe('Tab', () => {
 
       await tab.refLocators([{ element: 'Added', ref: '2' }]);
 
-      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai' });
+      expect(mockPage.ariaSnapshot).toHaveBeenCalledWith({ mode: 'ai', boxes: undefined });
       expect(mockPage.locator).toHaveBeenCalledWith('aria-ref=2');
     });
 

--- a/tests/tools-snapshot.test.ts
+++ b/tests/tools-snapshot.test.ts
@@ -29,10 +29,11 @@ describe('Snapshot Tools', () => {
   const snapshotTool = snapshotTools.find(tool => tool.schema.name === 'browser_snapshot')!;
   const findTool = snapshotTools.find(tool => tool.schema.name === 'browser_find')!;
 
-  it('should expose browser_snapshot with optional compression', () => {
+  it('should expose browser_snapshot with optional compression and boxes', () => {
     const mcpTool = toMcpTool(snapshotTool.schema);
     const jsonSchema = mcpTool.inputSchema as JSONSchema7;
     const compressSchema = jsonSchema.properties?.compress as JSONSchema7;
+    const boxesSchema = jsonSchema.properties?.boxes as JSONSchema7;
 
     expect(snapshotTool).toBeDefined();
     expect(snapshotTool.schema.type).toBe('readOnly');
@@ -40,9 +41,13 @@ describe('Snapshot Tools', () => {
     expect(jsonSchema.required ?? []).toEqual([]);
     expect(compressSchema.type).toBe('boolean');
     expect(compressSchema.description).toContain('more than 100 times');
+    expect(boxesSchema.type).toBe('boolean');
+    expect(boxesSchema.description).toContain('viewport-relative');
     expect(snapshotTool.schema.inputSchema.parse({})).toEqual({});
     expect(snapshotTool.schema.inputSchema.parse({ compress: true })).toEqual({ compress: true });
     expect(snapshotTool.schema.inputSchema.parse({ compress: false })).toEqual({ compress: false });
+    expect(snapshotTool.schema.inputSchema.parse({ boxes: true })).toEqual({ boxes: true });
+    expect(snapshotTool.schema.inputSchema.parse({ boxes: false })).toEqual({ boxes: false });
   });
 
   it('should request the current snapshot flow with compression disabled by default', async () => {
@@ -56,7 +61,7 @@ describe('Snapshot Tools', () => {
     await snapshotTool.handle(context as any, {}, response as any);
 
     expect(context.ensureTab).toHaveBeenCalled();
-    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(undefined);
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(undefined, undefined);
   });
 
   it('should pass the compression option to the snapshot response', async () => {
@@ -70,7 +75,7 @@ describe('Snapshot Tools', () => {
     await snapshotTool.handle(context as any, { compress: true }, response as any);
 
     expect(context.ensureTab).toHaveBeenCalled();
-    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(true);
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(true, undefined);
   });
 
   it('should pass explicit compression opt-out to the snapshot response', async () => {
@@ -84,7 +89,21 @@ describe('Snapshot Tools', () => {
     await snapshotTool.handle(context as any, { compress: false }, response as any);
 
     expect(context.ensureTab).toHaveBeenCalled();
-    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(false);
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(false, undefined);
+  });
+
+  it('should pass the boxes option to the snapshot response', async () => {
+    const context = {
+      ensureTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const response = {
+      setIncludeSnapshot: vi.fn(),
+    };
+
+    await snapshotTool.handle(context as any, { boxes: true }, response as any);
+
+    expect(context.ensureTab).toHaveBeenCalled();
+    expect(response.setIncludeSnapshot).toHaveBeenCalledWith(undefined, true);
   });
 
   it('should expose browser_find with text and regex search options', () => {


### PR DESCRIPTION
## Summary

- add `snapshot.boxes`, `--snapshot-boxes`, and `PLAYWRIGHT_MCP_SNAPSHOT_BOXES`
- add a per-call `boxes` override to `browser_snapshot`
- pass viewport-relative box metadata through automatic snapshots while keeping cached refs stable when geometry changes
- document the public config, CLI, environment, and tool surfaces

This intentionally adopts only the high-value `boxes` option from the upstream snapshot work. Snapshot mode, depth, target, and filename semantics remain out of scope.

## Validation

- `npx vitest run tests/config.test.ts tests/response.test.ts tests/tab.test.ts tests/tools-snapshot.test.ts` — 185 passed, 13 skipped
- `npx vitest run tests/program.test.ts -t "shows global options"` — 1 passed
- `npm run lint`
- `npm run build`
- `npm run knip`
- `git diff --check`
- mutation check: changing the explicit-false `??` fallback to `||` makes the regression fail

The full suite was also attempted; its remaining failures are the same environment-only groups reproduced on unchanged main (missing Playwright Chromium and four local proxy subprocess/socket failures).

Closes #187