### PR TITLE
test: cover trace recovery after failed stop

### DIFF
--- a/tests/trace-recovery.test.ts
+++ b/tests/trace-recovery.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { chromium, type Browser, type BrowserContext } from 'playwright';
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveConfig } from '../src/config.js';
+import { Context } from '../src/context.js';
+
+import type { BrowserContextFactory } from '../src/browserContextFactory.js';
+
+describe.skipIf(!fs.existsSync(chromium.executablePath()))('trace recovery in a real browser', () => {
+  it('starts another trace after saving the previous trace fails', async () => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-a11y-trace-'));
+    let browser: Browser | undefined;
+    let browserContext: BrowserContext | undefined;
+
+    try {
+      const notADirectory = path.join(outputDir, 'not-a-directory');
+      const recoveredTrace = path.join(outputDir, 'recovered.zip');
+      await fs.promises.writeFile(notADirectory, '');
+
+      browser = await chromium.launch({ headless: true, chromiumSandbox: false });
+      browserContext = await browser.newContext();
+      const stop = browserContext.tracing.stop.bind(browserContext.tracing);
+      let stopCount = 0;
+      vi.spyOn(browserContext.tracing, 'stop').mockImplementation(() => stop({
+        path: ++stopCount === 1 ? path.join(notADirectory, 'failed.zip') : recoveredTrace,
+      }));
+      const factory: BrowserContextFactory = {
+        createContext: async () => ({ browserContext, close: async () => {} }),
+      };
+      const config = await resolveConfig({ saveTrace: true });
+      const newContext = () => new Context({
+        tools: [],
+        config,
+        browserContextFactory: factory,
+        sessionLog: undefined,
+        clientInfo: {},
+      });
+
+      const first = newContext();
+      await first.newTab();
+      await first.closeBrowserContext();
+
+      const second = newContext();
+      await second.newTab();
+      await second.closeBrowserContext();
+
+      const archive = await fs.promises.readFile(recoveredTrace);
+      expect(stopCount).toBe(2);
+      expect(archive.subarray(0, 4)).toEqual(Buffer.from('PK\x03\x04'));
+      expect(archive.includes(Buffer.from('trace.trace'))).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+      await Context.disposeAll();
+      await browserContext?.close();
+      await browser?.close();
+      await fs.promises.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a real-browser regression through the server's `saveTrace` Context lifecycle
- force the first trace archive save to fail by placing its destination under a regular file
- verify a second session can start tracing and save a valid, nonempty ZIP containing `trace.trace`

## Stack

This test depends on the paired Playwright August 29 upgrade in #189, so this PR intentionally targets `monitor/playwright-mcp-recording-tools`. Merge #189 first, then retarget this PR to `main`.

The upstream fix restores future tracing after a failed save; it cannot recover the first failed archive, so this PR does not invent a server warning or context-replacement policy.

## Validation

- `npx vitest run tests/trace-recovery.test.ts` — test loads successfully; executable-guarded here because Chromium 1243 is unavailable
- `npm run lint`
- `npm run build`
- `npm run knip`
- `git diff --check`
- slop-check — clean
- verified August 29 is the first published Playwright build containing upstream trace recovery

The browser download was attempted with an extended timeout, but the CDN returned zero-byte/truncated archives and then reset the connection.

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trace collection recovery after a trace-saving failure, allowing subsequent tracing sessions to start and save successfully.

- **Tests**
  - Added browser-based coverage verifying trace recovery and confirming that successfully saved trace archives are valid and contain the expected trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->