### PR TITLE
fix: wait for HTTP event stream before heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-a
 
 #### HTTP Heartbeat
 
-When the server runs with `--port`, it sends MCP heartbeat pings for Streamable HTTP sessions. Set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to override the default `5000` ms timeout. Set it to `0` or any negative value to disable heartbeat pings for clients or proxies that do not answer server-initiated pings. A client that answers `ping` with a JSON-RPC "method not found" error (as clients on the MCP 2026-07-28 revision do) is treated as alive: the server stops heartbeating that session instead of closing it. Only an unanswered ping (timeout) or a transport failure closes the session.
+When the server runs with `--port`, it sends MCP heartbeat pings after a Streamable HTTP client opens the optional event stream. POST-only clients stay connected without heartbeat because server-initiated requests cannot reach them. Set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to override the default `5000` ms timeout, or to `0` or any negative value to disable heartbeat pings. A client that answers `ping` with a JSON-RPC "method not found" error is treated as alive: the server stops heartbeating that session instead of closing it. Only an unanswered ping (timeout) or a transport failure closes the session.
 
 #### Clients without the initialize handshake
 

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -23,6 +23,7 @@ import debug from 'debug';
 
 import { createMcpHandler, isInitializeRequest, isLegacyRequest, STDIO_DEFAULT_MAX_BUFFER_SIZE } from '@modelcontextprotocol/server';
 import { NodeStreamableHTTPServerTransport, toNodeHandler, toWebRequest } from '@modelcontextprotocol/node';
+import { ManualPromise } from './manualPromise.js';
 import * as mcpServer from './server.js';
 
 import type { NodeMcpRequestHandler } from '@modelcontextprotocol/node';
@@ -99,8 +100,10 @@ export async function installHttpTransport(httpServer: http.Server, serverBacken
 //   stateless mode.
 // ─────────────────────────────────────────────────────────────────────────────
 
+type StatefulSession = { transport: NodeStreamableHTTPServerTransport, eventStreamReady: ManualPromise<void> };
+
 class SessionStore {
-  private readonly _sessions = new Map<string, NodeStreamableHTTPServerTransport>();
+  private readonly _sessions = new Map<string, StatefulSession>();
   // The modern (2026-07-28) endpoint: one handler for the server lifetime,
   // serving each enveloped request with a fresh server + backend from the
   // factory — the same per-request idiom as the legacy stateless path, so the
@@ -148,13 +151,26 @@ class SessionStore {
   }
 
   private async _handleSessionRequest(sessionId: string, req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const transport = this._sessions.get(sessionId);
-    if (!transport) {
+    const session = this._sessions.get(sessionId);
+    if (!session) {
       res.statusCode = 404;
       res.end('Session not found');
       return;
     }
-    await transport.handleRequest(req, res);
+    if (req.method === 'GET' && req.headers.accept?.split(',').some(type => type.split(';')[0].trim().toLowerCase() === 'text/event-stream')) {
+      // The transport answers 200 on this GET only when it accepts it as the
+      // standalone event stream, and handleRequest resolves when that stream
+      // ends, not when it opens — so readiness has to be signalled at the
+      // header flush, and only for a stream that actually established.
+      const writeHead = res.writeHead.bind(res);
+      const resolveOnEstablished = (...args: Parameters<http.ServerResponse['writeHead']>) => {
+        if (args[0] === 200)
+          session.eventStreamReady.resolve();
+        return writeHead(...args);
+      };
+      res.writeHead = resolveOnEstablished as http.ServerResponse['writeHead'];
+    }
+    await session.transport.handleRequest(req, res);
   }
 
   // Peeks at the JSON-RPC body once to route it: modern envelope → the
@@ -235,12 +251,13 @@ class SessionStore {
   }
 
   private async _createSession(req: http.IncomingMessage, res: http.ServerResponse, parsedBody: unknown): Promise<void> {
+    const eventStreamReady = new ManualPromise<void>();
     const transport = new NodeStreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
         testDebug(`create http session: ${transport.sessionId}`);
-        this._sessions.set(sessionId, transport);
-        await mcpServer.connect(this._serverBackendFactory, transport, true);
+        this._sessions.set(sessionId, { transport, eventStreamReady });
+        await mcpServer.connect(this._serverBackendFactory, transport, true, eventStreamReady);
       }
     });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -82,8 +82,8 @@ export type ServerBackendFactory = ServerMetadata & {
   createStateless?: () => ServerBackend;
 };
 
-export async function connect(factory: ServerBackendFactory, transport: Transport, runHeartbeat: boolean) {
-  const server = createServer(factory.name, factory.version, factory.create(), runHeartbeat, factory);
+export async function connect(factory: ServerBackendFactory, transport: Transport, runHeartbeat: boolean, heartbeatReady: Promise<void> = Promise.resolve()) {
+  const server = createServer(factory.name, factory.version, factory.create(), runHeartbeat, factory, heartbeatReady);
   await server.connect(transport);
 }
 
@@ -92,7 +92,7 @@ export async function wrapInProcess(backend: ServerBackend): Promise<Transport> 
   return new InProcessTransport(server);
 }
 
-export function createServer(name: string, version: string, backend: ServerBackend, runHeartbeat: boolean, metadata?: ServerMetadata): Server {
+export function createServer(name: string, version: string, backend: ServerBackend, runHeartbeat: boolean, metadata?: ServerMetadata, heartbeatReady: Promise<void> = Promise.resolve()): Server {
   const server = new Server({ name, version, title: metadata?.title }, {
     capabilities: {
       tools: {
@@ -153,7 +153,7 @@ export function createServer(name: string, version: string, backend: ServerBacke
 
     if (runHeartbeat && !heartbeatRunning) {
       heartbeatRunning = true;
-      startHeartbeat(server);
+      void heartbeatReady.then(() => startHeartbeat(server)).catch(errorsDebug);
     }
 
     const requestContext: CallToolRequestContext = {

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -85,7 +85,7 @@ describe('mcp http transport hardening', () => {
     return { server, port: address.port };
   }
 
-  async function sendRequest(port: number, options?: { method?: string, path?: string, hostHeader?: string, origin?: string, sessionId?: string, accept?: string, body?: string, contentLength?: number }) {
+  async function sendRequest(port: number, options?: { method?: string, path?: string, hostHeader?: string, origin?: string, sessionId?: string, accept?: string, protocolVersion?: string, body?: string, contentLength?: number }) {
     const response = await new Promise<{ statusCode: number, headers: http.IncomingHttpHeaders, body: string }>((resolve, reject) => {
       const req = http.request({
         host: '127.0.0.1',
@@ -97,6 +97,7 @@ describe('mcp http transport hardening', () => {
           ...(options?.origin ? { origin: options.origin } : {}),
           ...(options?.sessionId ? { 'mcp-session-id': options.sessionId } : {}),
           ...(options?.accept ? { accept: options.accept } : {}),
+          ...(options?.protocolVersion ? { 'mcp-protocol-version': options.protocolVersion } : {}),
           ...(options?.body ? { 'content-type': 'application/json' } : {}),
           ...(options?.contentLength !== undefined ? { 'content-length': String(options.contentLength) } : {}),
         },
@@ -729,7 +730,7 @@ describe('mcp http transport hardening', () => {
   // fetch them even from a client that still advertises the capability, and
   // the first tool call must be served without waiting for the standalone
   // event stream (the old listRoots round-trip needed it). Refs #169.
-  it('never requests roots and serves tools without the event stream', async () => {
+  it('keeps POST-only sessions alive without the event stream or roots', async () => {
     const callTool = vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
     const initialize = vi.fn(async () => undefined);
     const { port } = await startServer({
@@ -748,9 +749,11 @@ describe('mcp http transport hardening', () => {
     // listRoots could not be delivered, so a tool call only succeeds if the
     // server no longer performs any.
     const noStreamFetch: typeof fetch = async (input, init) => {
-      if (init?.method === 'GET') {
+      const request = input instanceof Request ? input : undefined;
+      const method = init?.method ?? request?.method;
+      if (method === 'GET') {
         return await new Promise<Response>((_resolve, reject) => {
-          init.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          (init?.signal ?? request?.signal)?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
         });
       }
       return fetch(input, init);
@@ -759,6 +762,8 @@ describe('mcp http transport hardening', () => {
     client.setRequestHandler('roots/list', listRoots);
     client.setRequestHandler('ping', () => ({}));
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
+    const previousPingTimeout = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+    process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = '20';
 
     try {
       await client.connect(transport);
@@ -768,11 +773,69 @@ describe('mcp http transport hardening', () => {
       expect(invalidGet.statusCode).toBe(406);
 
       await client.callTool({ name: 'probe', arguments: {} });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      await client.callTool({ name: 'probe', arguments: {} });
 
       expect(listRoots).not.toHaveBeenCalled();
       expect(initialize).toHaveBeenCalledTimes(1);
-      expect(callTool).toHaveBeenCalledTimes(1);
+      expect(callTool).toHaveBeenCalledTimes(2);
     } finally {
+      if (previousPingTimeout === undefined)
+        delete process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+      else
+        process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = previousPingTimeout;
+      await client.close();
+    }
+  });
+
+  it('does not arm the heartbeat off a rejected event-stream GET', async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
+    const { port } = await startServer({
+      ...testBackendFactory,
+      create: () => ({
+        async initialize() {},
+        async listTools() {
+          return [];
+        },
+        callTool,
+      }),
+    });
+
+    const noStreamFetch: typeof fetch = async (input, init) => {
+      const request = input instanceof Request ? input : undefined;
+      const method = init?.method ?? request?.method;
+      if (method === 'GET') {
+        return await new Promise<Response>((_resolve, reject) => {
+          (init?.signal ?? request?.signal)?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      }
+      return fetch(input, init);
+    };
+    const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
+    client.setRequestHandler('ping', () => ({}));
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), { fetch: noStreamFetch });
+    const previousPingTimeout = process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+    process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = '20';
+
+    try {
+      await client.connect(transport);
+
+      const rejectedStream = await sendRequest(port, {
+        sessionId: transport.sessionId,
+        accept: 'text/event-stream',
+        protocolVersion: '0.0.0',
+      });
+      expect(rejectedStream.statusCode).toBe(400);
+
+      await client.callTool({ name: 'probe', arguments: {} });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      await client.callTool({ name: 'probe', arguments: {} });
+      expect(callTool).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousPingTimeout === undefined)
+        delete process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS;
+      else
+        process.env.PLAYWRIGHT_MCP_PING_TIMEOUT_MS = previousPingTimeout;
       await client.close();
     }
   });


### PR DESCRIPTION
## Upstream change

Playwright MCP v0.0.80 includes microsoft/playwright#42189 and commit 43a9121961cb7dacd753133a6b5765bc00289d53. The HTTP heartbeat now waits until the client opens its event stream.

- Release: https://github.com/microsoft/playwright-mcp/releases/tag/v0.0.80
- Upstream PR: https://github.com/microsoft/playwright/pull/42189
- Upstream commit: https://github.com/microsoft/playwright/commit/43a9121961cb7dacd753133a6b5765bc00289d53

## Why it matters here

This server started heartbeat on the first stateful HTTP tool call. A POST-only client cannot receive the server-initiated ping, so the server could close a healthy session after the ping timeout.

## Fix

- Wait for a successful standalone event-stream response before starting heartbeat.
- Keep POST-only sessions alive without heartbeat.
- Do not arm heartbeat for a rejected event-stream GET.
- Document the behavior.

## Validation

Passed:
- npm test -- tests/mcp-http.test.ts tests/mcp-server-errors.test.ts
- npm run lint
- npm run build
- npm run knip
- git diff --check
- mutation check: inverting the successful-stream status gate made the rejected-stream regression fail with Session not found

The full npm test run reaches 920 passing tests, 27 skipped, and 31 failures already present outside this diff: 3 recorder tests read a missing config.snapshot fixture, and 28 browser-backed screen-reader tests cannot launch because the current Playwright browser is not installed in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP sessions using POST requests remain connected without requiring an event stream.
  - Heartbeats now begin only after the optional event stream is successfully established.
  - Rejected or invalid event-stream requests no longer incorrectly activate heartbeats.
  - Heartbeat timeout and disable behavior are clarified in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->