### PR TITLE
fix: disable bundled Chromium sandbox on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Create a `config.json` file with the following options:
 - `browser.browserName`: Browser to use (`chromium`, `firefox`, `webkit`)
 - `browser.launchOptions.headless`: Run browser in headless mode (default: `true` on Linux without display, `false` otherwise)
 - `browser.launchOptions.channel`: Browser channel (`chrome`, `chrome-beta`, `msedge`, etc.)
-- `browser.launchOptions.chromiumSandbox`: Defaults to `false` for downloaded Chromium builds on Linux because they lack the setuid sandbox helper, and `true` otherwise. Remote endpoints choose on the remote host. An explicit config or `PLAYWRIGHT_MCP_SANDBOX` value wins; `--no-sandbox` always disables it.
+- `browser.launchOptions.chromiumSandbox`: Defaults to `false` for downloaded Chromium builds on Linux because they lack the setuid sandbox helper, and `true` otherwise. Remote and VS Code endpoints choose on the remote host. An explicit config or `PLAYWRIGHT_MCP_SANDBOX` value wins; `--no-sandbox` always disables it.
 - `browser.cdpEndpoint`: Attach to an already-running Chromium-family app with CDP enabled
 - `browser.cdpHeaders`: Map of HTTP headers to send with the CDP connect request, e.g. `{ "Authorization": "Bearer <token>" }`, for endpoints that require header-based authentication
 - `browser.cdpTimeout`: Maximum time in milliseconds to wait when connecting to the CDP endpoint (default: `30000`)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Create a `config.json` file with the following options:
 - `browser.browserName`: Browser to use (`chromium`, `firefox`, `webkit`)
 - `browser.launchOptions.headless`: Run browser in headless mode (default: `true` on Linux without display, `false` otherwise)
 - `browser.launchOptions.channel`: Browser channel (`chrome`, `chrome-beta`, `msedge`, etc.)
-- `browser.launchOptions.chromiumSandbox`: Defaults to `false` for downloaded Chromium builds on Linux because they lack the setuid sandbox helper, and `true` otherwise. An explicit config or `PLAYWRIGHT_MCP_SANDBOX` value wins; `--no-sandbox` always disables it.
+- `browser.launchOptions.chromiumSandbox`: Defaults to `false` for downloaded Chromium builds on Linux because they lack the setuid sandbox helper, and `true` otherwise. Remote endpoints choose on the remote host. An explicit config or `PLAYWRIGHT_MCP_SANDBOX` value wins; `--no-sandbox` always disables it.
 - `browser.cdpEndpoint`: Attach to an already-running Chromium-family app with CDP enabled
 - `browser.cdpHeaders`: Map of HTTP headers to send with the CDP connect request, e.g. `{ "Authorization": "Bearer <token>" }`, for endpoints that require header-based authentication
 - `browser.cdpTimeout`: Maximum time in milliseconds to wait when connecting to the CDP endpoint (default: `30000`)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Create a `config.json` file with the following options:
 - `browser.browserName`: Browser to use (`chromium`, `firefox`, `webkit`)
 - `browser.launchOptions.headless`: Run browser in headless mode (default: `true` on Linux without display, `false` otherwise)
 - `browser.launchOptions.channel`: Browser channel (`chrome`, `chrome-beta`, `msedge`, etc.)
+- `browser.launchOptions.chromiumSandbox`: Defaults to `false` for downloaded Chromium builds on Linux because they lack the setuid sandbox helper, and `true` otherwise. An explicit config or `PLAYWRIGHT_MCP_SANDBOX` value wins; `--no-sandbox` always disables it.
 - `browser.cdpEndpoint`: Attach to an already-running Chromium-family app with CDP enabled
 - `browser.cdpHeaders`: Map of HTTP headers to send with the CDP connect request, e.g. `{ "Authorization": "Bearer <token>" }`, for endpoints that require header-based authentication
 - `browser.cdpTimeout`: Maximum time in milliseconds to wait when connecting to the CDP endpoint (default: `30000`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,6 @@ const defaultConfig: FullConfig = {
     launchOptions: {
       channel: 'chrome',
       headless: os.platform() === 'linux' && !process.env.DISPLAY,
-      chromiumSandbox: true,
     },
     contextOptions: {
       viewport: null,
@@ -110,7 +109,7 @@ export async function resolveConfig(config: Config): Promise<FullConfig> {
 export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConfig> {
   const configInFile = await loadConfig(cliOptions.config);
   const envOptions = cliOptionsFromEnv();
-  const envOverrides = configFromCLIOptions(envOptions);
+  const envOverrides = configFromCLIOptions(envOptions, true);
   const cliOverrides = configFromCLIOptions(cliOptions);
   const result = mergeCLIConfigSources(configInFile, envOverrides, cliOverrides);
   return validateResolvedConfig(applyMobileConfig(result, configInFile, envOverrides, cliOverrides, envOptions, cliOptions));
@@ -128,6 +127,11 @@ export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConf
 function validateResolvedConfig(config: FullConfig): FullConfig {
   if (config.outputDir !== undefined && config.outputDir !== null && !String(config.outputDir).trim())
     throw new Error('outputDir must not be blank: provide a directory path, or omit the option to use a temp directory.');
+  if (config.browser.browserName === 'chromium' && config.browser.launchOptions.chromiumSandbox === undefined) {
+    const { channel } = config.browser.launchOptions;
+    config.browser.launchOptions.chromiumSandbox = os.platform() !== 'linux'
+      || (channel !== undefined && channel !== 'chromium' && channel !== 'chrome-for-testing');
+  }
   return config;
 }
 
@@ -168,7 +172,7 @@ function applyMobileConfig(resolved: FullConfig, configInFile: Config, envOverri
   return mergeCLIConfigSources(configInFile, envOverrides, cliOverrides, mobileOverride, source);
 }
 
-function configFromCLIOptions(cliOptions: CLIOptions): Config {
+function configFromCLIOptions(cliOptions: CLIOptions, sandboxTrueIsExplicit = false): Config {
   let browserName: 'chromium' | 'firefox' | 'webkit' | undefined;
   let channel: string | undefined;
   switch (cliOptions.browser) {
@@ -199,9 +203,10 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config {
     headless: cliOptions.headless,
   };
 
-  // --no-sandbox was passed, disable the sandbox
-  if (cliOptions.sandbox === false)
-    launchOptions.chromiumSandbox = false;
+  // Commander reports true when --no-sandbox is omitted, while true from the
+  // environment is explicit and must override the platform default.
+  if (cliOptions.sandbox === false || (sandboxTrueIsExplicit && cliOptions.sandbox === true))
+    launchOptions.chromiumSandbox = cliOptions.sandbox;
 
   if (cliOptions.proxyServer) {
     launchOptions.proxy = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,7 @@ type BrowserUserConfig = NonNullable<Config['browser']>;
 export type FullConfig = Config & {
     browser: Omit<BrowserUserConfig, 'browserName'> & {
         browserName: 'chromium' | 'firefox' | 'webkit';
+        chromiumSandboxDefaulted?: boolean;
         launchOptions: NonNullable<BrowserUserConfig['launchOptions']>;
         contextOptions: NonNullable<BrowserUserConfig['contextOptions']>;
     },
@@ -132,6 +133,7 @@ function validateResolvedConfig(config: FullConfig): FullConfig {
     config.browser.launchOptions.chromiumSandbox = os.platform() !== 'linux'
       || executablePath !== undefined
       || (channel !== undefined && channel !== 'chromium' && channel !== 'chrome-for-testing');
+    config.browser.chromiumSandboxDefaulted = true;
   }
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,9 +127,10 @@ export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConf
 function validateResolvedConfig(config: FullConfig): FullConfig {
   if (config.outputDir !== undefined && config.outputDir !== null && !String(config.outputDir).trim())
     throw new Error('outputDir must not be blank: provide a directory path, or omit the option to use a temp directory.');
-  if (config.browser.browserName === 'chromium' && config.browser.launchOptions.chromiumSandbox === undefined) {
-    const { channel } = config.browser.launchOptions;
+  if (config.browser.browserName === 'chromium' && !config.browser.remoteEndpoint && config.browser.launchOptions.chromiumSandbox === undefined) {
+    const { channel, executablePath } = config.browser.launchOptions;
     config.browser.launchOptions.chromiumSandbox = os.platform() !== 'linux'
+      || executablePath !== undefined
       || (channel !== undefined && channel !== 'chromium' && channel !== 'chrome-for-testing');
   }
   return config;

--- a/src/vscode/browserContextFactory.ts
+++ b/src/vscode/browserContextFactory.ts
@@ -45,7 +45,9 @@ export class VSCodeBrowserContextFactory implements BrowserContextFactory {
     // already refuses to do. Checked before connecting, so the contradiction
     // fails fast without ever reaching the browser.
     assertStorageStateDoesNotResetUserProfile(this._config, vscodeProfileConflictRemedy);
-    let launchOptions: any = this._config.browser.launchOptions;
+    let launchOptions: Record<string, unknown> = { ...this._config.browser.launchOptions };
+    if (this._config.browser.chromiumSandboxDefaulted)
+      delete launchOptions.chromiumSandbox;
     if (this._config.browser.userDataDir) {
       launchOptions = {
         ...launchOptions,

--- a/tests/browserContextFactory.test.ts
+++ b/tests/browserContextFactory.test.ts
@@ -2445,6 +2445,23 @@ describe('VSCodeBrowserContextFactory', () => {
     return { chromium: { connect: vi.fn().mockResolvedValue(browser) } } as any;
   }
 
+  it('lets the VS Code endpoint choose the sandbox default but forwards explicit values', async () => {
+    const browser = createMockBrowser(createMockBrowserContext());
+    const vscodePlaywright = createVSCodePlaywright(browser);
+
+    for (const [config, expected] of [
+      [await resolveConfig({}), undefined],
+      [await resolveConfig({ browser: { launchOptions: { chromiumSandbox: false } } }), false],
+      [await resolveConfig({ browser: { launchOptions: { chromiumSandbox: true } } }), true],
+    ] as const) {
+      const factory = new VSCodeBrowserContextFactory(config, vscodePlaywright, 'ws://127.0.0.1:1234/');
+      await factory.createContext({ name: 'vitest', version: '1.0.0' }, new AbortController().signal);
+      const endpoint = new URL(vscodePlaywright.chromium.connect.mock.calls.at(-1)[0]);
+      const launchOptions = JSON.parse(endpoint.searchParams.get('launch-options')!);
+      expect(launchOptions.chromiumSandbox).toBe(expected);
+    }
+  });
+
   it('rejects a storage state aimed at a user-supplied profile before connecting', async () => {
     // The configured --user-data-dir is forwarded to the extension's launch,
     // so the reused context lives inside the user's own profile — the same

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,7 +17,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { resolveConfig, resolveCLIConfig, outputFile, parseCdpHeaders, resolveOutputDir } from '../src/config.js';
 import type { Config } from '../config.js';
 
@@ -108,6 +108,31 @@ describe('Config', () => {
       expect(config.browser.browserName).toBe('webkit');
       expect(config.timeouts.navigationTimeout).toBe(60000);
       expect(config.saveTrace).toBe(false);
+    });
+  });
+
+  describe('sandbox defaults', () => {
+    const savedSandbox = process.env.PLAYWRIGHT_MCP_SANDBOX;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (savedSandbox === undefined)
+        delete process.env.PLAYWRIGHT_MCP_SANDBOX;
+      else
+        process.env.PLAYWRIGHT_MCP_SANDBOX = savedSandbox;
+    });
+
+    it('disables only the default sandbox for bundled Chromium on Linux', async () => {
+      vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+      expect((await resolveCLIConfig({ browser: 'chromium' })).browser.launchOptions.chromiumSandbox).toBe(false);
+      expect((await resolveCLIConfig({ browser: 'chrome' })).browser.launchOptions.chromiumSandbox).toBe(true);
+      expect((await resolveConfig({
+        browser: { launchOptions: { channel: 'chromium', chromiumSandbox: true } },
+      })).browser.launchOptions.chromiumSandbox).toBe(true);
+
+      process.env.PLAYWRIGHT_MCP_SANDBOX = 'true';
+      expect((await resolveCLIConfig({ browser: 'chromium' })).browser.launchOptions.chromiumSandbox).toBe(true);
     });
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,7 +17,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { resolveConfig, resolveCLIConfig, outputFile, parseCdpHeaders, resolveOutputDir } from '../src/config.js';
 import type { Config } from '../config.js';
 
@@ -114,6 +114,10 @@ describe('Config', () => {
   describe('sandbox defaults', () => {
     const savedSandbox = process.env.PLAYWRIGHT_MCP_SANDBOX;
 
+    beforeEach(() => {
+      delete process.env.PLAYWRIGHT_MCP_SANDBOX;
+    });
+
     afterEach(() => {
       vi.restoreAllMocks();
       if (savedSandbox === undefined)
@@ -127,6 +131,10 @@ describe('Config', () => {
 
       expect((await resolveCLIConfig({ browser: 'chromium' })).browser.launchOptions.chromiumSandbox).toBe(false);
       expect((await resolveCLIConfig({ browser: 'chrome' })).browser.launchOptions.chromiumSandbox).toBe(true);
+      expect((await resolveCLIConfig({ browser: 'chromium', executablePath: '/usr/bin/chromium' })).browser.launchOptions.chromiumSandbox).toBe(true);
+      expect((await resolveConfig({
+        browser: { browserName: 'chromium', remoteEndpoint: 'ws://remote.example', launchOptions: { channel: 'chromium' } },
+      })).browser.launchOptions.chromiumSandbox).toBeUndefined();
       expect((await resolveConfig({
         browser: { launchOptions: { channel: 'chromium', chromiumSandbox: true } },
       })).browser.launchOptions.chromiumSandbox).toBe(true);


### PR DESCRIPTION
## Summary

- mirror https://github.com/microsoft/playwright/pull/42490 for Linux downloaded Chromium builds
- keep installed Chrome and Edge channels sandboxed by default
- preserve explicit config, environment, and --no-sandbox values
- document the default and add focused coverage

## Why

Downloaded Chromium builds do not include the Linux setuid sandbox helper. The current --browser chromium path forces the sandbox on and can fail at launch with No usable sandbox.

## Validation

- npm test -- tests/config.test.ts
- npm run lint
- npm run build
- npm run knip
- mutation check: breaking the Chromium channel branch makes the focused test fail
- npm test: 921 passed, 27 skipped; 31 existing failures remain (28 need the missing Playwright browser executable, 3 recorder fixtures lack snapshot config)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration documentation for Chromium sandbox behavior, including platform defaults and override precedence.
  * VS Code and remote browser endpoints now select sandbox defaults based on the remote host environment.

* **Bug Fixes**
  * Chromium sandbox settings now apply platform-specific defaults on Linux.
  * Explicit configuration and environment-based settings continue to override defaults appropriately.
  * Default sandbox settings are omitted from VS Code launch options unless explicitly configured.

* **Tests**
  * Added coverage for Linux defaults, alternate browser channels, explicit configuration, environment overrides, and VS Code launch options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->