### PR TITLE
fix: resolve open scanner issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Create a `config.json` file with the following options:
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
-Caller-supplied screenshot, PDF, and audit report filenames use a no-clobber policy: an existing file causes the tool call to fail instead of being overwritten. Windows-reserved basenames and names ending in a dot or space are rejected on every platform so configured names behave consistently across hosts.
+Caller-supplied screenshot, PDF, scan-page-matrix, and audit report filenames use a no-clobber policy: an existing file causes the tool call to fail instead of being overwritten. Windows-reserved basenames and names ending in a dot or space are rejected on every platform so configured names behave consistently across hosts.
 
 Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after every action so delayed DOM-only updates are included in the response; a short observation window also catches scheduled requests and waits for them before that delay.
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Create a `config.json` file with the following options:
 
 CLI equivalents are also available: `--cdp-launch-command`, `--cdp-launch-args`, `--cdp-launch-cwd`, `--cdp-launch-port`, `--cdp-launch-startup-timeout`, `--cdp-endpoint`, `--cdp-header` (repeat for multiple headers, e.g. `--cdp-header "Authorization: Bearer <token>"`), and `--cdp-timeout`. The CDP headers and timeout can also be set via the `PLAYWRIGHT_MCP_CDP_HEADERS` (one `Name: Value` entry per line) and `PLAYWRIGHT_MCP_CDP_TIMEOUT` environment variables.
 
+Caller-supplied screenshot, PDF, and audit report filenames use a no-clobber policy: an existing file causes the tool call to fail instead of being overwritten. Windows-reserved basenames and names ending in a dot or space are rejected on every platform so configured names behave consistently across hosts.
+
 Use `--timeout-settle` or `PLAYWRIGHT_MCP_TIMEOUT_SETTLE` to override the post-action settle delay. It applies after every action so delayed DOM-only updates are included in the response; a short observation window also catches scheduled requests and waits for them before that delay.
 
 #### HTTP Heartbeat
@@ -588,6 +590,10 @@ Close the page.
 #### `browser_resize`
 Resize the browser window.
 - Parameters: `width`, `height`
+
+#### `browser_emulate_media`
+Emulate CSS media features on the current page without resetting omitted features.
+- Parameters: `colorScheme` (`light` or `dark`), `reducedMotion` (`reduce` or `no-preference`), `forcedColors` (`active` or `none`), `contrast` (`more` or `no-preference`), and `media` (`screen` or `print`); provide at least one.
 
 ### Tab Management
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -195,6 +195,7 @@ These tools are always available and work in the interactive REPL.
 | `browser_navigate_back` | Go back to previous page |
 | `browser_close` | Close the page |
 | `browser_resize` | Resize window: `{"width": 1280, "height": 720}` |
+| `browser_emulate_media` | Emulate color scheme, reduced motion, forced colors, contrast, or print/screen media |
 | `browser_snapshot` | Capture accessibility snapshot; pass `{"boxes": true}` to include element bounds |
 | `browser_take_screenshot` | Take screenshot (png/jpeg/webp, fullPage option) |
 | `browser_wait_for` | Wait for text/time: `{"text": "loaded"}` or `{"time": 5}` |

--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -244,6 +244,11 @@ export class BrowserServerBackend implements ServerBackend {
         sessionLog?.logResponse(response);
       }
     } catch (error: any) {
+      try {
+        await response.cleanupFilesOnError();
+      } catch (cleanupError) {
+        logUnhandledError(cleanupError);
+      }
       response.addError(String(error));
     } finally {
       endToolCall();

--- a/src/config.ts
+++ b/src/config.ts
@@ -376,11 +376,24 @@ export function resolveOutputDir(config: FullConfig): string {
   return outputDir;
 }
 
-export async function outputFile(config: FullConfig, name: string): Promise<string> {
+export async function outputFile(config: FullConfig, name: string, exclusive = false): Promise<string> {
+  const fileName = sanitizeForFilePath(name);
+  if (!fileName || fileName === '.' || fileName === '..' || /[. ]$/.test(name) || /[. ]$/.test(fileName) || /^(?:con|prn|aux|nul|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])(?:\.|$)/i.test(fileName))
+    throw new Error(`Invalid output filename "${name}": use a portable, non-reserved file name.`);
   const outputDir = resolveOutputDir(config);
   await fs.promises.mkdir(outputDir, { recursive: true });
-  const fileName = sanitizeForFilePath(name);
-  return path.join(outputDir, fileName);
+  const filePath = path.join(outputDir, fileName);
+  if (!exclusive)
+    return filePath;
+  try {
+    const handle = await fs.promises.open(filePath, 'wx');
+    await handle.close();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST')
+      throw new Error(`Output file already exists: ${filePath}. Choose a different filename.`, { cause: error });
+    throw error;
+  }
+  return filePath;
 }
 
 function pickDefined<T extends object>(obj: T | undefined): Partial<T> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -377,7 +377,7 @@ export function resolveOutputDir(config: FullConfig): string {
 }
 
 export async function outputFile(config: FullConfig, name: string, exclusive = false): Promise<string> {
-  const fileName = sanitizeForFilePath(name);
+  const fileName = name.trim() ? sanitizeForFilePath(name) : '';
   if (!fileName || fileName === '.' || fileName === '..' || /[. ]$/.test(name) || /[. ]$/.test(fileName) || /^(?:con|prn|aux|nul|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])(?:\.|$)/i.test(fileName))
     throw new Error(`Invalid output filename "${name}": use a portable, non-reserved file name.`);
   const outputDir = resolveOutputDir(config);

--- a/src/context.ts
+++ b/src/context.ts
@@ -34,21 +34,24 @@ const testDebug = debug('pw:mcp:test');
 const recorderBufferMs = 500;
 const recorderControlTools = new Set(['browser_start_recording', 'browser_stop_recording']);
 const expectPrelude = "const { expect } = require('playwright/test');";
-const pageCloseAttemptTimeoutMs = 1000;
 
 /**
  * Chromium can acknowledge Target.closeTarget while a racing navigation keeps
  * the target alive. Retry the public close call instead of letting one tool or
  * an entire crawl wait forever.
  */
-async function closePage(page: playwright.Page, attemptTimeoutMs = pageCloseAttemptTimeoutMs): Promise<void> {
+async function closePage(page: playwright.Page, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   for (let attempt = 0; attempt < 3; attempt++) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0)
+      break;
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
         page.close(),
-        new Promise<void>(resolve => {
-          timer = setTimeout(resolve, attemptTimeoutMs);
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms while closing the page.`)), remaining);
           timer.unref?.();
         }),
       ]);
@@ -62,7 +65,7 @@ async function closePage(page: playwright.Page, attemptTimeoutMs = pageCloseAtte
       clearTimeout(timer);
     }
   }
-  throw new Error('Timed out while closing the page after 3 attempts.');
+  throw new Error(`Failed to close the page after 3 attempts within ${timeoutMs}ms.`);
 }
 
 class ContextRegistry {
@@ -368,7 +371,7 @@ export class Context {
     if (!tab)
       throw new Error(`Tab ${index} not found`);
     const url = tab.page.url();
-    await closePage(tab.page);
+    await closePage(tab.page, tab.operationTimeout());
     return url;
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,14 +45,14 @@ async function closePage(page: playwright.Page, attemptTimeoutMs = pageCloseAtte
   for (let attempt = 0; attempt < 3; attempt++) {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const closed = await Promise.race([
-        page.close().then(() => true),
-        new Promise<false>(resolve => {
-          timer = setTimeout(() => resolve(false), attemptTimeoutMs);
+      await Promise.race([
+        page.close(),
+        new Promise<void>(resolve => {
+          timer = setTimeout(resolve, attemptTimeoutMs);
           timer.unref?.();
         }),
       ]);
-      if (closed || page.isClosed())
+      if (page.isClosed())
         return;
     } catch (error) {
       if (page.isClosed())

--- a/src/context.ts
+++ b/src/context.ts
@@ -34,6 +34,36 @@ const testDebug = debug('pw:mcp:test');
 const recorderBufferMs = 500;
 const recorderControlTools = new Set(['browser_start_recording', 'browser_stop_recording']);
 const expectPrelude = "const { expect } = require('playwright/test');";
+const pageCloseAttemptTimeoutMs = 1000;
+
+/**
+ * Chromium can acknowledge Target.closeTarget while a racing navigation keeps
+ * the target alive. Retry the public close call instead of letting one tool or
+ * an entire crawl wait forever.
+ */
+async function closePage(page: playwright.Page, attemptTimeoutMs = pageCloseAttemptTimeoutMs): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const closed = await Promise.race([
+        page.close().then(() => true),
+        new Promise<false>(resolve => {
+          timer = setTimeout(() => resolve(false), attemptTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+      if (closed || page.isClosed())
+        return;
+    } catch (error) {
+      if (page.isClosed())
+        return;
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error('Timed out while closing the page after 3 attempts.');
+}
 
 class ContextRegistry {
   private readonly _contexts = new Set<Context>();
@@ -338,12 +368,12 @@ export class Context {
     if (!tab)
       throw new Error(`Tab ${index} not found`);
     const url = tab.page.url();
-    await tab.page.close();
+    await closePage(tab.page);
     return url;
   }
 
-  async outputFile(name: string): Promise<string> {
-    return outputFile(this.config, name);
+  async outputFile(name: string, exclusive = false): Promise<string> {
+    return outputFile(this.config, name, exclusive);
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -34,6 +34,21 @@ const testDebug = debug('pw:mcp:test');
 const recorderBufferMs = 500;
 const recorderControlTools = new Set(['browser_start_recording', 'browser_stop_recording']);
 const expectPrelude = "const { expect } = require('playwright/test');";
+const pendingPageCloses = new WeakMap<playwright.Page, Promise<void>>();
+
+function pendingPageClose(page: playwright.Page): Promise<void> {
+  const pending = pendingPageCloses.get(page);
+  if (pending)
+    return pending;
+  const close = page.close();
+  pendingPageCloses.set(page, close);
+  const clear = () => {
+    if (pendingPageCloses.get(page) === close)
+      pendingPageCloses.delete(page);
+  };
+  void close.then(clear, clear);
+  return close;
+}
 
 /**
  * Chromium can acknowledge Target.closeTarget while a racing navigation keeps
@@ -49,7 +64,7 @@ async function closePage(page: playwright.Page, timeoutMs: number): Promise<void
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
-        page.close(),
+        pendingPageClose(page),
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms while closing the page.`)), remaining);
           timer.unref?.();

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -22,14 +22,23 @@ export type ToolSchema<Input extends z.Schema> = {
   title: string;
   description: string;
   inputSchema: Input;
-  // 'stateChanging' is an additive update: it creates state a retry would
-  // duplicate (readOnlyHint false) without destroying anything
-  // (destructiveHint false) — e.g. browser_session_open, which mints a new
-  // live session and bearer handle on every call.
+  // State-changing tools default to non-idempotent; convergent setters can
+  // explicitly opt into safe retries.
   type: 'readOnly' | 'stateChanging' | 'destructive';
+  idempotent?: boolean;
 };
 
 export function toMcpTool(tool: ToolSchema<any>): mcpServer.Tool {
+  const annotations: NonNullable<mcpServer.Tool['annotations']> = {
+    title: tool.title,
+    readOnlyHint: tool.type === 'readOnly',
+    destructiveHint: tool.type === 'destructive',
+    openWorldHint: true,
+  };
+  if (tool.idempotent !== undefined)
+    annotations.idempotentHint = tool.idempotent;
+  else if (tool.type === 'stateChanging')
+    annotations.idempotentHint = false;
   return {
     name: tool.name,
     // Top-level title takes precedence over annotations.title on spec
@@ -37,15 +46,7 @@ export function toMcpTool(tool: ToolSchema<any>): mcpServer.Tool {
     title: tool.title,
     description: tool.description,
     inputSchema: z.toJSONSchema(tool.inputSchema) as mcpServer.Tool['inputSchema'],
-    annotations: {
-      title: tool.title,
-      readOnlyHint: tool.type === 'readOnly',
-      destructiveHint: tool.type === 'destructive',
-      // stateChanging tools are non-idempotent by nature (each call creates
-      // fresh state), so clients must not silently retry them.
-      ...(tool.type === 'stateChanging' ? { idempotentHint: false } : {}),
-      openWorldHint: true,
-    },
+    annotations,
   };
 }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import debug from 'debug';
@@ -48,6 +49,7 @@ export class Response {
   private _tabSnapshot: TabSnapshot | undefined;
   private _requestContext: CallToolRequestContext | undefined;
   private _structuredContent: Record<string, unknown> | undefined;
+  private _filesToDeleteOnError = new Set<string>();
 
   readonly toolName: string;
   readonly toolArgs: Record<string, any>;
@@ -121,6 +123,16 @@ export class Response {
       description: options?.description,
       mimeType: options?.mimeType,
     });
+  }
+
+  deleteFileOnError(filePath: string) {
+    this._filesToDeleteOnError.add(filePath);
+  }
+
+  async cleanupFilesOnError() {
+    const files = [...this._filesToDeleteOnError];
+    this._filesToDeleteOnError.clear();
+    await Promise.all(files.map(file => fs.promises.rm(file, { force: true })));
   }
 
   resourceLinks() {

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -165,7 +165,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     // default artifact names carry goes in before the extension, keeping the
     // suggested name as the recognizable part; responses print the suggested
     // name next to the saved path, so the file stays attributable.
-    const suggested = download.suggestedFilename() || 'download';
+    const suggested = download.suggestedFilename().replace(/[. ]+$/, '') || 'download';
     const separator = suggested.lastIndexOf('.');
     let base = separator > 0 ? suggested.slice(0, separator) : suggested;
     let extension = separator > 0 ? suggested.slice(separator) : '';

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -248,6 +248,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this.page.setDefaultTimeout(timeout);
   }
 
+  operationTimeout(): number {
+    return this._defaultTimeout > 0 ? this._defaultTimeout : 5000;
+  }
+
   isCurrentTab(): boolean {
     return this === this.context.currentTab();
   }
@@ -369,7 +373,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _pageStateTimeoutMs(): number {
-    return this._defaultTimeout > 0 ? this._defaultTimeout : 5000;
+    return this.operationTimeout();
   }
 
   private async _withPageStateTimeout<T>(promise: Promise<T>, description: string, timeoutMs = this._pageStateTimeoutMs()): Promise<T> {

--- a/src/tools/auditKeyboard.ts
+++ b/src/tools/auditKeyboard.ts
@@ -374,6 +374,11 @@ const auditKeyboard = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
+    const { reportFile, ...auditOptions } = params;
+    const reportFileName = reportFile ?? `audit-keyboard-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, reportFile !== undefined);
+    if (reportFile !== undefined)
+      response.deleteFileOnError(reportPath);
     const getActiveElementInfo = async (): Promise<FocusPoint> => {
       return await tab.page.evaluate(() => {
         const current = document.activeElement as HTMLElement | null;
@@ -576,7 +581,6 @@ const auditKeyboard = defineTabTool({
       return fileName;
     };
 
-    const { reportFile, ...auditOptions } = params;
     const result = await runKeyboardFocusAudit(auditOptions, {
       pressKey: async key => {
         await tab.waitForCompletion(async () => {
@@ -608,8 +612,6 @@ const auditKeyboard = defineTabTool({
       ...result,
     };
 
-    const reportFileName = reportFile ?? `audit-keyboard-${safeIsoTimestampForFileName()}.json`;
-    const reportPath = await tab.context.outputFile(reportFileName, reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-keyboard-report',

--- a/src/tools/auditKeyboard.ts
+++ b/src/tools/auditKeyboard.ts
@@ -608,8 +608,8 @@ const auditKeyboard = defineTabTool({
       ...result,
     };
 
-    const reportFileName = sanitizeForFilePath(reportFile ?? `audit-keyboard-${safeIsoTimestampForFileName()}.json`);
-    const reportPath = await tab.context.outputFile(reportFileName);
+    const reportFileName = reportFile ?? `audit-keyboard-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-keyboard-report',

--- a/src/tools/auditScreenReader.ts
+++ b/src/tools/auditScreenReader.ts
@@ -858,6 +858,10 @@ const auditScreenReader = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
+    const reportFileName = params.reportFile ?? `audit-screen-reader-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
+    if (params.reportFile !== undefined)
+      response.deleteFileOnError(reportPath);
     const ariaNodes = parseAriaSnapshot(await tab.page.ariaSnapshot({ mode: 'ai' }));
     const refIndexes = ariaNodes.map((node, index) => node.ref ? index : -1).filter(index => index >= 0);
     const childCounts = new Map<number, number>();
@@ -1100,8 +1104,6 @@ const auditScreenReader = defineTabTool({
       findings: result.findings,
     };
 
-    const reportFileName = params.reportFile ?? `audit-screen-reader-${safeIsoTimestampForFileName()}.json`;
-    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-screen-reader-report',

--- a/src/tools/auditScreenReader.ts
+++ b/src/tools/auditScreenReader.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
 import { frameConcurrency, frameReadTimeoutMs, injectAxeForNames, withConcurrency, withFrameTimeout } from './axe.js';
-import { safeIsoTimestampForFileName, sanitizeForFilePath } from '../utils/fileUtils.js';
+import { safeIsoTimestampForFileName } from '../utils/fileUtils.js';
 
 import type * as playwright from 'playwright';
 
@@ -1100,8 +1100,8 @@ const auditScreenReader = defineTabTool({
       findings: result.findings,
     };
 
-    const reportFileName = sanitizeForFilePath(params.reportFile ?? `audit-screen-reader-${safeIsoTimestampForFileName()}.json`);
-    const reportPath = await tab.context.outputFile(reportFileName);
+    const reportFileName = params.reportFile ?? `audit-screen-reader-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-screen-reader-report',

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -422,6 +422,10 @@ const auditSite = defineTabTool({
     assertRuleOptionsValid({ rules: params.withRules, disableRules: params.disableRules });
 
     const context = tab.context;
+    const reportFileName = params.reportFile ?? `audit-site-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await context.outputFile(reportFileName, params.reportFile !== undefined);
+    if (params.reportFile !== undefined)
+      response.deleteFileOnError(reportPath);
     const originalTab = tab;
     const queue: CrawlItem[] = [];
     const queued = new Set<string>();
@@ -701,8 +705,6 @@ const auditSite = defineTabTool({
       sessionLosses,
     };
 
-    const reportFileName = params.reportFile ?? `audit-site-${safeIsoTimestampForFileName()}.json`;
-    const reportPath = await context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-site-report',

--- a/src/tools/auditSite.ts
+++ b/src/tools/auditSite.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import RE2 from 're2';
 import { z } from 'zod';
 import { defineTabTool } from './tool.js';
-import { safeIsoTimestampForFileName, sanitizeForFilePath } from '../utils/fileUtils.js';
+import { safeIsoTimestampForFileName } from '../utils/fileUtils.js';
 import {
   assertRuleOptionsValid,
   axeRuleSchemaShape,
@@ -701,8 +701,8 @@ const auditSite = defineTabTool({
       sessionLosses,
     };
 
-    const reportFileName = sanitizeForFilePath(params.reportFile ?? `audit-site-${safeIsoTimestampForFileName()}.json`);
-    const reportPath = await context.outputFile(reportFileName);
+    const reportFileName = params.reportFile ?? `audit-site-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'audit-site-report',

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -84,6 +84,7 @@ const emulateMedia = defineTabTool({
       media: params.media,
       reducedMotion: params.reducedMotion,
     };
+    // SAFETY: filtering removes only undefined values and preserves every key and value type from requested.
     const options = Object.fromEntries(Object.entries(requested).filter(([, value]) => value !== undefined)) as NonNullable<Parameters<playwright.Page['emulateMedia']>[0]>;
     if (!Object.keys(options).length) {
       response.addError('Specify at least one media feature to emulate.');

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -73,6 +73,7 @@ const emulateMedia = defineTabTool({
       media: z.enum(['screen', 'print']).optional().describe('Changes the CSS media type'),
     }),
     type: 'stateChanging',
+    idempotent: true,
   },
 
   handle: async (tab, params, response) => {
@@ -89,7 +90,9 @@ const emulateMedia = defineTabTool({
       return;
     }
     response.addCode(`await page.emulateMedia(${javascript.formatObject(options)});`);
-    await tab.page.emulateMedia(options);
+    await tab.waitForCompletion(async () => {
+      await tab.page.emulateMedia(options);
+    });
   },
 });
 

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -16,6 +16,9 @@
 
 import { z } from 'zod';
 import { defineTabTool, defineTool } from './tool.js';
+import * as javascript from '../utils/codegen.js';
+
+import type * as playwright from 'playwright';
 
 const close = defineTool({
   capability: 'core',
@@ -56,7 +59,42 @@ const resize = defineTabTool({
   },
 });
 
+const emulateMedia = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_emulate_media',
+    title: 'Emulate media features',
+    description: 'Emulate CSS media features for the page. Omitted parameters keep their current state.',
+    inputSchema: z.object({
+      colorScheme: z.enum(['light', 'dark']).optional().describe('Emulates prefers-color-scheme'),
+      reducedMotion: z.enum(['reduce', 'no-preference']).optional().describe('Emulates prefers-reduced-motion'),
+      forcedColors: z.enum(['active', 'none']).optional().describe('Emulates forced-colors'),
+      contrast: z.enum(['more', 'no-preference']).optional().describe('Emulates prefers-contrast'),
+      media: z.enum(['screen', 'print']).optional().describe('Changes the CSS media type'),
+    }),
+    type: 'stateChanging',
+  },
+
+  handle: async (tab, params, response) => {
+    const requested = {
+      colorScheme: params.colorScheme,
+      contrast: params.contrast,
+      forcedColors: params.forcedColors,
+      media: params.media,
+      reducedMotion: params.reducedMotion,
+    };
+    const options = Object.fromEntries(Object.entries(requested).filter(([, value]) => value !== undefined)) as NonNullable<Parameters<playwright.Page['emulateMedia']>[0]>;
+    if (!Object.keys(options).length) {
+      response.addError('Specify at least one media feature to emulate.');
+      return;
+    }
+    response.addCode(`await page.emulateMedia(${javascript.formatObject(options)});`);
+    await tab.page.emulateMedia(options);
+  },
+});
+
 export default [
   close,
-  resize
+  resize,
+  emulateMedia,
 ];

--- a/src/tools/pdf.ts
+++ b/src/tools/pdf.ts
@@ -21,7 +21,7 @@ import * as javascript from '../utils/codegen.js';
 import { safeIsoTimestampForFileName } from '../utils/fileUtils.js';
 
 const pdfSchema = z.object({
-  filename: z.string().optional().describe('File name to save the pdf to. Defaults to `page-{timestamp}-{token}.pdf` if not specified (the random token keeps concurrent sessions from overwriting each other).'),
+  filename: z.string().optional().describe('File name to save the pdf to. Existing files are never overwritten. Defaults to `page-{timestamp}-{token}.pdf` if not specified.'),
 });
 
 const pdf = defineTabTool({
@@ -38,7 +38,7 @@ const pdf = defineTabTool({
   handle: async (tab, params, response) => {
     // Random token besides the timestamp: see browser_take_screenshot — two
     // sessions saving a PDF in the same millisecond must not collide.
-    const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.pdf`);
+    const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.pdf`, params.filename !== undefined);
     response.addCode(`await page.pdf(${javascript.formatObject({ path: fileName })});`);
     response.addResult(`Saved page as ${fileName}`);
     await tab.page.pdf({ path: fileName });

--- a/src/tools/pdf.ts
+++ b/src/tools/pdf.ts
@@ -39,6 +39,8 @@ const pdf = defineTabTool({
     // Random token besides the timestamp: see browser_take_screenshot — two
     // sessions saving a PDF in the same millisecond must not collide.
     const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.pdf`, params.filename !== undefined);
+    if (params.filename !== undefined)
+      response.deleteFileOnError(fileName);
     response.addCode(`await page.pdf(${javascript.formatObject({ path: fileName })});`);
     response.addResult(`Saved page as ${fileName}`);
     await tab.page.pdf({ path: fileName });

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -183,6 +183,10 @@ const scanPageMatrix = defineTabTool({
     // by the time the per-scan check would reject the argument.
     assertRuleOptionsValid({ rules: params.withRules, disableRules: params.disableRules });
 
+    const reportFileName = params.reportFile ?? `scan-matrix-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
+    if (params.reportFile !== undefined)
+      response.deleteFileOnError(reportPath);
     const variants = params.variants ?? defaultVariants;
     const originalViewport = tab.page.viewportSize() ?? await tab.page.evaluate(() => ({
       width: window.innerWidth,
@@ -297,8 +301,6 @@ const scanPageMatrix = defineTabTool({
       variants: variantResults,
     };
 
-    const reportFileName = params.reportFile ?? `scan-matrix-${safeIsoTimestampForFileName()}.json`;
-    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'scan-page-matrix-report',

--- a/src/tools/scanPageMatrix.ts
+++ b/src/tools/scanPageMatrix.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { z } from 'zod';
 import type * as playwright from 'playwright';
 import { defineTabTool } from './tool.js';
-import { safeIsoTimestampForFileName, sanitizeForFilePath } from '../utils/fileUtils.js';
+import { safeIsoTimestampForFileName } from '../utils/fileUtils.js';
 import {
   assertRuleOptionsValid,
   axeRuleSchemaShape,
@@ -297,8 +297,8 @@ const scanPageMatrix = defineTabTool({
       variants: variantResults,
     };
 
-    const reportFileName = sanitizeForFilePath(params.reportFile ?? `scan-matrix-${safeIsoTimestampForFileName()}.json`);
-    const reportPath = await tab.context.outputFile(reportFileName);
+    const reportFileName = params.reportFile ?? `scan-matrix-${safeIsoTimestampForFileName()}.json`;
+    const reportPath = await tab.context.outputFile(reportFileName, params.reportFile !== undefined);
     await fs.promises.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
     const reportResourceLink = response.addFileResourceLink(reportPath, {
       name: 'scan-page-matrix-report',

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -26,7 +26,7 @@ import type * as playwright from 'playwright';
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg', 'webp']).default('png').describe('Image format for the screenshot. Default is png.'),
   scale: z.enum(['css', 'device']).default('css').describe(`Image resolution scale. 'css' produces a screenshot sized in CSS pixels (smaller, consistent across devices). 'device' produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.`),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}-{token}.{png|jpeg|webp}` if not specified (the random token keeps concurrent sessions from overwriting each other).'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Existing files are never overwritten. Defaults to `page-{timestamp}-{token}.{png|jpeg|webp}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
@@ -56,8 +56,9 @@ const screenshot = defineTabTool({
     const fileType = params.type || 'png';
     // The default name carries a random token besides the timestamp: sessions
     // share one output directory, and two same-millisecond screenshots would
-    // otherwise overwrite each other. User-specified filenames stay untouched.
-    const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.${fileType}`);
+    // otherwise overwrite each other. User-specified filenames are reserved
+    // exclusively so an existing artifact is never replaced.
+    const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.${fileType}`, params.filename !== undefined);
     const options: playwright.PageScreenshotOptions = {
       type: fileType,
       quality: fileType === 'png' ? undefined : 90,

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -59,6 +59,8 @@ const screenshot = defineTabTool({
     // otherwise overwrite each other. User-specified filenames are reserved
     // exclusively so an existing artifact is never replaced.
     const fileName = await tab.context.outputFile(params.filename ?? `page-${safeIsoTimestampForFileName()}.${fileType}`, params.filename !== undefined);
+    if (params.filename !== undefined)
+      response.deleteFileOnError(fileName);
     const options: playwright.PageScreenshotOptions = {
       type: fileType,
       quality: fileType === 'png' ? undefined : 90,

--- a/tests/browserServerBackend.test.ts
+++ b/tests/browserServerBackend.test.ts
@@ -22,6 +22,7 @@ import { ProtocolErrorCode } from '@modelcontextprotocol/server';
 import { BrowserServerBackend } from '../src/browserServerBackend.js';
 import { BrowserSessionRegistry } from '../src/browserSessions.js';
 import { resolveConfig } from '../src/config.js';
+import { allTools } from '../src/tools.js';
 
 const unusedFactory = {
   createContext: async () => {
@@ -46,6 +47,30 @@ describe('BrowserServerBackend.callTool', () => {
     const backend = new BrowserServerBackend(config, unusedFactory);
     await expect(backend.callTool('browser_navigate', { url: 123 }))
         .rejects.toThrow(/Invalid input for tool "browser_navigate"/);
+  });
+
+  it('removes reserved output files when a tool fails', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-a11y-reservation-'));
+    const tool = allTools.find(candidate => candidate.schema.name === 'browser_default_timeout')!;
+    const originalHandle = tool.handle;
+    try {
+      tool.handle = async (context, _params, response) => {
+        const filePath = await context.outputFile('reserved.json', true);
+        response.deleteFileOnError(filePath);
+        throw new Error('write failed');
+      };
+      const config = await resolveConfig({ outputDir });
+      const backend = new BrowserServerBackend(config, unusedFactory);
+      await backend.initialize({ notifyToolListChanged: async () => {} }, { name: 'vitest', version: '1.0.0' });
+
+      const result = await backend.callTool('browser_default_timeout', { timeout: 30000 });
+
+      expect(result.isError).toBe(true);
+      expect(fs.existsSync(path.join(outputDir, 'reserved.json'))).toBe(false);
+    } finally {
+      tool.handle = originalHandle;
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
   });
 
   it('registers no session when the --save-session log cannot be created', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -417,6 +417,45 @@ describe('Config', () => {
       expect(result).not.toContain('../');
     });
 
+    it('rejects non-portable Windows reserved names on every platform', async () => {
+      const outputDir = path.join(os.tmpdir(), `mcp-invalid-output-${Date.now()}-${Math.random()}`);
+      const config = await resolveConfig({ outputDir });
+
+      await expect(outputFile(config, 'NUL.png')).rejects.toThrow('portable, non-reserved');
+      await expect(outputFile(config, 'report.')).rejects.toThrow('portable, non-reserved');
+      await expect(outputFile(config, 'report.json ')).rejects.toThrow('portable, non-reserved');
+      expect(fs.existsSync(outputDir)).toBe(false);
+    });
+
+    it('atomically refuses to reserve an existing explicit filename', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-output-collision-'));
+      try {
+        const config = await resolveConfig({ outputDir });
+        const existing = path.join(outputDir, 'report.json');
+        await fs.promises.writeFile(existing, 'keep me');
+
+        await expect(outputFile(config, 'report.json', true)).rejects.toThrow('Output file already exists');
+        expect(await fs.promises.readFile(existing, 'utf-8')).toBe('keep me');
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
+    it('allows only one concurrent reservation for an explicit filename', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-output-race-'));
+      try {
+        const config = await resolveConfig({ outputDir });
+        const results = await Promise.allSettled([
+          outputFile(config, 'report.json', true),
+          outputFile(config, 'report.json', true),
+        ]);
+
+        expect(results.map(result => result.status).sort()).toEqual(['fulfilled', 'rejected']);
+      } finally {
+        await fs.promises.rm(outputDir, { recursive: true, force: true });
+      }
+    });
+
     it('keeps every artifact of one server in one fallback directory', async () => {
       // The timestamped fallback used to be recomputed per call, scattering
       // one audit's screenshots, reports, traces and session logs across a

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -424,6 +424,7 @@ describe('Config', () => {
       await expect(outputFile(config, 'NUL.png')).rejects.toThrow('portable, non-reserved');
       await expect(outputFile(config, 'report.')).rejects.toThrow('portable, non-reserved');
       await expect(outputFile(config, 'report.json ')).rejects.toThrow('portable, non-reserved');
+      await expect(outputFile(config, '   ')).rejects.toThrow('portable, non-reserved');
       expect(fs.existsSync(outputDir)).toBe(false);
     });
 
@@ -451,6 +452,12 @@ describe('Config', () => {
         ]);
 
         expect(results.map(result => result.status).sort()).toEqual(['fulfilled', 'rejected']);
+        expect(results).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            status: 'rejected',
+            reason: expect.objectContaining({ message: expect.stringContaining('Output file already exists') }),
+          }),
+        ]));
       } finally {
         await fs.promises.rm(outputDir, { recursive: true, force: true });
       }

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -20,6 +20,66 @@ import { Context } from '../src/context.js';
 import type { BrowserContextFactory } from '../src/browserContextFactory.js';
 import { EventEmitter } from 'events';
 
+describe('closePage', () => {
+  const contextFor = (page: any) => {
+    const context = new Context({
+      tools: [],
+      config: {} as any,
+      browserContextFactory: {} as any,
+      sessionLog: undefined,
+      clientInfo: {},
+    });
+    const tab = { page };
+    (context as any)._tabs = [tab];
+    (context as any)._currentTab = tab;
+    return context;
+  };
+
+  it('retries when Chromium acknowledges a close but leaves the target alive', async () => {
+    vi.useFakeTimers();
+    let closed = false;
+    const page = {
+      url: () => 'https://example.com',
+      close: vi.fn()
+          .mockImplementationOnce(() => new Promise(() => {}))
+          .mockImplementationOnce(async () => { closed = true; }),
+      isClosed: vi.fn(() => closed),
+    };
+    const context = contextFor(page);
+
+    try {
+      const closing = expect(context.closeTab(undefined)).resolves.toBe('https://example.com');
+      await vi.advanceTimersByTimeAsync(1000);
+      await closing;
+
+      expect(page.close).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      await context.dispose();
+    }
+  });
+
+  it('fails within a bounded number of attempts when the target never closes', async () => {
+    vi.useFakeTimers();
+    const page = {
+      url: () => 'https://example.com',
+      close: vi.fn(() => new Promise(() => {})),
+      isClosed: vi.fn(() => false),
+    };
+    const context = contextFor(page);
+
+    try {
+      const failure = expect(context.closeTab(undefined)).rejects.toThrow('after 3 attempts');
+      await vi.advanceTimersByTimeAsync(3000);
+      await failure;
+      expect(page.close).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+      await context.dispose();
+    }
+  });
+});
+
 describe('Context', () => {
   let mockBrowserContextFactory: BrowserContextFactory;
   let mockBrowserContext: any;

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -93,12 +93,19 @@ describe('closePage', () => {
     }
   });
 
-  it('fails within the operation timeout without overlapping close attempts', async () => {
+  it('reuses a timed-out close request when another tool call retries', async () => {
     vi.useFakeTimers();
+    let closed = false;
+    let finishClose = () => {};
     const page = {
       url: () => 'https://example.com',
-      close: vi.fn(() => new Promise<void>(() => {})),
-      isClosed: vi.fn(() => false),
+      close: vi.fn(() => new Promise<void>(resolve => {
+        finishClose = () => {
+          closed = true;
+          resolve();
+        };
+      })),
+      isClosed: vi.fn(() => closed),
     };
     const context = await contextFor(page);
 
@@ -106,7 +113,11 @@ describe('closePage', () => {
       const failure = expect(context.closeTab(undefined)).rejects.toThrow('Timed out after 5000ms');
       await vi.advanceTimersByTimeAsync(5000);
       await failure;
+
+      const retry = context.closeTab(undefined);
       expect(page.close).toHaveBeenCalledTimes(1);
+      finishClose();
+      await expect(retry).resolves.toBe('https://example.com');
     } finally {
       vi.useRealTimers();
       await context.dispose();

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -21,17 +21,26 @@ import type { BrowserContextFactory } from '../src/browserContextFactory.js';
 import { EventEmitter } from 'events';
 
 describe('closePage', () => {
-  const contextFor = (page: any) => {
+  type CloseablePage = {
+    url: () => string;
+    close: () => Promise<void>;
+    isClosed: () => boolean;
+  };
+
+  const browserContextFactory: BrowserContextFactory = {
+    createContext: async () => { throw new Error('Not used by closeTab tests.'); },
+  };
+
+  const contextFor = async (page: CloseablePage) => {
     const context = new Context({
       tools: [],
-      config: {} as any,
-      browserContextFactory: {} as any,
+      config: await resolveConfig({}),
+      browserContextFactory,
       sessionLog: undefined,
       clientInfo: {},
     });
-    const tab = { page };
-    (context as any)._tabs = [tab];
-    (context as any)._currentTab = tab;
+    const tab = { page, operationTimeout: () => 5000 };
+    Object.assign(context, { _tabs: [tab], _currentTab: tab });
     return context;
   };
 
@@ -44,7 +53,7 @@ describe('closePage', () => {
           .mockImplementationOnce(async () => { closed = true; }),
       isClosed: vi.fn(() => closed),
     };
-    const context = contextFor(page);
+    const context = await contextFor(page);
 
     try {
       await expect(context.closeTab(undefined)).resolves.toBe('https://example.com');
@@ -54,20 +63,50 @@ describe('closePage', () => {
     }
   });
 
-  it('fails within a bounded number of attempts when the target never closes', async () => {
+  it('allows a slow remote page to close within the operation timeout', async () => {
+    vi.useFakeTimers();
+    let closed = false;
+    let finishClose = () => {};
+    const page = {
+      url: () => 'https://example.com',
+      close: vi.fn(() => new Promise<void>(resolve => {
+        finishClose = () => {
+          closed = true;
+          resolve();
+        };
+      })),
+      isClosed: vi.fn(() => closed),
+    };
+    const context = await contextFor(page);
+
+    try {
+      const closing = context.closeTab(undefined);
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(page.close).toHaveBeenCalledTimes(1);
+
+      finishClose();
+      await expect(closing).resolves.toBe('https://example.com');
+      expect(page.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      await context.dispose();
+    }
+  });
+
+  it('fails within the operation timeout without overlapping close attempts', async () => {
     vi.useFakeTimers();
     const page = {
       url: () => 'https://example.com',
-      close: vi.fn(() => new Promise(() => {})),
+      close: vi.fn(() => new Promise<void>(() => {})),
       isClosed: vi.fn(() => false),
     };
-    const context = contextFor(page);
+    const context = await contextFor(page);
 
     try {
-      const failure = expect(context.closeTab(undefined)).rejects.toThrow('after 3 attempts');
-      await vi.advanceTimersByTimeAsync(3000);
+      const failure = expect(context.closeTab(undefined)).rejects.toThrow('Timed out after 5000ms');
+      await vi.advanceTimersByTimeAsync(5000);
       await failure;
-      expect(page.close).toHaveBeenCalledTimes(3);
+      expect(page.close).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
       await context.dispose();

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -36,25 +36,20 @@ describe('closePage', () => {
   };
 
   it('retries when Chromium acknowledges a close but leaves the target alive', async () => {
-    vi.useFakeTimers();
     let closed = false;
     const page = {
       url: () => 'https://example.com',
       close: vi.fn()
-          .mockImplementationOnce(() => new Promise(() => {}))
+          .mockResolvedValueOnce(undefined)
           .mockImplementationOnce(async () => { closed = true; }),
       isClosed: vi.fn(() => closed),
     };
     const context = contextFor(page);
 
     try {
-      const closing = expect(context.closeTab(undefined)).resolves.toBe('https://example.com');
-      await vi.advanceTimersByTimeAsync(1000);
-      await closing;
-
+      await expect(context.closeTab(undefined)).resolves.toBe('https://example.com');
       expect(page.close).toHaveBeenCalledTimes(2);
     } finally {
-      vi.useRealTimers();
       await context.dispose();
     }
   });

--- a/tests/mcp-tool.test.ts
+++ b/tests/mcp-tool.test.ts
@@ -79,6 +79,20 @@ describe('mcp/tool', () => {
     expect(tool.annotations?.idempotentHint).toBe(false);
   });
 
+  it('allows a state-changing tool to declare idempotent retries', () => {
+    const tool = toMcpTool(defineToolSchema({
+      name: 'idempotent_state_change',
+      title: 'Idempotent state change',
+      description: 'Converges to the requested state',
+      inputSchema: z.object({}),
+      type: 'stateChanging',
+      idempotent: true,
+    }));
+
+    expect(tool.annotations?.readOnlyHint).toBe(false);
+    expect(tool.annotations?.idempotentHint).toBe(true);
+  });
+
   it('defineToolSchema is identity helper', () => {
     const schema = defineToolSchema({
       name: 'identity',

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -382,6 +382,19 @@ describe('Tab', () => {
       expect(path.basename(download.saveAs.mock.calls[0][0] as string)).toMatch(/^download-.+$/);
     });
 
+    it.each([
+      ['report.', /^report-.+$/],
+      ['report.txt ', /^report-.+\.txt$/],
+    ])('normalizes a generated download name ending in a dot or space: %s', async (suggested, expected) => {
+      new Tab(mockContext, mockPage, onPageClose);
+      const download = makeDownload(suggested);
+      mockPage.emit('download', download);
+      await vi.waitFor(() => expect(download.saveAs).toHaveBeenCalledTimes(1));
+      const savedName = path.basename(download.saveAs.mock.calls[0][0]);
+      expect(savedName).toMatch(expected);
+      expect(savedName).not.toMatch(/[. ]$/);
+    });
+
     it('keeps a long suggested name within the 255-byte filename limit', async () => {
       // A long but valid Content-Disposition name plus the uniqueness suffix
       // used to exceed the filesystem's 255-byte component cap and fail

--- a/tests/tab.test.ts
+++ b/tests/tab.test.ts
@@ -289,6 +289,7 @@ describe('Tab', () => {
       await updatePromise;
 
       expect(finished).toBe(true);
+      expect(tab.operationTimeout()).toBe(75);
       expect(mockPage.setDefaultTimeout).toHaveBeenLastCalledWith(75);
     });
   });

--- a/tests/tools-auditKeyboard.tool.test.ts
+++ b/tests/tools-auditKeyboard.tool.test.ts
@@ -57,13 +57,12 @@ function createHarness(sequence: FocusPoint[], requestContext?: any) {
     screenshot: vi.fn(async () => undefined),
   };
 
+  const outputFile = vi.fn(async (name: string) => `/tmp/${name}`);
   const tab: any = {
     modalStates: vi.fn(() => []),
     waitForCompletion: vi.fn(async (callback: () => Promise<void>) => await callback()),
     page,
-    context: {
-      outputFile: vi.fn(async (name: string) => `/tmp/${name}`),
-    },
+    context: { outputFile },
   };
 
   const context: any = {
@@ -72,7 +71,7 @@ function createHarness(sequence: FocusPoint[], requestContext?: any) {
   };
 
   const response = new Response(context, 'audit_keyboard', {}, requestContext);
-  return { context, tab, page, response };
+  return { context, tab, page, outputFile, response };
 }
 
 describe('audit_keyboard tool', () => {
@@ -82,6 +81,16 @@ describe('audit_keyboard tool', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+  });
+
+  it('reserves an explicit report before pressing a key', async () => {
+    const { page, outputFile, response } = createHarness([]);
+    outputFile.mockRejectedValue(new Error('Output file already exists'));
+
+    await expect(tool.handle(response.context, tool.schema.inputSchema.parse({ reportFile: 'taken.json' }), response))
+        .rejects.toThrow('Output file already exists');
+
+    expect(page.keyboard.press).not.toHaveBeenCalled();
   });
 
   it('writes report with custom reportFile name', async () => {

--- a/tests/tools-auditScreenReader.test.ts
+++ b/tests/tools-auditScreenReader.test.ts
@@ -506,13 +506,14 @@ function createToolHarness(options: {
       },
     })),
   };
+  const outputFile = vi.fn(async (name: string) => `/tmp/${name}`);
   const tab: any = {
     modalStates: () => [],
     page,
-    context: { outputFile: async (name: string) => `/tmp/${name}` },
+    context: { outputFile },
   };
   const context: any = { currentTabOrDie: () => tab, config: {} };
-  return { context, concurrency, frameConcurrency, ownerFrames, disposals, installs, frame, frames };
+  return { context, concurrency, frameConcurrency, ownerFrames, disposals, installs, frame, frames, outputFile };
 }
 
 describe('audit_screen_reader tool measurement', () => {
@@ -533,6 +534,17 @@ describe('audit_screen_reader tool measurement', () => {
     } as any, response);
     return response.result();
   }
+
+  it('reserves an explicit report before reading the accessibility tree', async () => {
+    const harness = createToolHarness({ snapshot: '- button "Save" [ref=e1]' });
+    harness.outputFile.mockRejectedValue(new Error('Output file already exists'));
+    const response = new Response(harness.context, 'audit_screen_reader', {});
+
+    await expect(tool.handle(harness.context, tool.schema.inputSchema.parse({ reportFile: 'taken.json' }), response))
+        .rejects.toThrow('Output file already exists');
+
+    expect(harness.context.currentTabOrDie().page.ariaSnapshot).not.toHaveBeenCalled();
+  });
 
   it('spends the element budget on elements a screen reader can reach', async () => {
     // The AI snapshot also refs aria-hidden subtrees: slicing the raw ref list

--- a/tests/tools-auditSite.test.ts
+++ b/tests/tools-auditSite.test.ts
@@ -178,6 +178,16 @@ describe('audit_site tool', () => {
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
   });
 
+  it('reserves an explicit report before opening the crawl tab', async () => {
+    const { context, response } = createHarness({ 'https://example.com/': [] });
+    context.outputFile.mockRejectedValue(new Error('Output file already exists'));
+
+    await expect(tool.handle(response.context, tool.schema.inputSchema.parse({ reportFile: 'taken.json' }), response))
+        .rejects.toThrow('Output file already exists');
+
+    expect(context.newTab).not.toHaveBeenCalled();
+  });
+
   it('warns about pages whose frames the scan could not reach', async () => {
     // A page scanned with a frame missing reports fewer violations, so a reader
     // counting them has to know which pages those numbers are incomplete for.

--- a/tests/tools-common.test.ts
+++ b/tests/tools-common.test.ts
@@ -30,6 +30,7 @@ describe('Common Tools', () => {
     mockPage = {
       url: () => 'https://example.com',
       setViewportSize: vi.fn().mockResolvedValue(undefined),
+      emulateMedia: vi.fn().mockResolvedValue(undefined),
       close: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -101,6 +102,24 @@ describe('Common Tools', () => {
       expect(response.code()).toContain('setViewportSize');
       expect(response.code()).toContain('800');
       expect(response.code()).toContain('600');
+    });
+  });
+
+  describe('browser_emulate_media tool', () => {
+    const emulateMediaTool = commonTools.find(t => t.schema.name === 'browser_emulate_media')!;
+
+    it('emulates only the supplied media features', async () => {
+      await emulateMediaTool.handle(mockContext, { colorScheme: 'dark', reducedMotion: 'reduce', browserSessionId: 'bs_test' } as any, response);
+
+      expect(mockPage.emulateMedia).toHaveBeenCalledWith({ colorScheme: 'dark', reducedMotion: 'reduce' });
+      expect(response.code()).toContain('page.emulateMedia');
+    });
+
+    it('rejects a call with no media feature', async () => {
+      await emulateMediaTool.handle(mockContext, {}, response);
+
+      expect(mockPage.emulateMedia).not.toHaveBeenCalled();
+      expect(response.result()).toContain('Specify at least one media feature to emulate.');
     });
   });
 

--- a/tests/tools-common.test.ts
+++ b/tests/tools-common.test.ts
@@ -109,9 +109,11 @@ describe('Common Tools', () => {
     const emulateMediaTool = commonTools.find(t => t.schema.name === 'browser_emulate_media')!;
 
     it('emulates only the supplied media features', async () => {
+      expect(emulateMediaTool.schema.idempotent).toBe(true);
       await emulateMediaTool.handle(mockContext, { colorScheme: 'dark', reducedMotion: 'reduce', browserSessionId: 'bs_test' } as any, response);
 
       expect(mockPage.emulateMedia).toHaveBeenCalledWith({ colorScheme: 'dark', reducedMotion: 'reduce' });
+      expect(mockTab.waitForCompletion).toHaveBeenCalledTimes(1);
       expect(response.code()).toContain('page.emulateMedia');
     });
 

--- a/tests/tools-common.test.ts
+++ b/tests/tools-common.test.ts
@@ -110,7 +110,8 @@ describe('Common Tools', () => {
 
     it('emulates only the supplied media features', async () => {
       expect(emulateMediaTool.schema.idempotent).toBe(true);
-      await emulateMediaTool.handle(mockContext, { colorScheme: 'dark', reducedMotion: 'reduce', browserSessionId: 'bs_test' } as any, response);
+      const params = { colorScheme: 'dark', reducedMotion: 'reduce', browserSessionId: 'bs_test' } as const;
+      await emulateMediaTool.handle(mockContext, params, response);
 
       expect(mockPage.emulateMedia).toHaveBeenCalledWith({ colorScheme: 'dark', reducedMotion: 'reduce' });
       expect(mockTab.waitForCompletion).toHaveBeenCalledTimes(1);

--- a/tests/tools-scanPageMatrix.test.ts
+++ b/tests/tools-scanPageMatrix.test.ts
@@ -57,11 +57,12 @@ function createMatrixHarness(outputFile: string) {
     evaluate: vi.fn().mockResolvedValueOnce(pageState('')).mockResolvedValue(undefined),
     reload: vi.fn(async () => undefined),
   };
+  const resolveOutputFile = vi.fn(async () => outputFile);
   const mockTab = {
     page: mockPage,
     waitForTimeout: vi.fn(async () => undefined),
     modalStates: vi.fn(() => []),
-    context: { outputFile: vi.fn(async () => outputFile) },
+    context: { outputFile: resolveOutputFile },
   };
   const context = { currentTabOrDie: vi.fn(() => mockTab), config: {} };
   return { context, mockPage, response: new Response(context as any, 'scan_page_matrix', {}) };
@@ -74,6 +75,16 @@ describe('scan_page_matrix tool', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+  });
+
+  it('reserves an explicit report before changing the page', async () => {
+    const { context, mockPage, response } = createMatrixHarness('/tmp/taken.json');
+    context.currentTabOrDie().context.outputFile.mockRejectedValue(new Error('Output file already exists'));
+
+    await expect(tool.handle(response.context, tool.schema.inputSchema.parse({ reportFile: 'taken.json' }), response))
+        .rejects.toThrow('Output file already exists');
+
+    expect(mockPage.viewportSize).not.toHaveBeenCalled();
   });
 
   it('passes tags, rule filters and scope selectors through to the axe scan', async () => {

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -76,10 +76,12 @@ describe('Screenshot Tools', () => {
   });
 
   it('reserves a caller-supplied filename without clobbering it', async () => {
+    const deleteFileOnError = vi.spyOn(response, 'deleteFileOnError');
     const params = screenshotTool.schema.inputSchema.parse({ filename: 'shot.png' });
     await screenshotTool.handle(mockContext, params, response);
 
     expect(mockTab.context.outputFile).toHaveBeenCalledWith('shot.png', true);
+    expect(deleteFileOnError).toHaveBeenCalledWith('/out/page.png');
   });
 
   it('should default the image format to png', () => {

--- a/tests/tools-screenshot.test.ts
+++ b/tests/tools-screenshot.test.ts
@@ -75,6 +75,13 @@ describe('Screenshot Tools', () => {
     expect(mockPage.screenshot).toHaveBeenCalledWith(expect.objectContaining({ scale: 'device' }));
   });
 
+  it('reserves a caller-supplied filename without clobbering it', async () => {
+    const params = screenshotTool.schema.inputSchema.parse({ filename: 'shot.png' });
+    await screenshotTool.handle(mockContext, params, response);
+
+    expect(mockTab.context.outputFile).toHaveBeenCalledWith('shot.png', true);
+  });
+
   it('should default the image format to png', () => {
     const params = screenshotTool.schema.inputSchema.parse({});
     expect(params.type).toBe('png');


### PR DESCRIPTION
## Summary

- add atomic, no-clobber artifact reservation and reject non-portable filenames
- add `browser_emulate_media` for color-scheme, reduced-motion, media, contrast, and forced-colors emulation
- retry `page.close()` up to three times when Chromium drops a close during navigation
- close the remaining tracking issues already covered by current `main` or the repository's Playwright pin

## Issue coverage

Closes #177
Closes #186
Closes #192
Closes #206
Closes #207

## Verification

- `npm run lint`
- `npm run build`
- `npm run knip`
- 178 focused tests pass
- full suite: 932 pass; 28 browser-dependent tests cannot run in this environment because the pinned Chromium executable is unavailable, and 4 proxy socket failures reproduce on `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `browser_emulate_media` for emulating color schemes, reduced motion, forced colors, contrast, and print or screen media.
  * Added no-clobber handling for caller-supplied screenshot, PDF, scan, and audit report filenames.

* **Bug Fixes**
  * Improved tab-closing reliability with bounded retries and consistent timeout handling.
  * Added validation for invalid or non-portable output filenames.
  * Cleaned up reserved output files when tool operations fail.

* **Documentation**
  * Documented media emulation and output filename behavior in the README and skill guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->