### PR TITLE
fix: bound extension token connection waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ npx mcp-accessibility-scanner --extension
 
 Set `PLAYWRIGHT_MCP_EXTENSION_TOKEN` to the token shown by the extension to bypass the connection approval dialog. The relay's CDP WebSocket endpoint always requires a separate random token, generated per relay and appended automatically for the server's own connection. This CDP token is never passed in Chrome's launch arguments or extension URL; the extension approval token cannot authenticate a CDP client.
 Token-bypass connections are not background-safe: Chrome focuses the connection tab and window, and client-created tabs remain open after disconnect ([upstream limitation](https://github.com/microsoft/playwright/issues/42343)).
+With a token, the extension must connect and finish setup within 30 seconds after the connection page opens. Failed attempts release the relay so the next tool call can retry. Without a token, manual approval waits until you approve or cancel the call.
 When `--user-data-dir` contains multiple Chrome profiles, the profile with the extension installed is selected automatically, preferring Chrome's last-used profile.
 
 ### Discovering available tools (`list-tools` subcommand)

--- a/src/extension/cdpRelay.ts
+++ b/src/extension/cdpRelay.ts
@@ -93,6 +93,7 @@ export class CDPRelayServer {
   private _browserChannel: string;
   private _userDataDir?: string;
   private _executablePath?: string;
+  private readonly _token = process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN;
   private _cdpPath: string;
   private readonly _cdpToken = crypto.randomUUID();
   private _extensionPath: string;
@@ -164,6 +165,7 @@ export class CDPRelayServer {
     if (abortSignal.aborted)
       throw abortSignal.reason;
     let abortListener = () => {};
+    let connectionTimer: ReturnType<typeof setTimeout> | undefined;
     const abortPromise = new Promise<never>((_, reject) => {
       abortListener = () => reject(abortSignal.reason);
       abortSignal.addEventListener('abort', abortListener, { once: true });
@@ -173,12 +175,22 @@ export class CDPRelayServer {
       if (!this._extensionConnection)
         await Promise.race([this._connectBrowser(clientInfo, abortSignal), abortPromise]);
       debugLogger('Waiting for incoming extension connection');
-      // Manual approval is intentionally unbounded; callers cancel it through the abort signal.
+      // Token connections need no human approval, so a missing/rejected token must not hang forever.
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        if (this._token) {
+          connectionTimer = setTimeout(() => reject(new Error(
+              'Playwright extension did not connect within 30s after opening the connect page. Make sure the extension is installed in the selected Chrome profile and PLAYWRIGHT_MCP_EXTENSION_TOKEN matches its token.'
+          )), 30_000);
+        }
+      });
+      // Without a token, manual approval remains unbounded and cancellable.
       await Promise.race([
         Promise.all([this._extensionConnectionPromise, this._handler.ready()]),
         abortPromise,
+        timeoutPromise,
       ]);
     } finally {
+      clearTimeout(connectionTimer);
       abortSignal.removeEventListener('abort', abortListener);
     }
     debugLogger('Extension connection established');
@@ -193,9 +205,8 @@ export class CDPRelayServer {
     };
     url.searchParams.set('client', JSON.stringify(client));
     url.searchParams.set('protocolVersion', process.env.PWMCP_TEST_PROTOCOL_VERSION ?? protocol.VERSION.toString());
-    const token = process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN;
-    if (token)
-      url.searchParams.set('token', token);
+    if (this._token)
+      url.searchParams.set('token', this._token);
     const href = url.toString();
 
     let executablePath = this._executablePath;

--- a/src/extension/extensionContextFactory.ts
+++ b/src/extension/extensionContextFactory.ts
@@ -53,13 +53,15 @@ export class ExtensionContextFactory implements BrowserContextFactory {
 
   private async _obtainBrowser(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined): Promise<playwright.Browser> {
     const relay = await this._startRelay(abortSignal);
-    await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
-    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint()).catch((error: unknown) => {
+    try {
+      await relay.ensureExtensionConnectionForMCPContext(clientInfo, abortSignal, toolName);
+      const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint());
+      browser.on('disconnected', () => relay.stop());
+      return browser;
+    } catch (error) {
       relay.stop();
       throw error;
-    });
-    browser.on('disconnected', () => relay.stop());
-    return browser;
+    }
   }
 
   private async _startRelay(abortSignal: AbortSignal) {
@@ -69,7 +71,9 @@ export class ExtensionContextFactory implements BrowserContextFactory {
       throw new Error(abortSignal.reason);
     }
     const cdpRelayServer = new CDPRelayServer(httpServer, this._browserChannel, this._userDataDir, this._executablePath);
-    abortSignal.addEventListener('abort', () => cdpRelayServer.stop());
+    const stop = () => cdpRelayServer.stop();
+    abortSignal.addEventListener('abort', stop, { once: true });
+    httpServer.once('close', () => abortSignal.removeEventListener('abort', stop));
     debugLogger(`CDP relay server started, extension endpoint: ${cdpRelayServer.extensionEndpoint()}.`);
     return cdpRelayServer;
   }

--- a/tests/extension-protocol.test.ts
+++ b/tests/extension-protocol.test.ts
@@ -825,9 +825,11 @@ describe('extension protocol v2', () => {
     expect(() => relay.stop()).not.toThrow();
   });
 
-  it('stops the relay when CDP attachment fails', async () => {
+  it.each(['extension connection', 'CDP attachment'])('stops the relay and retries when %s fails', async phase => {
     onTestFinished(() => vi.restoreAllMocks());
     const ensure = vi.spyOn(CDPRelayServer.prototype, 'ensureExtensionConnectionForMCPContext').mockResolvedValue(undefined);
+    if (phase === 'extension connection')
+      ensure.mockRejectedValue(new Error('attach failed'));
     const stop = vi.spyOn(CDPRelayServer.prototype, 'stop');
     vi.spyOn(playwright.chromium, 'connectOverCDP').mockRejectedValue(new Error('attach failed'));
     onTestFinished(() => (ensure.mock.instances[0] as CDPRelayServer | undefined)?.stop());
@@ -836,12 +838,67 @@ describe('extension protocol v2', () => {
     await expect(factory.createContext(
         { name: 'test-client', version: '1.0.0' }, new AbortController().signal, undefined)).rejects.toThrow('attach failed');
     expect(stop).toHaveBeenCalledTimes(1);
+    await expect(factory.createContext(
+        { name: 'test-client', version: '1.0.0' }, new AbortController().signal, undefined)).rejects.toThrow('attach failed');
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(ensure.mock.instances[1]).not.toBe(ensure.mock.instances[0]);
+  });
+
+  it.each(['no connection', 'no initialization', 'success', 'manual approval', 'cancel'])('bounds token approval and clears timers: %s', async phase => {
+    vi.stubEnv('PLAYWRIGHT_MCP_EXTENSION_TOKEN', phase === 'manual approval' ? '' : 'test-token');
+    const server = http.createServer();
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const relay = new CDPRelayServer(server, 'chrome', undefined, '/tmp/chrome');
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+    // SAFETY: This real relay owns these private fields; the test drives setup without launching Chrome.
+    const relayState = relay as unknown as {
+      _connectBrowser: () => Promise<void>;
+      _extensionConnectionPromise: { resolve(): void };
+      _handler: ExtensionProtocolV2;
+    };
+    vi.spyOn(relayState, '_connectBrowser').mockResolvedValue(undefined);
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const connecting = relay.ensureExtensionConnectionForMCPContext(
+          { name: 'test-client', version: '1.0.0' }, controller.signal, undefined);
+      let settled = false;
+      void connecting.then(() => settled = true, () => settled = true);
+      await vi.advanceTimersByTimeAsync(0);
+      if (phase === 'no initialization' || phase === 'success')
+        relayState._extensionConnectionPromise.resolve();
+      if (phase === 'success') {
+        relayState._handler.handleExtensionEvent('extension.initialized', []);
+        await expect(connecting).resolves.toBeUndefined();
+      } else if (phase === 'cancel' || phase === 'manual approval') {
+        if (phase === 'manual approval') {
+          await vi.advanceTimersByTimeAsync(60_000);
+          expect(settled).toBe(false);
+          expect(vi.getTimerCount()).toBe(0);
+        }
+        controller.abort(new Error('cancelled'));
+        await expect(connecting).rejects.toThrow('cancelled');
+      } else {
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(settled).toBe(false);
+        const failure = expect(connecting).rejects.toThrow('did not connect within 30s');
+        await vi.advanceTimersByTimeAsync(1);
+        await failure;
+      }
+      expect(vi.getTimerCount()).toBe(0);
+      expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    } finally {
+      vi.useRealTimers();
+      relay.stop();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+      vi.restoreAllMocks();
+      vi.unstubAllEnvs();
+    }
   });
 
   it('waits for extension approval and forwards the configured token', async () => {
     vi.mocked(spawn).mockClear();
     vi.stubEnv('PLAYWRIGHT_MCP_EXTENSION_TOKEN', 'test-token');
-    vi.stubEnv('PWMCP_TEST_CONNECTION_TIMEOUT', '1');
     const server = http.createServer();
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject);


### PR DESCRIPTION
## Summary

Mirror the token connection timeout from https://github.com/microsoft/playwright/pull/42525 (https://github.com/microsoft/playwright/commit/df01cf969b22daf5cc5b7c2b588e19382c39f6fa).

Upstream now bounds automatic extension setup when an approval token is supplied. This server had the same unbounded wait: a wrong token or an extension that never initializes could leave a tool call pending indefinitely.

- Require token-based extension connection and initialization within 30 seconds after opening the connection page.
- Keep token-free manual approval unbounded and cancellable.
- Clear the timer and abort listener on every outcome; stop failed relays and remove their abort listeners so later calls can retry with a fresh relay.
- Document the timeout and retry behavior. No package, binary, or tool names change.

## Validation

- `npm test`: 47 files, 1,086 tests passed.
- Focused extension tests: 37 passed.
- `npm run lint` and `npm run build` passed.
- Regression mutation: replacing the combined connection/setup wait with a first-completion wait made the stalled-initialization test fail; restored and reran successfully.
- Diff and static checks passed.

Tests use real relay sockets and simulated extension setup; no manual Chrome extension session was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token-based browser extension connections now time out after 30 seconds if setup is not completed.
  * Failed connection attempts release the relay so users can retry.
  * Connections without a token continue waiting for manual approval or cancellation.

* **Bug Fixes**
  * Relay resources are now stopped reliably when extension or browser connection setup fails.
  * Connection cancellation and retry handling are more reliable.

* **Documentation**
  * Documented browser extension connection timeout and approval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->